### PR TITLE
VB-3947 Pre-populate Additional support page with session data when returning

### DIFF
--- a/server/routes/bookVisit/additionalSupportController.test.ts
+++ b/server/routes/bookVisit/additionalSupportController.test.ts
@@ -5,7 +5,6 @@ import { SessionData } from 'express-session'
 import { FieldValidationError } from 'express-validator'
 import { FlashData, FlashErrors, FlashFormValues, appWithAllRoutes, flashProvider } from '../testutils/appSetup'
 import TestData from '../testutils/testData'
-import { BookingJourney } from '../../@types/bapv'
 
 let app: Express
 
@@ -60,8 +59,51 @@ describe('Additional support needs', () => {
           expect($('[data-test=prison-name]').text().trim()).toContain('Hewell (HMP)')
 
           expect($('form[method=POST]').attr('action')).toBe('/book-visit/additional-support')
+          expect($('input[name=additionalSupportRequired]:checked').length).toBe(0)
+          expect($('input[name=additionalSupport]').val()).toBe(undefined)
 
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
+        })
+    })
+
+    it('should pre-populate with data in session (no support)', () => {
+      sessionData.bookingJourney.visitorSupport = ''
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=additionalSupportRequired][value=no]').prop('checked')).toBe(true)
+          expect($('input[name=additionalSupport]').val()).toBe('')
+        })
+    })
+
+    it('should pre-populate with data in session (support required)', () => {
+      sessionData.bookingJourney.visitorSupport = 'Wheelchair access'
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=additionalSupportRequired][value=yes]').prop('checked')).toBe(true)
+          expect($('input[name=additionalSupport]').val()).toBe('Wheelchair access')
+        })
+    })
+
+    it('should pre-populate with data in formValues overriding that in session', () => {
+      sessionData.bookingJourney.visitorSupport = 'Wheelchair access'
+      const formValues = { additionalSupportRequired: 'no', additionalSupport: '' }
+      flashData = { formValues: [formValues] }
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=additionalSupportRequired][value=no]').prop('checked')).toBe(true)
+          expect($('input[name=additionalSupport]').val()).toBe('')
         })
     })
 
@@ -90,8 +132,6 @@ describe('Additional support needs', () => {
   })
 
   describe(`POST ${url}`, () => {
-    let expectedBookingJourney: BookingJourney
-
     beforeEach(() => {
       sessionData = {
         booker: {
@@ -110,17 +150,6 @@ describe('Additional support needs', () => {
         },
       } as SessionData
 
-      expectedBookingJourney = {
-        prisoner,
-        prison,
-        allVisitors: [visitor],
-        selectedVisitors: [visitor],
-        allVisitSessionIds: ['2024-05-30_a'],
-        selectedSessionDate: '2024-05-30',
-        selectedSessionTemplateReference: 'a',
-        applicationReference: TestData.applicationDto().reference,
-      }
-
       app = appWithAllRoutes({ sessionData })
     })
 
@@ -132,10 +161,7 @@ describe('Additional support needs', () => {
         .expect('Location', '/book-visit/main-contact')
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
-          expect(sessionData.bookingJourney).toStrictEqual({
-            ...expectedBookingJourney,
-            visitorSupport: 'Wheelchair access',
-          })
+          expect(sessionData.bookingJourney.visitorSupport).toBe('Wheelchair access')
         })
     })
 
@@ -147,16 +173,37 @@ describe('Additional support needs', () => {
         .expect('Location', '/book-visit/main-contact')
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
-          expect(sessionData.bookingJourney).toStrictEqual({
-            ...expectedBookingJourney,
-            visitorSupport: '',
-          })
+          expect(sessionData.bookingJourney.visitorSupport).toBe('')
         })
     })
 
     describe('Validation errors', () => {
       let expectedFlashErrors: FlashErrors
       let expectedFlashFormValues: FlashFormValues
+
+      it('should discard any unexpected form data', () => {
+        expectedFlashErrors = [
+          {
+            type: 'field',
+            location: 'body',
+            path: 'additionalSupportRequired',
+            value: undefined,
+            msg: 'No answer selected',
+          },
+        ]
+        expectedFlashFormValues = { additionalSupport: '' }
+
+        return request(app)
+          .post(url)
+          .send({ unexpected: 'data' })
+          .expect(302)
+          .expect('Location', url)
+          .expect(() => {
+            expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
+            expect(flashProvider).toHaveBeenCalledWith('formValues', expectedFlashFormValues)
+            expect(sessionData.bookingJourney.visitorSupport).toBe(undefined)
+          })
+      })
 
       it('should set a validation error and redirect to original page when no options selected', () => {
         expectedFlashErrors = [
@@ -177,8 +224,7 @@ describe('Additional support needs', () => {
           .expect(() => {
             expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
             expect(flashProvider).toHaveBeenCalledWith('formValues', expectedFlashFormValues)
-
-            expect(sessionData.bookingJourney).toStrictEqual(expectedBookingJourney)
+            expect(sessionData.bookingJourney.visitorSupport).toBe(undefined)
           })
       })
 
@@ -202,8 +248,7 @@ describe('Additional support needs', () => {
           .expect(() => {
             expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
             expect(flashProvider).toHaveBeenCalledWith('formValues', expectedFlashFormValues)
-
-            expect(sessionData.bookingJourney).toStrictEqual(expectedBookingJourney)
+            expect(sessionData.bookingJourney.visitorSupport).toBe(undefined)
           })
       })
     })


### PR DESCRIPTION
* When going back to the Additional support page within a journey, pre-populate it with existing session data - with new form data overriding this