### PR TITLE
VB-2554 Add test API call

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     GOVUK_ONE_LOGIN_URL: "https://oidc.integration.account.gov.uk"
+    ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/server/config.ts
+++ b/server/config.ts
@@ -74,6 +74,14 @@ export default {
       agent: new AgentConfig(Number(get('TOKEN_VERIFICATION_API_TIMEOUT_RESPONSE', 5000))),
       enabled: get('TOKEN_VERIFICATION_ENABLED', 'false') === 'true',
     },
+    orchestration: {
+      url: get('ORCHESTRATION_API_URL', 'http://localhost:8080', requiredInProduction),
+      timeout: {
+        response: Number(get('ORCHESTRATION_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('ORCHESTRATION_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(Number(get('ORCHESTRATION_API_TIMEOUT_RESPONSE', 10000))),
+    },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -11,6 +11,7 @@ initialiseAppInsights()
 buildAppInsightsClient(applicationInfo)
 
 import HmppsAuthClient from './hmppsAuthClient'
+import OrchestrationApiClient from './orchestrationApiClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 
@@ -19,8 +20,10 @@ type RestClientBuilder<T> = (token: string) => T
 export const dataAccess = () => ({
   applicationInfo,
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient())),
+  orchestrationApiClientBuilder: ((token: string) =>
+    new OrchestrationApiClient(token)) as RestClientBuilder<OrchestrationApiClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, RestClientBuilder }
+export { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder }

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -1,0 +1,38 @@
+import nock from 'nock'
+import config from '../config'
+import OrchestrationApiClient from './orchestrationApiClient'
+
+describe('orchestrationApiClient', () => {
+  let fakeOrchestrationApi: nock.Scope
+  let orchestrationApiClient: OrchestrationApiClient
+  const token = 'token-1'
+
+  beforeEach(() => {
+    fakeOrchestrationApi = nock(config.apis.orchestration.url)
+    orchestrationApiClient = new OrchestrationApiClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('getSupportedPrisonIds', () => {
+    it('should return an array of supported prison IDs', async () => {
+      const results = ['HEI', 'BLI']
+
+      fakeOrchestrationApi
+        .get('/config/prisons/supported')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, results)
+
+      const output = await orchestrationApiClient.getSupportedPrisonIds()
+
+      expect(output).toEqual(results)
+    })
+  })
+})

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -1,0 +1,16 @@
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+
+export default class OrchestrationApiClient {
+  private restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('orchestrationApiClient', config.apis.orchestration as ApiConfig, token)
+  }
+
+  async getSupportedPrisonIds(): Promise<string[]> {
+    return this.restClient.get({
+      path: '/config/prisons/supported',
+    })
+  }
+}

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -50,7 +50,7 @@ export default class RestClient {
     return this.config.timeout
   }
 
-  async get({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
+  async get<T>({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<T> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
     try {
       const result = await superagent
@@ -75,14 +75,14 @@ export default class RestClient {
     }
   }
 
-  async post({
+  async post<T>({
     path = null,
     headers = {},
     responseType = '',
     data = {},
     raw = false,
     retry = false,
-  }: PostRequest = {}): Promise<unknown> {
+  }: PostRequest = {}): Promise<T> {
     logger.info(`Post using user credentials: calling ${this.name}: ${path}`)
     try {
       const result = await superagent

--- a/server/data/testutils/mocks.ts
+++ b/server/data/testutils/mocks.ts
@@ -1,0 +1,26 @@
+/* eslint-disable import/first */
+/*
+ * Import from '..' (server/data/index.ts) fails if applicationInfo not mocked first. This is
+ * because paths in it differ between running app (in 'dist') and where ts-jest runs.
+ */
+import type { ApplicationInfo } from '../../applicationInfo'
+
+const testAppInfo: ApplicationInfo = {
+  applicationName: 'test',
+  buildNumber: '1',
+  gitRef: 'long ref',
+  gitShortHash: 'short ref',
+}
+
+jest.mock('../../applicationInfo', () => {
+  return jest.fn(() => testAppInfo)
+})
+
+import { HmppsAuthClient, OrchestrationApiClient } from '..'
+
+jest.mock('..')
+
+export const createMockHmppsAuthClient = () => new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+export const createMockOrchestrationApiClient = () =>
+  new OrchestrationApiClient(null) as jest.Mocked<OrchestrationApiClient>

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,11 +1,15 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import { appWithAllRoutes } from './testutils/appSetup'
+import { createMockSupportedPrisonsService } from '../services/testutils/mocks'
 
 let app: Express
 
+const supportedPrisonsService = createMockSupportedPrisonsService()
+
 beforeEach(() => {
-  app = appWithAllRoutes({})
+  supportedPrisonsService.getSupportedPrisonIds.mockResolvedValue(['HEI', 'PNI'])
+  app = appWithAllRoutes({ services: { supportedPrisonsService } })
 })
 
 afterEach(() => {
@@ -19,6 +23,20 @@ describe('GET /', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('This site is under construction...')
+      })
+  })
+})
+
+describe('GET /prisons', () => {
+  it('should render prisons page with API call', () => {
+    return request(app)
+      .get('/prisons')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Test API call')
+        expect(res.text).toContain('HEI')
+        expect(res.text).toContain('PNI')
+        expect(supportedPrisonsService.getSupportedPrisonIds).toHaveBeenCalledWith()
       })
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,13 +3,17 @@ import { type RequestHandler, Router } from 'express'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function routes(service: Services): Router {
+export default function routes({ supportedPrisonsService }: Services): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', (req, res, next) => {
     res.render('pages/index', { user: req.user })
+  })
+
+  get('/prisons', async (req, res, next) => {
+    const prisonIds = await supportedPrisonsService.getSupportedPrisonIds()
+    res.render('pages/prisons', { prisonIds })
   })
 
   return router

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,3 +1,18 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import type { ApplicationInfo } from '../../applicationInfo'
+
+const testAppInfo: ApplicationInfo = {
+  applicationName: 'test',
+  buildNumber: '1',
+  gitRef: 'long ref',
+  gitShortHash: 'short ref',
+}
+
+jest.mock('../../applicationInfo', () => {
+  return jest.fn(() => testAppInfo)
+})
+
 import express, { Express } from 'express'
 import cookieSession from 'cookie-session'
 import createError from 'http-errors'
@@ -7,14 +22,6 @@ import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
 import * as govukOneLogin from '../../authentication/govukOneLogin'
 import type { Services } from '../../services'
-import type { ApplicationInfo } from '../../applicationInfo'
-
-const testAppInfo: ApplicationInfo = {
-  applicationName: 'test',
-  buildNumber: '1',
-  gitRef: 'long ref',
-  gitShortHash: 'short ref',
-}
 
 export const user: Express.User = {
   sub: 'user1',

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -1,0 +1,3 @@
+export default class TestData {
+  static supportedPrisonIds = ({ prisonIds = ['HEI', 'BLI'] } = {}): string[] => prisonIds
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,17 +1,21 @@
 import { dataAccess } from '../data'
+import SupportedPrisonsService from './supportedPrisonsService'
 import UserService from './userService'
 
 export const services = () => {
-  const { hmppsAuthClient, applicationInfo } = dataAccess()
+  const { hmppsAuthClient, applicationInfo, orchestrationApiClientBuilder } = dataAccess()
+
+  const supportedPrisonsService = new SupportedPrisonsService(orchestrationApiClientBuilder, hmppsAuthClient)
 
   const userService = new UserService(hmppsAuthClient)
 
   return {
     applicationInfo,
+    supportedPrisonsService,
     userService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService }
+export { SupportedPrisonsService, UserService }

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -1,0 +1,38 @@
+import SupportedPrisonsService from './supportedPrisonsService'
+import { createMockHmppsAuthClient, createMockOrchestrationApiClient } from '../data/testutils/mocks'
+import TestData from '../routes/testutils/testData'
+
+const token = 'some token'
+
+describe('Supported prisons service', () => {
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const orchestrationApiClient = createMockOrchestrationApiClient()
+
+  let supportedPrisonsService: SupportedPrisonsService
+
+  const OrchestrationApiClientFactory = jest.fn()
+
+  const supportedPrisonIds = TestData.supportedPrisonIds()
+
+  beforeEach(() => {
+    OrchestrationApiClientFactory.mockReturnValue(orchestrationApiClient)
+    supportedPrisonsService = new SupportedPrisonsService(OrchestrationApiClientFactory, hmppsAuthClient)
+
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getSupportedPrisonIds', () => {
+    it('should return an array of supported prison IDs', async () => {
+      orchestrationApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+
+      const results = await supportedPrisonsService.getSupportedPrisonIds()
+
+      expect(orchestrationApiClient.getSupportedPrisonIds).toHaveBeenCalledTimes(1)
+      expect(results).toStrictEqual(supportedPrisonIds)
+    })
+  })
+})

--- a/server/services/supportedPrisonsService.ts
+++ b/server/services/supportedPrisonsService.ts
@@ -1,0 +1,14 @@
+import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
+
+export default class SupportedPrisonsService {
+  constructor(
+    private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
+    private readonly hmppsAuthClient: HmppsAuthClient,
+  ) {}
+
+  async getSupportedPrisonIds(): Promise<string[]> {
+    const token = await this.hmppsAuthClient.getSystemClientToken()
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+    return orchestrationApiClient.getSupportedPrisonIds()
+  }
+}

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -1,0 +1,7 @@
+import { SupportedPrisonsService } from '..'
+
+jest.mock('..')
+
+// eslint-disable-next-line import/prefer-default-export
+export const createMockSupportedPrisonsService = () =>
+  new SupportedPrisonsService(null, null) as jest.Mocked<SupportedPrisonsService>

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -17,5 +17,10 @@
 
   <hr>
 
+  <p>API test: <a href="/prisons">list of supported prison IDs</a></p>
+
+  <br>
+  <br>
+
   <p><a href="/sign-out">Sign out</a></p>
 {% endblock %}

--- a/server/views/pages/prisons.njk
+++ b/server/views/pages/prisons.njk
@@ -1,0 +1,18 @@
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Prisons" %}
+
+{% block content %}
+
+  <h1 class="govuk-heading-l">Test API call</h1>
+  <p>Requesting list of supported prison IDs from the Orchestration Service</p>
+
+  <hr>
+
+  <pre>
+{{ (prisonIds | dump(2)) if prisonIds else "NONE" }}
+  </pre>
+
+  <hr>
+
+{% endblock %}


### PR DESCRIPTION
Add support for calling the Orchestration Service API and make a test call (to list supported prison IDs).

Code and config, including for tests, etc brought over from Staff and Admin UI apps.

Purpose is to demonstrate that calling APIs with credentials is still working given HMPPS Auth login replaced with GOV.UK One Login - and that testing set up still works. Will help inform what lingering auth code can be removed.