### PR TITLE
VB-3567 Redirect user to originally requested URL after log in

### DIFF
--- a/integration_tests/e2e/govukOneLogin.cy.ts
+++ b/integration_tests/e2e/govukOneLogin.cy.ts
@@ -35,9 +35,16 @@ context('Sign in with GOV.UK One Login', () => {
     indexPage.prisonerName().contains('Adam Greene')
   })
 
+  it('User can request a specific page and be redirected to this after sign in', () => {
+    const page = '/deep-link' // will be a 404, but OK as testing original URL preserved
+    cy.signIn({ failOnStatusCode: false }, undefined, page)
+    cy.location('pathname').should('equal', page)
+    cy.contains('404')
+  })
+
   it('User sent to auth error page if sign in fails', () => {
     // setting an invalid nonce value should cause ID token validation to fail
-    cy.signIn({ failOnStatusCode: false, nonce: 'INVALID_NONCE' })
+    cy.signIn({ failOnStatusCode: false }, 'INVALID_NONCE')
     cy.get('h1').contains('Authorisation Error')
   })
 

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -5,6 +5,6 @@ declare namespace Cypress {
      * Optionally set nonce to override the value used in the ID token
      * @example cy.signIn({ failOnStatusCode: boolean })
      */
-    signIn(options?: { failOnStatusCode: boolean; nonce?: string }): Chainable<unknown>
+    signIn(options?: { failOnStatusCode: boolean }, nonce?: string, initialRequestUrl?: string): Chainable<unknown>
   }
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,6 +1,6 @@
-Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.request('/')
-  return cy.task('getSignInUrl', options.nonce).then((url: string) => {
+Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }, nonce = undefined, initialRequestUrl = '/') => {
+  cy.request(initialRequestUrl)
+  return cy.task('getSignInUrl', nonce).then((url: string) => {
     cy.visit(url, options)
     return cy.task('verifyJwtAssertionForToken')
   })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -3,7 +3,7 @@ export default {}
 declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
   interface SessionData {
-    // returnTo: string
+    returnTo: string
     nowInMinutes: number
   }
 }

--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -22,6 +22,7 @@ const authenticationMiddleware = (): RequestHandler => {
       return next()
     }
 
+    req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
   }
 }

--- a/server/middleware/setUpGovukOneLogin.ts
+++ b/server/middleware/setUpGovukOneLogin.ts
@@ -33,7 +33,7 @@ export default function setUpGovukOneLogin(): Router {
     router.get('/auth/callback', (req, res, next) => {
       passport.authenticate('oidc', {
         nonce: generators.nonce(),
-        successRedirect: '/',
+        successReturnToOrRedirect: req.session.returnTo || '/',
         failureRedirect: '/autherror',
       })(req, res, next)
     })


### PR DESCRIPTION
If a user wasn't logged in to GOV.UK One Login and they requested a specific URL within the application they would end up on the home page `"/"` after log in.

This fixes the issue; restoring functionality that was in the HMPPS Auth implementation in the template app.