### PR TITLE
VB-4183 CSP form-action fix

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -37,7 +37,11 @@ export default function setUpWebSecurity(): Router {
             'https://*.analytics.google.com',
             'https://*.googletagmanager.com',
           ],
-          formAction: [`'self' ${config.apis.govukOneLogin.url}`],
+          formAction: [
+            "'self'",
+            config.apis.govukOneLogin.url,
+            config.apis.govukOneLogin.url.replace('oidc', 'signin'),
+          ],
           upgradeInsecureRequests: process.env.NODE_ENV === 'development' ? null : [],
         },
       },


### PR DESCRIPTION
Add '`signin`' as well as the '`oidc`' sub-domain for the GOV.UK One Login URL to the CSP `form-action` rule.

Needed because with an expired session, when a user makes a `POST` request, Chrome blocks the initial redirect to the `oidc` domain and then the subsequent redirect to the `signin` domain.