### PR TITLE
Update IP allow lists and add pen test IP

### DIFF
--- a/helm_deploy/hmpps-book-a-prison-visit-ui/values.yaml
+++ b/helm_deploy/hmpps-book-a-prison-visit-ui/values.yaml
@@ -58,7 +58,8 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
 
 generic-prometheus-alerts:
   targetApplication: hmpps-book-a-prison-visit-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,8 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
       - circleci
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -23,8 +23,10 @@ generic-service:
       APPINSIGHTS_INSTRUMENTATIONKEY: null # disable App Insights for staging
 
   allowlist:
+    pen-test: "80.195.27.199"
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
       - circleci
 
 generic-prometheus-alerts:


### PR DESCRIPTION
* Replace deprecated `internal` IP group (see https://github.com/ministryofjustice/hmpps-ip-allowlists)
* add (temporarily) an IP to staging for pen testing