### PR TITLE
VB-4183 Update CSP 'formAction' to include GOV.UK One Login URL

### DIFF
--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -19,6 +19,7 @@ passport.deserializeUser((user, done) => {
 const authenticationMiddleware = (): RequestHandler => {
   return async (req, res, next) => {
     if (req.isAuthenticated()) {
+      res.locals.user = req.user
       return next()
     }
 

--- a/server/middleware/setUpGovukOneLogin.ts
+++ b/server/middleware/setUpGovukOneLogin.ts
@@ -46,11 +46,6 @@ export default function setUpGovukOneLogin(): Router {
         })
       } else res.redirect(client.endSessionUrl())
     })
-
-    router.use((req, res, next) => {
-      res.locals.user = req.user
-      next()
-    })
   })
 
   return router

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import express, { Router, Request, Response, NextFunction } from 'express'
 import helmet from 'helmet'
+import config from '../config'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -36,7 +37,7 @@ export default function setUpWebSecurity(): Router {
             'https://*.analytics.google.com',
             'https://*.googletagmanager.com',
           ],
-          formAction: [`'self'`],
+          formAction: [`'self' ${config.apis.govukOneLogin.url}`],
           upgradeInsecureRequests: process.env.NODE_ENV === 'development' ? null : [],
         },
       },


### PR DESCRIPTION
Fixes an issue where if a user had an expired session then tried a form submission it would fail - and appear to 'hang' - because the resultant redirect to re-authenticate with GOV.UK One Login would be blocked by the browser for violating the CSP policy.