### PR TITLE
Improve date formatting (and fix integration test bug)

### DIFF
--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -1,6 +1,6 @@
 import { addDays, format, subYears } from 'date-fns'
 import { AvailableVisitSessionDto } from '../../server/data/orchestrationApiTypes'
-import { DateFormats } from '../../server/utils/constants'
+import { DateFormats } from '../../server/constants/dateFormats'
 import TestData from '../../server/routes/testutils/testData'
 import AdditionalSupportPage from '../pages/bookVisit/additionalSupport'
 import ChooseVisitTimePage from '../pages/bookVisit/chooseVisitTime'
@@ -153,7 +153,7 @@ context('Booking journey', () => {
     checkVisitDetailsPage.prisonerName().contains('John Smith')
     checkVisitDetailsPage.visitorName(1).contains('Adult One (25 years old)')
     checkVisitDetailsPage.visitorName(2).contains('Child Two (5 years old')
-    checkVisitDetailsPage.visitDate().contains('Monday 24 June 2024')
+    checkVisitDetailsPage.visitDate().contains(format(in5Days, DateFormats.PRETTY_DATE))
     checkVisitDetailsPage.visitTime().contains('2pm to 3pm')
     checkVisitDetailsPage.additionalSupport().contains('Wheelchair access')
     checkVisitDetailsPage.mainContactName().contains('Adult One')

--- a/server/constants/dateFormats.ts
+++ b/server/constants/dateFormats.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export, no-shadow
 export enum DateFormats {
   ISO_DATE = 'yyyy-MM-dd',
+  PRETTY_DATE = 'EEEE d MMMM yyyy',
 }

--- a/server/routes/bookVisit/checkVisitDetailsController.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.ts
@@ -18,8 +18,8 @@ export default class CheckVisitDetailsController {
         additionalSupport: bookingJourney.visitorSupport,
         mainContactName,
         mainContactNumber: bookingJourney.mainContact.phoneNumber,
-        visitSlot: bookingJourney.selectedVisitSession.sessionDate,
-        visitTimeslot: bookingJourney.selectedVisitSession.sessionTimeSlot,
+        sessionDate: bookingJourney.selectedVisitSession.sessionDate,
+        sessionTimeSlot: bookingJourney.selectedVisitSession.sessionTimeSlot,
         visitors: bookingJourney.selectedVisitors,
         prisoner: bookingJourney.prisoner,
       })

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -1,7 +1,7 @@
 import { addDays, eachDayOfInterval, format } from 'date-fns'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
 import { AvailableVisitSessionDto } from '../data/orchestrationApiTypes'
-import { DateFormats } from '../utils/constants'
+import { DateFormats } from '../constants/dateFormats'
 
 export type SessionRestriction = AvailableVisitSessionDto['sessionRestriction']
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,6 +8,7 @@ import { formatDate, formatTime, formatTimeDuration, initialiseName, pluralise }
 import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import paths from '../constants/paths'
+import { DateFormats } from '../constants/dateFormats'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -20,6 +21,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.showExtraTestAttrs = ['DEV', 'STAGING'].includes(config.environmentName)
   app.locals.oneLoginLink = config.apis.govukOneLogin.homeUrl
   app.locals.paths = paths
+  app.locals.dateFormats = DateFormats
 
   // Cachebusting version string
   if (production) {

--- a/server/views/pages/bookVisit/checkVisitDetails.njk
+++ b/server/views/pages/bookVisit/checkVisitDetails.njk
@@ -58,8 +58,8 @@
             text: "Date and time"
           },
           value: {
-            html: "<p><span data-test='visit-date'>" + visitSlot | formatDate("EEEE d MMMM yyyy") + "</span></p>
-              <p><span data-test='visit-time'>" + visitTimeslot.startTime | formatTime + " to " + visitTimeslot.endTime | formatTime + "</span></p>"
+            html: "<p><span data-test='visit-date'>" + sessionDate | formatDate(dateFormats.PRETTY_DATE) + "</span></p>
+              <p><span data-test='visit-time'>" + sessionTimeSlot.startTime | formatTime + " to " + sessionTimeSlot.endTime | formatTime + "</span></p>"
           },
           actions: {
             items: [

--- a/server/views/pages/bookVisit/chooseVisitTime.njk
+++ b/server/views/pages/bookVisit/chooseVisitTime.njk
@@ -118,7 +118,7 @@
                 fieldset: {
                   attributes: { id: 'day-group-' + date },
                   legend: {
-                    text: date | formatDate("EEEE d MMMM yyyy"),
+                    text: date | formatDate(dateFormats.PRETTY_DATE),
                     classes: "govuk-fieldset__legend--s"
                   }
                 },


### PR DESCRIPTION
* Fix integration test failure because of hard-coded test date (Cypress tests run using actual time)
* Small refactor of `DateFormats` constant and add to `app.locals` for re-use within templates