### PR TITLE
VB-3725 Fix unnecessary commas on visitor list

### DIFF
--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -93,9 +93,9 @@ context('Booking journey', () => {
     selectVisitorsPage.visitorsMaxChildren().contains(prison.maxChildVisitors)
     selectVisitorsPage.visitorsAdultAge().eq(0).contains(prison.adultAgeYears)
     selectVisitorsPage.visitorsAdultAge().eq(1).contains(prison.adultAgeYears)
-    selectVisitorsPage.getVisitorLabel(1).contains('Adult One, (25 years old)')
-    selectVisitorsPage.getVisitorLabel(2).contains('Child One, (12 years old)')
-    selectVisitorsPage.getVisitorLabel(3).contains('Child Two, (5 years old)')
+    selectVisitorsPage.getVisitorLabel(1).contains('Adult One (25 years old)')
+    selectVisitorsPage.getVisitorLabel(2).contains('Child One (12 years old)')
+    selectVisitorsPage.getVisitorLabel(3).contains('Child Two (5 years old)')
     selectVisitorsPage.selectVisitor(1)
     selectVisitorsPage.selectVisitor(3)
 

--- a/server/routes/bookingJourney/selectVisitorsController.test.ts
+++ b/server/routes/bookingJourney/selectVisitorsController.test.ts
@@ -79,14 +79,14 @@ describe('Select visitors page', () => {
 
           expect($('form[method=POST]').attr('action')).toBe('/book-a-visit/select-visitors')
           expect($('input[name=visitorIds]').length).toBe(8)
-          expect($('input[name=visitorIds][value=1] + label').text().trim()).toBe('Visitor Age 20y, (20 years old)')
-          expect($('input[name=visitorIds][value=2] + label').text().trim()).toBe('Visitor Age 18y, (18 years old)')
-          expect($('input[name=visitorIds][value=3] + label').text().trim()).toBe('Visitor Age 17y, (17 years old)')
-          expect($('input[name=visitorIds][value=4] + label').text().trim()).toBe('Visitor Age 16y, (16 years old)')
-          expect($('input[name=visitorIds][value=5] + label').text().trim()).toBe('Visitor Age 15y, (15 years old)')
-          expect($('input[name=visitorIds][value=6] + label').text().trim()).toBe('Visitor Age 10y, (10 years old)')
-          expect($('input[name=visitorIds][value=7] + label').text().trim()).toBe('Visitor Age 1y, (1 year old)')
-          expect($('input[name=visitorIds][value=8] + label').text().trim()).toBe('Visitor Age 4m, (4 months old)')
+          expect($('input[name=visitorIds][value=1] + label').text().trim()).toBe('Visitor Age 20y (20 years old)')
+          expect($('input[name=visitorIds][value=2] + label').text().trim()).toBe('Visitor Age 18y (18 years old)')
+          expect($('input[name=visitorIds][value=3] + label').text().trim()).toBe('Visitor Age 17y (17 years old)')
+          expect($('input[name=visitorIds][value=4] + label').text().trim()).toBe('Visitor Age 16y (16 years old)')
+          expect($('input[name=visitorIds][value=5] + label').text().trim()).toBe('Visitor Age 15y (15 years old)')
+          expect($('input[name=visitorIds][value=6] + label').text().trim()).toBe('Visitor Age 10y (10 years old)')
+          expect($('input[name=visitorIds][value=7] + label').text().trim()).toBe('Visitor Age 1y (1 year old)')
+          expect($('input[name=visitorIds][value=8] + label').text().trim()).toBe('Visitor Age 4m (4 months old)')
 
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 

--- a/server/views/pages/bookingJourney/selectVisitors.njk
+++ b/server/views/pages/bookingJourney/selectVisitors.njk
@@ -37,7 +37,7 @@
         {% for visitor in visitors %}
           {% set visitorList = (visitorList.push({
             value: visitor.visitorId,
-            text: visitor.firstName + ' ' + visitor.lastName + ', (' + visitor.dateOfBirth | displayAge + ')'
+            text: visitor.firstName + " " + visitor.lastName + " (" + visitor.dateOfBirth | displayAge + ")"
           }), visitorList)%}
         {% endfor %}
         <form action="/book-a-visit/select-visitors" method="POST" novalidate>
@@ -53,7 +53,7 @@
             },
             items: visitorList,
             values: formValues.visitorIds,
-            errorMessage: errors | findError('visitorIds')
+            errorMessage: errors | findError("visitorIds")
           }) }}
 
           {{ govukButton({


### PR DESCRIPTION
Remove unnecessary comma between visitor name and visitor age on select visitors page.