### PR TITLE
VB-3946 Pre-populate Choose visit time page with session data when returning

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -161,7 +161,7 @@ export default {
     prisonerId,
     visitorIds,
     visitSessions,
-    excludedApplicationReference,
+    excludedApplicationReference = '',
   }: {
     prisonId: string
     prisonerId: string
@@ -177,7 +177,16 @@ export default {
           prisonId: { equalTo: prisonId },
           prisonerId: { equalTo: prisonerId },
           visitors: { equalTo: visitorIds.join(',') },
-          ...(excludedApplicationReference && { excludedApplicationReference }),
+          excludedApplicationReference: {
+            or: [
+              {
+                equalTo: excludedApplicationReference,
+              },
+              {
+                absent: true,
+              },
+            ],
+          },
         },
       },
       response: {

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -161,11 +161,13 @@ export default {
     prisonerId,
     visitorIds,
     visitSessions,
+    excludedApplicationReference,
   }: {
     prisonId: string
     prisonerId: string
     visitorIds: number[]
     visitSessions: AvailableVisitSessionDto[]
+    excludedApplicationReference?: string
   }): SuperAgentRequest =>
     stubFor({
       request: {
@@ -175,6 +177,7 @@ export default {
           prisonId: { equalTo: prisonId },
           prisonerId: { equalTo: prisonerId },
           visitors: { equalTo: visitorIds.join(',') },
+          ...(excludedApplicationReference && { excludedApplicationReference }),
         },
       },
       response: {

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -695,12 +695,10 @@ export interface components {
       visitTimeSlot: components['schemas']['SessionTimeSlotDto']
     }
     PageVisitDto: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
+      /** Format: int32 */
+      totalPages?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
@@ -710,18 +708,20 @@ export interface components {
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject'][]
-      /** Format: int32 */
-      pageSize?: number
+      unpaged?: boolean
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
     }
     SortObject: {
       direction?: string
@@ -840,7 +840,7 @@ export interface components {
        */
       endTimestamp: string
       /** @description Session conflicts */
-      sessionConflicts?: ('NON_ASSOCIATION' | 'DOUBLE_BOOKED')[]
+      sessionConflicts?: ('NON_ASSOCIATION' | 'DOUBLE_BOOKING_OR_RESERVATION')[]
     }
     /** @description Session Capacity */
     SessionCapacityDto: {
@@ -2184,6 +2184,11 @@ export interface operations {
         visitors?: number[]
         /** @description Defaults to true if not passed. If true, will not return visit times that clash with higher priority legal or medical appointments. */
         withAppointmentsCheck?: boolean
+        /**
+         * @description The current application reference to be excluded from capacity count and double booking
+         * @example dfs-wjs-eqr
+         */
+        excludedApplicationReference?: string
       }
     }
     responses: {

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -183,7 +183,7 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitSessions', () => {
-    it('should get available visit sessions for prison / prisoner / visitors', async () => {
+    it('should get available visit sessions for prison / prisoner / visitors with undefined excludeApplicationReference ignored', async () => {
       const prisoner = TestData.prisonerInfoDto()
       const visitorIds = [1, 2]
       const visitSessions: AvailableVisitSessionDto[] = [TestData.availableVisitSessionDto()]
@@ -198,11 +198,39 @@ describe('orchestrationApiClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, visitSessions)
 
-      const result = await orchestrationApiClient.getVisitSessions(
-        prisoner.prisonCode,
-        prisoner.prisonerNumber,
+      const result = await orchestrationApiClient.getVisitSessions({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
         visitorIds,
-      )
+        excludedApplicationReference: undefined,
+      })
+
+      expect(result).toStrictEqual(visitSessions)
+    })
+
+    it('should get available visit sessions for prison / prisoner / visitors with excludeApplicationReference set', async () => {
+      const prisoner = TestData.prisonerInfoDto()
+      const visitorIds = [1, 2]
+      const visitSessions: AvailableVisitSessionDto[] = [TestData.availableVisitSessionDto()]
+      const excludedApplicationReference = 'aaa-bbb-ccc'
+
+      fakeOrchestrationApi
+        .get('/visit-sessions/available')
+        .query({
+          prisonId: prisoner.prisonCode,
+          prisonerId: prisoner.prisonerNumber,
+          visitors: visitorIds.join(','),
+          excludedApplicationReference,
+        })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, visitSessions)
+
+      const result = await orchestrationApiClient.getVisitSessions({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
+        visitorIds,
+        excludedApplicationReference,
+      })
 
       expect(result).toStrictEqual(visitSessions)
     })

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -183,32 +183,7 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitSessions', () => {
-    it('should get available visit sessions for prison / prisoner / visitors with undefined excludeApplicationReference ignored', async () => {
-      const prisoner = TestData.prisonerInfoDto()
-      const visitorIds = [1, 2]
-      const visitSessions: AvailableVisitSessionDto[] = [TestData.availableVisitSessionDto()]
-
-      fakeOrchestrationApi
-        .get('/visit-sessions/available')
-        .query({
-          prisonId: prisoner.prisonCode,
-          prisonerId: prisoner.prisonerNumber,
-          visitors: visitorIds.join(','),
-        })
-        .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, visitSessions)
-
-      const result = await orchestrationApiClient.getVisitSessions({
-        prisonId: prisoner.prisonCode,
-        prisonerId: prisoner.prisonerNumber,
-        visitorIds,
-        excludedApplicationReference: undefined,
-      })
-
-      expect(result).toStrictEqual(visitSessions)
-    })
-
-    it('should get available visit sessions for prison / prisoner / visitors with excludeApplicationReference set', async () => {
+    it('should get available visit sessions for prison / prisoner / visitors', async () => {
       const prisoner = TestData.prisonerInfoDto()
       const visitorIds = [1, 2]
       const visitSessions: AvailableVisitSessionDto[] = [TestData.availableVisitSessionDto()]

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -122,14 +122,25 @@ export default class OrchestrationApiClient {
 
   // orchestration-sessions-controller
 
-  async getVisitSessions(
-    prisonId: string,
-    prisonerId: string,
-    visitorIds: number[],
-  ): Promise<AvailableVisitSessionDto[]> {
+  async getVisitSessions({
+    prisonId,
+    prisonerId,
+    visitorIds,
+    excludedApplicationReference,
+  }: {
+    prisonId: string
+    prisonerId: string
+    visitorIds: number[]
+    excludedApplicationReference?: string
+  }): Promise<AvailableVisitSessionDto[]> {
     return this.restClient.get({
       path: '/visit-sessions/available',
-      query: new URLSearchParams({ prisonId, prisonerId, visitors: visitorIds.join(',') }).toString(),
+      query: new URLSearchParams({
+        prisonId,
+        prisonerId,
+        visitors: visitorIds.join(','),
+        ...(excludedApplicationReference && { excludedApplicationReference }),
+      }).toString(),
     })
   }
 

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -138,12 +138,12 @@ describe('Choose visit time', () => {
 
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 
-          expect(visitSessionsService.getVisitSessionsCalendar).toHaveBeenCalledWith(
-            prison.code,
-            prisoner.prisonerNumber,
-            [visitor.visitorId],
-            prison.policyNoticeDaysMax,
-          )
+          expect(visitSessionsService.getVisitSessionsCalendar).toHaveBeenCalledWith({
+            prisonId: prison.code,
+            prisonerId: prisoner.prisonerNumber,
+            visitorIds: [visitor.visitorId],
+            daysAhead: prison.policyNoticeDaysMax,
+          })
 
           expect(sessionData).toStrictEqual({
             booker: {
@@ -183,12 +183,12 @@ describe('Choose visit time', () => {
           expect($('[data-test=return-to-home]').text()).toBe('return to the homepage')
           expect($('[data-test=return-to-home]').attr('href')).toBe('/')
 
-          expect(visitSessionsService.getVisitSessionsCalendar).toHaveBeenCalledWith(
-            prison.code,
-            prisoner.prisonerNumber,
-            [visitor.visitorId],
-            prison.policyNoticeDaysMax,
-          )
+          expect(visitSessionsService.getVisitSessionsCalendar).toHaveBeenCalledWith({
+            prisonId: prison.code,
+            prisonerId: prisoner.prisonerNumber,
+            visitorIds: [visitor.visitorId],
+            daysAhead: prison.policyNoticeDaysMax,
+          })
 
           expect(sessionData).toStrictEqual({
             booker: {

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -146,20 +146,7 @@ describe('Choose visit time', () => {
             daysAhead: prison.policyNoticeDaysMax,
           })
 
-          expect(sessionData).toStrictEqual({
-            booker: {
-              reference: bookerReference,
-              prisoners: [prisoner],
-            },
-            bookingJourney: {
-              prisoner,
-              prison,
-              allVisitors: [visitor],
-              selectedVisitors: [visitor],
-              allVisitSessionIds,
-              sessionRestriction,
-            },
-          } as SessionData)
+          expect(sessionData.bookingJourney.sessionRestriction).toBe(sessionRestriction)
         })
     })
 
@@ -211,18 +198,7 @@ describe('Choose visit time', () => {
             daysAhead: prison.policyNoticeDaysMax,
           })
 
-          expect(sessionData).toStrictEqual({
-            booker: {
-              reference: bookerReference,
-              prisoners: [prisoner],
-            },
-            bookingJourney: {
-              prisoner,
-              prison,
-              allVisitors: [visitor],
-              selectedVisitors: [visitor],
-            },
-          } as SessionData)
+          expect(sessionData.bookingJourney.sessionRestriction).toBe(undefined)
         })
     })
 
@@ -283,34 +259,21 @@ describe('Choose visit time', () => {
           })
           expect(visitService.changeVisitApplication).not.toHaveBeenCalled()
 
-          expect(sessionData).toStrictEqual({
-            booker: {
-              reference: bookerReference,
-              prisoners: [prisoner],
-            },
-            bookingJourney: {
-              prisoner,
-              prison,
-              allVisitors: [visitor],
-              selectedVisitors: [visitor],
-              allVisitSessionIds,
-              sessionRestriction,
-              selectedSessionDate: '2024-05-30',
-              selectedSessionTemplateReference: 'a',
-              applicationReference: application.reference,
-            },
-          } as SessionData)
+          expect(sessionData.bookingJourney.selectedSessionDate).toBe('2024-05-30')
+          expect(sessionData.bookingJourney.selectedSessionTemplateReference).toBe('a')
+          expect(sessionData.bookingJourney.applicationReference).toBe(application.reference)
         })
     })
 
     it('it should update an in-progress visit application with selected date/time and store data in session', () => {
-      sessionData.bookingJourney.selectedSessionDate = '2024-05-30'
-      sessionData.bookingJourney.selectedSessionTemplateReference = 'a'
-      sessionData.bookingJourney.applicationReference = application.reference
+      const { bookingJourney } = sessionData
+      bookingJourney.selectedSessionDate = '2024-05-30'
+      bookingJourney.selectedSessionTemplateReference = 'a'
+      bookingJourney.applicationReference = application.reference
 
       return request(app)
         .post(url)
-        .send({ visitSession: '2024-05-30_a' })
+        .send({ visitSession: '2024-06-02_d' })
         .expect(302)
         .expect('Location', '/book-visit/additional-support')
         .expect(() => {
@@ -318,26 +281,12 @@ describe('Choose visit time', () => {
 
           expect(visitService.createVisitApplication).not.toHaveBeenCalled()
           expect(visitService.changeVisitApplication).toHaveBeenCalledWith({
-            bookingJourney: sessionData.bookingJourney,
+            bookingJourney,
           })
 
-          expect(sessionData).toStrictEqual({
-            booker: {
-              reference: bookerReference,
-              prisoners: [prisoner],
-            },
-            bookingJourney: {
-              prisoner,
-              prison,
-              allVisitors: [visitor],
-              selectedVisitors: [visitor],
-              allVisitSessionIds,
-              sessionRestriction,
-              selectedSessionDate: '2024-05-30',
-              selectedSessionTemplateReference: 'a',
-              applicationReference: application.reference,
-            },
-          } as SessionData)
+          expect(bookingJourney.selectedSessionDate).toBe('2024-06-02')
+          expect(bookingJourney.selectedSessionTemplateReference).toBe('d')
+          expect(bookingJourney.applicationReference).toBe(application.reference)
         })
     })
 

--- a/server/routes/bookVisit/chooseVisitTimeController.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from 'express'
-import { Meta, ValidationChain, body, validationResult } from 'express-validator'
+import { Meta, ValidationChain, body, matchedData, validationResult } from 'express-validator'
 import { VisitService, VisitSessionsService } from '../../services'
 
 export default class ChooseVisitTimeController {
@@ -31,11 +31,17 @@ export default class ChooseVisitTimeController {
       bookingJourney.allVisitSessionIds = allVisitSessionIds
       bookingJourney.sessionRestriction = sessionRestriction
 
+      const { selectedSessionDate, selectedSessionTemplateReference } = bookingJourney
+      const formValues =
+        selectedSessionDate && selectedSessionTemplateReference
+          ? { visitSession: `${selectedSessionDate}_${selectedSessionTemplateReference}` }
+          : {}
+
       return res.render('pages/bookVisit/chooseVisitTime', {
         errors: req.flash('errors'),
-        formValues: req.flash('formValues')?.[0] || {},
+        formValues,
         calendar,
-        selectedDate: firstSessionDate,
+        selectedDate: selectedSessionDate ?? firstSessionDate,
         prisoner,
       })
     }
@@ -46,13 +52,12 @@ export default class ChooseVisitTimeController {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array())
-        req.flash('formValues', req.body)
         return res.redirect('/book-visit/choose-visit-time')
       }
-
-      const visitSession = req.body.visitSession.split('_')
-      const selectedSessionDate = visitSession[0]
-      const selectedSessionTemplateReference = visitSession[1]
+      const { visitSession } = matchedData<{ visitSession: string }>(req)
+      const visitSessionSplit = visitSession.split('_')
+      const selectedSessionDate = visitSessionSplit[0]
+      const selectedSessionTemplateReference = visitSessionSplit[1]
 
       const { booker, bookingJourney } = req.session
       bookingJourney.selectedSessionDate = selectedSessionDate

--- a/server/routes/bookVisit/chooseVisitTimeController.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.ts
@@ -11,17 +11,18 @@ export default class ChooseVisitTimeController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { bookingJourney } = req.session
-      const { prison, prisoner, selectedVisitors } = bookingJourney
+      const { prisoner, prison, selectedVisitors, applicationReference } = bookingJourney
 
       const selectedVisitorIds = selectedVisitors.map(visitor => visitor.visitorId)
 
       const { calendar, firstSessionDate, allVisitSessionIds, sessionRestriction } =
-        await this.visitSessionsService.getVisitSessionsCalendar(
-          prisoner.prisonCode,
-          prisoner.prisonerNumber,
-          selectedVisitorIds,
-          prison.policyNoticeDaysMax,
-        )
+        await this.visitSessionsService.getVisitSessionsCalendar({
+          prisonId: prisoner.prisonCode,
+          prisonerId: prisoner.prisonerNumber,
+          visitorIds: selectedVisitorIds,
+          ...(applicationReference && { excludedApplicationReference: applicationReference }),
+          daysAhead: prison.policyNoticeDaysMax,
+        })
 
       if (allVisitSessionIds.length === 0) {
         return res.render('pages/bookVisit/chooseVisitTimeNoSessions')

--- a/server/routes/bookVisit/chooseVisitTimeController.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.ts
@@ -21,7 +21,7 @@ export default class ChooseVisitTimeController {
           prisonId: prisoner.prisonCode,
           prisonerId: prisoner.prisonerNumber,
           visitorIds: selectedVisitorIds,
-          ...(applicationReference && { excludedApplicationReference: applicationReference }),
+          excludedApplicationReference: applicationReference,
           daysAhead: prison.policyNoticeDaysMax,
         })
 

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -119,6 +119,31 @@ describe('Visit service', () => {
         })
         expect(results).toStrictEqual(application)
       })
+
+      it('should handle minimal available session data', async () => {
+        bookingJourney.visitorSupport = undefined
+        bookingJourney.mainContact = undefined
+
+        const visitors = [
+          { nomisPersonId: 100, visitContact: false },
+          { nomisPersonId: 200, visitContact: false },
+        ]
+
+        orchestrationApiClient.changeVisitApplication.mockResolvedValue(application)
+
+        const results = await visitService.changeVisitApplication({ bookingJourney })
+
+        expect(orchestrationApiClient.changeVisitApplication).toHaveBeenCalledWith({
+          applicationReference: bookingJourney.applicationReference,
+          applicationRestriction: bookingJourney.sessionRestriction,
+          sessionTemplateReference: bookingJourney.selectedSessionTemplateReference,
+          sessionDate: bookingJourney.selectedSessionDate,
+          visitContact: undefined,
+          visitors,
+          visitorSupport: undefined,
+        })
+        expect(results).toStrictEqual(application)
+      })
     })
 
     describe('bookVisit', () => {

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -38,11 +38,15 @@ export default class VisitService {
     const token = await this.hmppsAuthClient.getSystemClientToken()
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    const { contact, phoneNumber } = bookingJourney.mainContact
-    const visitContact = {
-      name: typeof contact === 'string' ? contact : `${contact.firstName} ${contact.lastName}`,
-      ...(phoneNumber && { telephone: phoneNumber }),
-    }
+    const contact = bookingJourney.mainContact?.contact
+    const phoneNumber = bookingJourney.mainContact?.phoneNumber
+
+    const visitContact = bookingJourney.mainContact
+      ? {
+          name: typeof contact === 'string' ? contact : `${contact.firstName} ${contact.lastName}`,
+          ...(phoneNumber && { telephone: phoneNumber }),
+        }
+      : undefined
 
     const visitors = bookingJourney.selectedVisitors.map(visitor => {
       return {
@@ -51,6 +55,8 @@ export default class VisitService {
       }
     })
 
+    const visitorSupport = bookingJourney.visitorSupport ? { description: bookingJourney.visitorSupport } : undefined
+
     const application = orchestrationApiClient.changeVisitApplication({
       applicationReference: bookingJourney.applicationReference,
       applicationRestriction: bookingJourney.sessionRestriction,
@@ -58,7 +64,7 @@ export default class VisitService {
       sessionDate: bookingJourney.selectedSessionDate,
       visitContact,
       visitors,
-      visitorSupport: { description: bookingJourney.visitorSupport },
+      visitorSupport,
     })
     logger.info(`Visit application '${bookingJourney.applicationReference}' changed`)
     return application

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -85,18 +85,18 @@ describe('Visit sessions service', () => {
       const expectedAllVisitSessionIds: string[] = ['2024-05-30_a', '2024-05-31_b', '2024-05-31_c', '2024-06-02_d']
       const expectedSessionRestriction: SessionRestriction = 'OPEN'
 
-      const results = await visitSessionsService.getVisitSessionsCalendar(
-        prisoner.prisonCode,
-        prisoner.prisonerNumber,
+      const results = await visitSessionsService.getVisitSessionsCalendar({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
         visitorIds,
         daysAhead,
-      )
+      })
 
-      expect(orchestrationApiClient.getVisitSessions).toHaveBeenCalledWith(
-        prisoner.prisonCode,
-        prisoner.prisonerNumber,
+      expect(orchestrationApiClient.getVisitSessions).toHaveBeenCalledWith({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
         visitorIds,
-      )
+      })
       expect(results).toStrictEqual({
         calendar: expectedCalendar,
         firstSessionDate: expectedFirstSessionDate,
@@ -116,23 +116,46 @@ describe('Visit sessions service', () => {
       const expectedAllVisitSessionIds: string[] = []
       const expectedSessionRestriction: SessionRestriction = undefined
 
-      const results = await visitSessionsService.getVisitSessionsCalendar(
-        prisoner.prisonCode,
-        prisoner.prisonerNumber,
+      const results = await visitSessionsService.getVisitSessionsCalendar({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
         visitorIds,
-        28,
-      )
+        daysAhead: 28,
+      })
 
-      expect(orchestrationApiClient.getVisitSessions).toHaveBeenCalledWith(
-        prisoner.prisonCode,
-        prisoner.prisonerNumber,
+      expect(orchestrationApiClient.getVisitSessions).toHaveBeenCalledWith({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
         visitorIds,
-      )
+      })
       expect(results).toStrictEqual({
         calendar: expectedCalendar,
         firstSessionDate: expectedFirstSessionDate,
         allVisitSessionIds: expectedAllVisitSessionIds,
         sessionRestriction: expectedSessionRestriction,
+      })
+    })
+
+    it('should pass excludeApplicationReference if present', async () => {
+      const prisoner = TestData.prisonerInfoDto()
+      const visitorIds = [1, 2]
+      const visitSessions: AvailableVisitSessionDto[] = []
+      const excludedApplicationReference = 'aaa-bbb-ccc'
+      orchestrationApiClient.getVisitSessions.mockResolvedValue(visitSessions)
+
+      await visitSessionsService.getVisitSessionsCalendar({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
+        visitorIds,
+        excludedApplicationReference,
+        daysAhead: 28,
+      })
+
+      expect(orchestrationApiClient.getVisitSessions).toHaveBeenCalledWith({
+        prisonId: prisoner.prisonCode,
+        prisonerId: prisoner.prisonerNumber,
+        visitorIds,
+        excludedApplicationReference,
       })
     })
   })

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -16,18 +16,25 @@ export default class VisitSessionsService {
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
-  async getVisitSessionsCalendar(
-    prisonId: string,
-    prisonerId: string,
-    visitorIds: number[],
-    daysAhead: number,
-  ): Promise<{
+  async getVisitSessionsCalendar({
+    prisonId,
+    prisonerId,
+    visitorIds,
+    excludedApplicationReference,
+    daysAhead,
+  }: {
+    prisonId: string
+    prisonerId: string
+    visitorIds: number[]
+    excludedApplicationReference?: string
+    daysAhead: number
+  }): Promise<{
     calendar: VisitSessionsCalendar
     firstSessionDate: string
     allVisitSessionIds: string[]
     sessionRestriction: SessionRestriction
   }> {
-    const visitSessions = await this.getVisitSessions(prisonId, prisonerId, visitorIds)
+    const visitSessions = await this.getVisitSessions(prisonId, prisonerId, visitorIds, excludedApplicationReference)
 
     if (visitSessions.length === 0) {
       return { calendar: {}, firstSessionDate: '', allVisitSessionIds: [], sessionRestriction: undefined }
@@ -74,10 +81,16 @@ export default class VisitSessionsService {
     prisonId: string,
     prisonerId: string,
     visitorIds: number[],
+    excludedApplicationReference?: string,
   ): Promise<AvailableVisitSessionDto[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    return orchestrationApiClient.getVisitSessions(prisonId, prisonerId, visitorIds)
+    return orchestrationApiClient.getVisitSessions({
+      prisonId,
+      prisonerId,
+      visitorIds,
+      ...(excludedApplicationReference && { excludedApplicationReference }),
+    })
   }
 }

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -90,7 +90,7 @@ export default class VisitSessionsService {
       prisonId,
       prisonerId,
       visitorIds,
-      ...(excludedApplicationReference && { excludedApplicationReference }),
+      excludedApplicationReference,
     })
   }
 }

--- a/server/views/pages/bookVisit/chooseVisitTime.njk
+++ b/server/views/pages/bookVisit/chooseVisitTime.njk
@@ -75,10 +75,12 @@
             {% if sessions | length %}
               {% set visitSessionItems = [] %}
               {% for session in sessions %}
+                {% set radioValue = date + "_" + session.reference %}
                 {% set visitSessionItems = (visitSessionItems.push({
-                  value: date + "_" + session.reference,
+                  value: radioValue,
                   html: (session.startTime | formatTime) + " to " + (session.endTime | formatTime) +
-                   ' <span class="visits-calendar__session-duration">(' + (session.startTime | formatTimeDuration(session.endTime)) + ')</span>'
+                   ' <span class="visits-calendar__session-duration">(' + (session.startTime | formatTimeDuration(session.endTime)) + ')</span>',
+                  checked: formValues.visitSession == radioValue
                 }), visitSessionItems) %}
               {% endfor %}
 


### PR DESCRIPTION
* Pre-populate page based on previously selected session date/time
  * if there is an existing application, pass its reference via `excludedApplicationReference` parameter to ensure it is included as an available visit session
* When choosing a time:
  * first time: call 'create application' endpoint to get a new application
  * subsequently: call 'change application' endpoint to update the existing application with the selected time