### PR TITLE
VB-3851, VB-3885 Set up static content pages for viewing when not logged in

### DIFF
--- a/integration_tests/e2e/staticContentPages.cy.ts
+++ b/integration_tests/e2e/staticContentPages.cy.ts
@@ -1,0 +1,39 @@
+import paths from '../../server/constants/paths'
+import TestData from '../../server/routes/testutils/testData'
+import AccessibilityStatementPage from '../pages/accessibilityStatement'
+import HomePage from '../pages/home'
+import Page from '../pages/page'
+
+context('Static content pages', () => {
+  describe('Unauthenticated user', () => {
+    it('should be able to access static content pages', () => {
+      cy.visit(paths.ACCESSIBILITY)
+      const accessibilityStatementPage = Page.verifyOnPage(AccessibilityStatementPage)
+
+      // should not have the GOVUK One Login header
+      accessibilityStatementPage.signOut().should('not.exist')
+    })
+  })
+
+  describe('Authenticated user', () => {
+    it('should be able to navigate to static content pages from home page using footer links', () => {
+      cy.task('reset')
+      cy.task('stubSignIn')
+      cy.task('stubHmppsAuthToken')
+
+      cy.task('stubGetBookerReference')
+      cy.task('stubGetPrisoners', { prisoners: [TestData.prisonerInfoDto] })
+      cy.signIn()
+
+      // Home page
+      const homePage = Page.verifyOnPage(HomePage)
+
+      // should have the GOVUK One Login header
+      homePage.signOut().should('exist')
+
+      // Select 'Accessibility' in footer
+      homePage.goToFooterLinkByName('Accessibility')
+      Page.verifyOnPage(AccessibilityStatementPage)
+    })
+  })
+})

--- a/integration_tests/pages/accessibilityStatement.ts
+++ b/integration_tests/pages/accessibilityStatement.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class AccessibilityStatementPage extends Page {
+  constructor() {
+    super('Accessibility statement')
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -42,4 +42,6 @@ export default abstract class Page {
   }
 
   signOut = (): PageElement => cy.get('.one-login-header a[href="/sign-out"]')
+
+  goToFooterLinkByName = (name: string): PageElement => cy.get('.govuk-footer__link').contains(name).click()
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -7,6 +7,7 @@ import errorHandler from './errorHandler'
 import { metricsMiddleware } from './monitoring/metricsApp'
 
 import setupGovukOneLogin from './middleware/setUpGovukOneLogin'
+import govukOneLogin from './authentication/govukOneLogin'
 import setUpCsrf from './middleware/setUpCsrf'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpStaticResources from './middleware/setUpStaticResources'
@@ -14,6 +15,7 @@ import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
 
+import unauthenticatedRoutes from './routes/unauthenticatedRoutes'
 import routes from './routes'
 
 import type { Services } from './services'
@@ -34,6 +36,8 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpStaticResources())
   nunjucksSetup(app, services.applicationInfo)
   app.use(setupGovukOneLogin())
+  app.use(unauthenticatedRoutes())
+  app.use(govukOneLogin.authenticationMiddleware())
   app.use(populateCurrentBooker(services.bookerService))
   app.use(setUpCsrf())
 

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -11,6 +11,9 @@ const paths = {
     CHECK_DETAILS: '/book-visit/check-visit-details',
     BOOKED: '/book-visit/visit-booked',
   },
+
+  // Footer links
+  ACCESSIBILITY: '/accessibility-statement',
 } as const
 
 export default paths

--- a/server/middleware/setUpGovukOneLogin.ts
+++ b/server/middleware/setUpGovukOneLogin.ts
@@ -47,8 +47,6 @@ export default function setUpGovukOneLogin(): Router {
       } else res.redirect(client.endSessionUrl())
     })
 
-    router.use(govukOneLogin.authenticationMiddleware())
-
     router.use((req, res, next) => {
       res.locals.user = req.user
       next()

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -19,6 +19,7 @@ import { NotFound } from 'http-errors'
 import type { Session, SessionData } from 'express-session'
 import { FieldValidationError } from 'express-validator'
 
+import unauthenticatedRoutes from '../unauthenticatedRoutes'
 import routes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
@@ -70,6 +71,7 @@ function appSetup(
   })
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
+  app.use(unauthenticatedRoutes())
   app.use(routes(services))
   app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))

--- a/server/routes/unauthenticatedRoutes.test.ts
+++ b/server/routes/unauthenticatedRoutes.test.ts
@@ -1,0 +1,54 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes, user } from './testutils/appSetup'
+import paths from '../constants/paths'
+
+let app: Express
+let userSupplier: () => Express.User
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Accessibility statement', () => {
+  it('should render accessibility statement with GOVUK One Login Header for an authenticated user', () => {
+    userSupplier = () => user
+    app = appWithAllRoutes({ userSupplier })
+
+    return request(app)
+      .get(paths.ACCESSIBILITY)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('title').text()).toMatch(/^Accessibility statement -/)
+        expect($('[data-test="back-link"]').length).toBe(0)
+        expect($('h1').text()).toBe('Accessibility statement')
+
+        expect($('header .one-login-header').length).toBe(1)
+        expect($('header.govuk-header').length).toBe(0)
+        expect($('.service-header__heading').text()).toBe('Visit someone in prison')
+        expect($('.service-header__nav-list-item-link').length).toBe(1)
+        expect($('.service-header__nav-list-item-link').eq(0).text().trim()).toBe('Home')
+      })
+  })
+
+  it('should render accessibility statement with fallback header for an unauthenticated user', () => {
+    userSupplier = () => undefined
+    app = appWithAllRoutes({ userSupplier })
+
+    return request(app)
+      .get(paths.ACCESSIBILITY)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('title').text()).toMatch(/^Accessibility statement -/)
+        expect($('[data-test="back-link"]').length).toBe(0)
+        expect($('h1').text()).toBe('Accessibility statement')
+
+        expect($('header.govuk-header').length).toBe(1)
+        expect($('header .one-login-header').length).toBe(0)
+        expect($('.govuk-header__content').text().trim()).toBe('Visit someone in prison')
+      })
+  })
+})

--- a/server/routes/unauthenticatedRoutes.ts
+++ b/server/routes/unauthenticatedRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+
+import paths from '../constants/paths'
+
+export default function routes(): Router {
+  const router = Router()
+
+  // Accessibility statement
+  router.get(paths.ACCESSIBILITY, (req, res) => {
+    res.render('pages/accessibilityStatement')
+  })
+
+  return router
+}

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -1,13 +1,4 @@
 {% extends "./partials/layout.njk" %}
-{% from "govuk/components/header/macro.njk" import govukHeader %}
-
-{% block header %}
-  {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: applicationName,
-    serviceUrl: "/"
-  }) }}
-{% endblock %}
 
 {% block content %}
   <h1 class="govuk-heading-l">

--- a/server/views/pages/accessibilityStatement.njk
+++ b/server/views/pages/accessibilityStatement.njk
@@ -1,0 +1,13 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = "Accessibility statement" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">Accessibility statement</h1>
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,7 +1,7 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
 {% from "../components/one_login_header/service-header.njk" import govukOneLoginServiceHeader %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {% set navigationItems = [
   {
@@ -23,13 +23,22 @@
 {%- endblock %}
 
 {% block header %}
+{# If user authenticated then use GOVUK One Login Header; otherwise default header #}
+{% if user and user.sub %}
   {{ govukOneLoginServiceHeader({ 
     navigationItems: navigationItems,
     serviceName: serviceName,
     activeLinkId: activeLinkId,
     signOutLink: signOutLink,
     oneLoginLink: oneLoginLink
-  })}}
+  }) }}
+{% else %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: applicationName,
+    serviceUrl: "/"
+  }) }}
+{% endif %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -42,6 +51,19 @@
       }) }}
     {% endif %}
   </div>
+{% endblock %}
+
+{% block footer %}
+  {{ govukFooter({
+    meta: {
+      items: [
+        {
+          href: paths.ACCESSIBILITY,
+          text: "Accessibility"
+        }
+      ]
+    }
+  }) }}
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
* Set up a set of routes that are loaded before `authenticate()` middleware run so these pages can be viewed by both authenticated and unauthenticated users
* Configure page layout to show GOVUK One Login header for logged in users and fallback header for others
* Unit and integration tests