### PR TITLE
VB-3945 Pre-populate Select visitors page with session data when returning

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -30,8 +30,8 @@ export declare global {
       id: string
       flash(type: 'errors'): ValidationError[]
       flash(type: 'errors', message: ValidationError[]): number
-      flash(type: 'formValues'): Record<string, string | string[]>[]
-      flash(type: 'formValues', message: Record<string, string | string[]>): number
+      flash(type: 'formValues'): Record<string, string | string[] | number[]>[]
+      flash(type: 'formValues', message: Record<string, string | string[] | number[]>): number
       logout(done: (err: unknown) => void): void
     }
 

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -20,64 +20,64 @@ const prisoner = TestData.prisonerInfoDto()
 const prison = TestData.prisonDto()
 
 const fakeDate = new Date('2024-05-02')
-const visitors = [
-  TestData.visitor({
-    visitorDisplayId: 1,
-    visitorId: 1000,
-    firstName: 'Visitor',
-    lastName: 'Age 20y',
-    dateOfBirth: '2004-04-01',
-  }),
-  TestData.visitor({
-    visitorDisplayId: 2,
-    visitorId: 2000,
-    firstName: 'Visitor',
-    lastName: 'Age 18y',
-    dateOfBirth: '2006-05-02', // 18 today
-  }),
-  TestData.visitor({
-    visitorDisplayId: 3,
-    visitorId: 3000,
-    firstName: 'Visitor',
-    lastName: 'Age 17y',
-    dateOfBirth: '2006-05-03', // 18 tomorrow
-  }),
-  TestData.visitor({
-    visitorDisplayId: 4,
-    visitorId: 4000,
-    firstName: 'Visitor',
-    lastName: 'Age 16y',
-    dateOfBirth: '2008-05-02', // 16 today
-  }),
-  TestData.visitor({
-    visitorDisplayId: 5,
-    visitorId: 5000,
-    firstName: 'Visitor',
-    lastName: 'Age 15y',
-    dateOfBirth: '2008-05-03', // 16 tomorrow
-  }),
-  TestData.visitor({
-    visitorDisplayId: 6,
-    visitorId: 6000,
-    firstName: 'Visitor',
-    lastName: 'Age 10y',
-    dateOfBirth: '2014-05-02',
-  }),
-  TestData.visitor({
-    visitorDisplayId: 7,
-    visitorId: 7000,
-    firstName: 'Visitor',
-    lastName: 'Age 1y',
-    dateOfBirth: '2023-05-02',
-  }),
-  TestData.visitor({
-    visitorDisplayId: 8,
-    visitorId: 8000,
-    firstName: 'Visitor',
-    lastName: 'Age 4m',
-    dateOfBirth: '2024-01-02',
-  }),
-]
+
+const visitor1 = TestData.visitor({
+  visitorDisplayId: 1,
+  visitorId: 1000,
+  firstName: 'Visitor',
+  lastName: 'Age 20y',
+  dateOfBirth: '2004-04-01',
+})
+const visitor2 = TestData.visitor({
+  visitorDisplayId: 2,
+  visitorId: 2000,
+  firstName: 'Visitor',
+  lastName: 'Age 18y',
+  dateOfBirth: '2006-05-02', // 18 today
+})
+const visitor3 = TestData.visitor({
+  visitorDisplayId: 3,
+  visitorId: 3000,
+  firstName: 'Visitor',
+  lastName: 'Age 17y',
+  dateOfBirth: '2006-05-03', // 18 tomorrow
+})
+const visitor4 = TestData.visitor({
+  visitorDisplayId: 4,
+  visitorId: 4000,
+  firstName: 'Visitor',
+  lastName: 'Age 16y',
+  dateOfBirth: '2008-05-02', // 16 today
+})
+const visitor5 = TestData.visitor({
+  visitorDisplayId: 5,
+  visitorId: 5000,
+  firstName: 'Visitor',
+  lastName: 'Age 15y',
+  dateOfBirth: '2008-05-03', // 16 tomorrow
+})
+const visitor6 = TestData.visitor({
+  visitorDisplayId: 6,
+  visitorId: 6000,
+  firstName: 'Visitor',
+  lastName: 'Age 10y',
+  dateOfBirth: '2014-05-02',
+})
+const visitor7 = TestData.visitor({
+  visitorDisplayId: 7,
+  visitorId: 7000,
+  firstName: 'Visitor',
+  lastName: 'Age 1y',
+  dateOfBirth: '2023-05-02',
+})
+const visitor8 = TestData.visitor({
+  visitorDisplayId: 8,
+  visitorId: 8000,
+  firstName: 'Visitor',
+  lastName: 'Age 4m',
+  dateOfBirth: '2024-01-02',
+})
+const visitors = [visitor1, visitor2, visitor3, visitor4, visitor5, visitor6, visitor7, visitor8]
 
 beforeEach(() => {
   jest.useFakeTimers({ advanceTimers: true, now: fakeDate })
@@ -152,6 +152,39 @@ describe('Select visitors', () => {
               allVisitors: visitors,
             },
           } as SessionData)
+        })
+    })
+
+    it('should pre-populate with data in session', () => {
+      sessionData.bookingJourney.selectedVisitors = [visitor1, visitor4, visitor8]
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=visitorDisplayIds]').length).toBe(8)
+          expect($('input[name=visitorDisplayIds]:checked').length).toBe(3)
+          expect($('input[name=visitorDisplayIds][value=1]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=4]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=8]:checked + label').length).toBe(1)
+        })
+    })
+
+    it('should pre-populate with data in formValues overriding that in session', () => {
+      sessionData.bookingJourney.selectedVisitors = [visitor1, visitor4, visitor8]
+      const formValues = { visitorDisplayIds: [2, 7] }
+      flashData = { formValues: [formValues] }
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=visitorDisplayIds]').length).toBe(8)
+          expect($('input[name=visitorDisplayIds]:checked').length).toBe(2)
+          expect($('input[name=visitorDisplayIds][value=2]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=7]:checked + label').length).toBe(1)
         })
     })
 
@@ -243,7 +276,7 @@ describe('Select visitors', () => {
               prisoner,
               prison,
               allVisitors: visitors,
-              selectedVisitors: [visitors[0], visitors[2]],
+              selectedVisitors: [visitor1, visitor3],
             },
           } as SessionData)
         })

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -315,6 +315,22 @@ describe('Select visitors', () => {
         expectedFlashFormValues = { visitorDisplayIds: [] }
       })
 
+      it('should discard any unexpected form data', () => {
+        expectedFlashErrors[0].msg = 'No visitors selected'
+        expectedFlashFormValues.visitorDisplayIds = []
+
+        return request(app)
+          .post(url)
+          .send({ unexpected: 'data' })
+          .expect(302)
+          .expect('Location', url)
+          .expect(() => {
+            expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
+            expect(flashProvider).toHaveBeenCalledWith('formValues', expectedFlashFormValues)
+            expect(sessionData.bookingJourney.selectedVisitors).toBe(undefined)
+          })
+      })
+
       it('should set a validation error and redirect to original page when no visitors selected', () => {
         expectedFlashErrors[0].msg = 'No visitors selected'
         expectedFlashFormValues.visitorDisplayIds = []

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -21,11 +21,17 @@ export default class SelectVisitorsController {
         ])
       }
 
-      // TODO pre-populate form (e.g. if coming from Back link or Change answers)
+      const selectedVisitorDisplayIds = {
+        visitorDisplayIds: bookingJourney.selectedVisitors?.map(visitor => visitor.visitorDisplayId) ?? [],
+      }
+      const formValues = {
+        ...selectedVisitorDisplayIds,
+        ...req.flash('formValues')?.[0],
+      }
 
       res.render('pages/bookVisit/selectVisitors', {
         errors: req.flash('errors'),
-        formValues: req.flash('formValues')?.[0] || {},
+        formValues,
         prison: bookingJourney.prison,
         visitors: bookingJourney.allVisitors,
       })

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from 'express'
-import { Meta, ValidationChain, body, validationResult } from 'express-validator'
+import { Meta, ValidationChain, body, matchedData, validationResult } from 'express-validator'
 import { differenceInYears } from 'date-fns'
 import { BookerService, PrisonService } from '../../services'
 import { pluralise } from '../../utils/utils'
@@ -41,14 +41,15 @@ export default class SelectVisitorsController {
   public submit(): RequestHandler {
     return async (req, res) => {
       const errors = validationResult(req)
+
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array())
-        req.flash('formValues', req.body)
+        req.flash('formValues', matchedData(req, { onlyValidData: false }))
         return res.redirect('/book-visit/select-visitors')
       }
 
       const { bookingJourney } = req.session
-      const { visitorDisplayIds }: { visitorDisplayIds: number[] } = req.body
+      const { visitorDisplayIds } = matchedData<{ visitorDisplayIds: number[] }>(req)
 
       const selectedVisitors = bookingJourney.allVisitors.filter(visitor =>
         visitorDisplayIds.includes(visitor.visitorDisplayId),


### PR DESCRIPTION
* When going back to the Select visitors page within a journey, pre-populate it with existing session data
  * New form data overrides this
* Use the `express-validator` `matchedData()` function rather than `req.body` to avoid potentially storing unexpected user data in the session