### PR TITLE
Enable setting GOVUK One Login VTR to low for local / dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ SYSTEM_CLIENT_SECRET="<system_client_secret>"
 ORCHESTRATION_API_URL="https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
 
 GOVUK_ONE_LOGIN_URL=https://oidc.integration.account.gov.uk
+GOVUK_ONE_LOGIN_HOME_URL=https://home.integration.account.gov.uk
 GOVUK_ONE_LOGIN_VTR=LOW # LOW will skip the OTP verification during sign-in
-GOVUK_ONE_LOGIN_ACCOUNT_URL=https://home.integration.account.gov.uk
 GOVUK_ONE_LOGIN_CLIENT_ID="<govuk_one_login_client_id>"
 GOVUK_ONE_LOGIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
 <private key contents>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ SYSTEM_CLIENT_SECRET="<system_client_secret>"
 ORCHESTRATION_API_URL="https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
 
 GOVUK_ONE_LOGIN_URL=https://oidc.integration.account.gov.uk
+GOVUK_ONE_LOGIN_VTR=LOW # LOW will skip the OTP verification during sign-in
 GOVUK_ONE_LOGIN_ACCOUNT_URL=https://home.integration.account.gov.uk
 GOVUK_ONE_LOGIN_CLIENT_ID="<govuk_one_login_client_id>"
 GOVUK_ONE_LOGIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
     INGRESS_URL: "https://visit-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     GOVUK_ONE_LOGIN_URL: "https://oidc.integration.account.gov.uk"
+    GOVUK_ONE_LOGIN_VTR: "LOW"
     GOVUK_ONE_LOGIN_ACCOUNT_URL: "https://home.integration.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,8 +11,8 @@ generic-service:
     INGRESS_URL: "https://visit-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     GOVUK_ONE_LOGIN_URL: "https://oidc.integration.account.gov.uk"
+    GOVUK_ONE_LOGIN_HOME_URL: "https://home.integration.account.gov.uk"
     GOVUK_ONE_LOGIN_VTR: "LOW"
-    GOVUK_ONE_LOGIN_ACCOUNT_URL: "https://home.integration.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,7 +11,7 @@ generic-service:
     INGRESS_URL: "https://visit-preprod.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     GOVUK_ONE_LOGIN_URL: "https://oidc.integration.account.gov.uk"
-    GOVUK_ONE_LOGIN_ACCOUNT_URL: "https://home.integration.account.gov.uk"
+    GOVUK_ONE_LOGIN_HOME_URL: "https://home.integration.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-preprod.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -11,6 +11,7 @@ generic-service:
     INGRESS_URL: "https://visit-staging.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     GOVUK_ONE_LOGIN_URL: "https://oidc.integration.account.gov.uk"
+    GOVUK_ONE_LOGIN_VTR: "LOW"
     GOVUK_ONE_LOGIN_ACCOUNT_URL: "https://home.integration.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
     APPLICATIONINSIGHTS_CONNECTION_STRING: null # disable App Insights for staging

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -11,8 +11,8 @@ generic-service:
     INGRESS_URL: "https://visit-staging.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     GOVUK_ONE_LOGIN_URL: "https://oidc.integration.account.gov.uk"
+    GOVUK_ONE_LOGIN_HOME_URL: "https://home.integration.account.gov.uk"
     GOVUK_ONE_LOGIN_VTR: "LOW"
-    GOVUK_ONE_LOGIN_ACCOUNT_URL: "https://home.integration.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk"
     APPLICATIONINSIGHTS_CONNECTION_STRING: null # disable App Insights for staging
 

--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -60,7 +60,7 @@ async function init(): Promise<Client> {
       client,
       params: {
         scope: 'openid email phone',
-        vtr: '["Cl.Cm"]',
+        vtr: config.apis.govukOneLogin.vtr,
         ui_locales: 'en',
       },
       usePKCE: false,

--- a/server/config.ts
+++ b/server/config.ts
@@ -68,6 +68,7 @@ export default {
       url: get('GOVUK_ONE_LOGIN_URL', 'http://localhost:9091/govukOneLogin', requiredInProduction),
       clientId: get('GOVUK_ONE_LOGIN_CLIENT_ID', 'clientId', requiredInProduction),
       privateKey: get('GOVUK_ONE_LOGIN_PRIVATE_KEY', 'privateKey', requiredInProduction),
+      vtr: process.env.GOVUK_ONE_LOGIN_VTR === 'LOW' ? '["Cl"]' : '["Cl.Cm"]',
     },
     orchestration: {
       url: get('ORCHESTRATION_API_URL', 'http://localhost:8080', requiredInProduction),

--- a/server/config.ts
+++ b/server/config.ts
@@ -66,6 +66,7 @@ export default {
     },
     govukOneLogin: {
       url: get('GOVUK_ONE_LOGIN_URL', 'http://localhost:9091/govukOneLogin', requiredInProduction),
+      homeUrl: get('GOVUK_ONE_LOGIN_HOME_URL', '', requiredInProduction),
       clientId: get('GOVUK_ONE_LOGIN_CLIENT_ID', 'clientId', requiredInProduction),
       privateKey: get('GOVUK_ONE_LOGIN_PRIVATE_KEY', 'privateKey', requiredInProduction),
       vtr: process.env.GOVUK_ONE_LOGIN_VTR === 'LOW' ? '["Cl"]' : '["Cl.Cm"]',
@@ -79,7 +80,6 @@ export default {
       agent: new AgentConfig(Number(get('ORCHESTRATION_API_TIMEOUT_RESPONSE', 10000))),
     },
   },
-  oneLoginLink: get('GOVUK_ONE_LOGIN_ACCOUNT_URL', 'https://home.account.gov.uk/'),
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -16,7 +16,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.applicationName = 'HMPPS Book a Prison Visit UI'
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
-  app.locals.oneLoginLink = config.oneLoginLink
+  app.locals.oneLoginLink = config.apis.govukOneLogin.homeUrl
 
   // Cachebusting version string
   if (production) {


### PR DESCRIPTION
Enables setting VTR to a lower level for local, dev and staging environments. This means that users authenticating are not prompted for a second factor code/SMS. (See docs: https://docs.sign-in.service.gov.uk/before-integrating/choose-the-level-of-authentication/#choose-the-level-of-authentication-for-your-service)

Also, some tidying of config for the OL home page URL.