### PR TITLE
VB-3783, VB-3944 Disable submit buttons on submit (create & book)

### DIFF
--- a/assets/js/disableButtonOnSubmit.js
+++ b/assets/js/disableButtonOnSubmit.js
@@ -1,0 +1,3 @@
+document.querySelector('.disable-button-on-submit')?.addEventListener('submit', e => {
+  e.target.querySelector('button[type=submit]').setAttribute('disabled', 'disabled')
+})

--- a/integration_tests/pages/bookVisit/checkVisitDetails.ts
+++ b/integration_tests/pages/bookVisit/checkVisitDetails.ts
@@ -19,7 +19,5 @@ export default class CheckVisitDetailsPage extends Page {
 
   mainContactNumber = (): PageElement => cy.get('[data-test="main-contact-number"]')
 
-  continue = (): void => {
-    cy.get('[data-test="submit-booking"]').click()
-  }
+  continue = (): void => this.clickDisabledOnSubmitButton('submit-booking')
 }

--- a/integration_tests/pages/bookVisit/chooseVisitTime.ts
+++ b/integration_tests/pages/bookVisit/chooseVisitTime.ts
@@ -18,7 +18,5 @@ export default class ChooseVisitTimePage extends Page {
     cy.get(`#day-group-${date} input`).eq(index).click()
   }
 
-  continue = (): void => {
-    cy.get('[data-test="continue-button"]').click()
-  }
+  continue = (): void => this.clickDisabledOnSubmitButton('continue-button')
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -44,4 +44,15 @@ export default abstract class Page {
   signOut = (): PageElement => cy.get('.one-login-header a[href="/sign-out"]')
 
   goToFooterLinkByName = (name: string): PageElement => cy.get('.govuk-footer__link').contains(name).click()
+
+  protected clickDisabledOnSubmitButton = (dataTestName: string): void => {
+    cy.get(`[data-test=${dataTestName}]`).within(bookButton => {
+      // set a one-off event listener for window unload to check
+      // submit booking button is disabled after it is clicked
+      cy.once('window:before:unload', () => {
+        expect(bookButton.attr('disabled')).to.eq('disabled')
+      })
+      cy.wrap(bookButton).click()
+    })
+  }
 }

--- a/server/views/pages/bookVisit/checkVisitDetails.njk
+++ b/server/views/pages/bookVisit/checkVisitDetails.njk
@@ -121,7 +121,7 @@
           rows: displayRows
       }) }}
 
-      <form action="{{ paths.BOOK_VISIT.CHECK_DETAILS }}" method="POST" novalidate>
+      <form action="{{ paths.BOOK_VISIT.CHECK_DETAILS }}" method="POST" novalidate class="disable-button-on-submit">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukButton({
@@ -134,4 +134,8 @@
     </div>
   </div>
 
+{% endblock %}
+
+{% block pageScripts %}
+<script src="/assets/disableButtonOnSubmit.js"></script>
 {% endblock %}

--- a/server/views/pages/bookVisit/chooseVisitTime.njk
+++ b/server/views/pages/bookVisit/chooseVisitTime.njk
@@ -85,7 +85,7 @@
       </nav>
 
       {# if errors, add error ID so anchor link from error summary works #}
-      <form action="{{ paths.BOOK_VISIT.CHOOSE_TIME }}" method="POST" novalidate {% if errors | length%}id="visitSession-error"{% endif %}>
+      <form action="{{ paths.BOOK_VISIT.CHOOSE_TIME }}" method="POST" novalidate {% if errors | length%}id="visitSession-error"{% endif %} class="disable-button-on-submit">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {# Build radio visit session items from months/dates/sessions data #}
@@ -147,4 +147,5 @@
 
 {% block pageScripts %}
 <script src="/assets/visitsCalendar.js"></script>
+<script src="/assets/disableButtonOnSubmit.js"></script>
 {% endblock %}


### PR DESCRIPTION
Disable submit buttons when clicked at key points in the journey to avoid the risk of 'double bookings', e.g. if user attempts to re-try because response is slow.

Applies to: choosing slot on calendar page (i.e. visit application creation) and check details page (i.e. visit booking).

Based on similar changes to Staff UI (https://github.com/ministryofjustice/book-a-prison-visit-staff-ui/pull/766)