### PR TITLE
VB-3853, VB-4056 Use GOV.UK One Login post_logout_redirect for user sign out

### DIFF
--- a/integration_tests/e2e/govukOneLogin.cy.ts
+++ b/integration_tests/e2e/govukOneLogin.cy.ts
@@ -1,6 +1,8 @@
 import HomePage from '../pages/home'
 import GovukOneLoginPage from '../pages/govukOneLogin'
 import Page from '../pages/page'
+import SignedOutPage from '../pages/signedOut'
+import paths from '../../server/constants/paths'
 
 context('Sign in with GOV.UK One Login', () => {
   beforeEach(() => {
@@ -14,7 +16,7 @@ context('Sign in with GOV.UK One Login', () => {
   })
 
   it('Unauthenticated user redirected to GOV.UK One Login - sign-in URL', () => {
-    cy.visit('/auth/sign-in')
+    cy.visit(paths.SIGN_IN)
     Page.verifyOnPage(GovukOneLoginPage)
   })
 
@@ -58,8 +60,10 @@ context('Sign in with GOV.UK One Login', () => {
     cy.task('stubGetPrisoners', {})
     cy.signIn()
     const indexPage = Page.verifyOnPage(HomePage)
+
+    cy.task('stubSignOut')
     indexPage.signOut().click()
-    Page.verifyOnPage(GovukOneLoginPage)
-    cy.contains('You have been logged out.')
+    const signedOutPage = Page.verifyOnPage(SignedOutPage)
+    signedOutPage.signInLink().should('have.attr', 'href', paths.SIGN_IN)
   })
 })

--- a/integration_tests/e2e/staticContentPages.cy.ts
+++ b/integration_tests/e2e/staticContentPages.cy.ts
@@ -11,9 +11,15 @@ context('Static content pages', () => {
     it('should be able to access static content pages', () => {
       cy.visit(paths.ACCESSIBILITY)
       const accessibilityStatementPage = Page.verifyOnPage(AccessibilityStatementPage)
+      accessibilityStatementPage.oneLoginHeader().should('not.exist')
 
-      // should not have the GOVUK One Login header
-      accessibilityStatementPage.signOut().should('not.exist')
+      cy.visit(paths.PRIVACY)
+      const privacyNoticePage = Page.verifyOnPage(PrivacyNoticePage)
+      privacyNoticePage.oneLoginHeader().should('not.exist')
+
+      cy.visit(paths.TERMS)
+      const termsAndConditionsPage = Page.verifyOnPage(TermsAndConditionsPage)
+      termsAndConditionsPage.oneLoginHeader().should('not.exist')
     })
   })
 
@@ -31,7 +37,7 @@ context('Static content pages', () => {
       const homePage = Page.verifyOnPage(HomePage)
 
       // should have the GOVUK One Login header
-      homePage.signOut().should('exist')
+      homePage.oneLoginHeader().contains('GOV.UK One Login')
 
       // Select 'Accessibility' in footer
       homePage.goToFooterLinkByName('Accessibility')

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -43,7 +43,9 @@ export default abstract class Page {
     )
   }
 
-  signOut = (): PageElement => cy.get('.one-login-header a[href="/sign-out"]')
+  oneLoginHeader = (): PageElement => cy.get('.one-login-header')
+
+  signOut = (): PageElement => cy.get('.one-login-header').contains('a', 'Sign out')
 
   backLink = (): PageElement => cy.get('[data-test="back-link"]')
 

--- a/integration_tests/pages/signedOut.ts
+++ b/integration_tests/pages/signedOut.ts
@@ -1,0 +1,9 @@
+import Page, { PageElement } from './page'
+
+export default class SignedOutPage extends Page {
+  constructor() {
+    super('You have signed out')
+  }
+
+  signInLink = (): PageElement => cy.get('[data-test=sign-in]')
+}

--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -7,6 +7,7 @@ import config from '../config'
 import logger from '../../logger'
 import TokenStore from '../data/tokenStore/tokenStore'
 import tokenStoreFactory from '../data/tokenStore/tokenStoreFactory'
+import paths from '../constants/paths'
 
 passport.serializeUser((user, done) => {
   // Not used but required for Passport
@@ -25,7 +26,7 @@ const authenticationMiddleware = (): RequestHandler => {
     }
 
     req.session.returnTo = req.originalUrl
-    return res.redirect('/sign-in')
+    return res.redirect(paths.SIGN_IN)
   }
 }
 

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -1,6 +1,11 @@
 const paths = {
   HOME: '/',
 
+  ACCESS_DENIED: '/access-denied',
+  SIGN_IN: '/sign-in',
+  SIGN_OUT: '/sign-out',
+  SIGNED_OUT: '/signed-out',
+
   BOOKINGS: {
     HOME: '/bookings',
     VISIT: '/bookings/details',
@@ -18,11 +23,9 @@ const paths = {
     BOOKED: '/book-visit/visit-booked',
   },
 
-  ACCESS_DENIED: '/access-denied',
   ACCESSIBILITY: '/accessibility-statement',
   COOKIES: '/cookies',
   PRIVACY: '/privacy-notice',
-  SIGNED_OUT: '/signed-out',
   TERMS: '/terms-and-conditions',
 } as const
 

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -6,7 +6,7 @@ import TokenStore from './tokenStore/redisTokenStore'
 
 jest.mock('./tokenStore/redisTokenStore')
 
-const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
+const tokenStore = new TokenStore(null, 'systemToken:') as jest.Mocked<TokenStore>
 
 const token = { access_token: 'token-1', expires_in: 300 }
 

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -11,19 +11,14 @@ initialiseAppInsights()
 buildAppInsightsClient(applicationInfo)
 
 import HmppsAuthClient from './hmppsAuthClient'
-import { createRedisClient } from './redisClient'
-import RedisTokenStore from './tokenStore/redisTokenStore'
-import InMemoryTokenStore from './tokenStore/inMemoryTokenStore'
 import OrchestrationApiClient from './orchestrationApiClient'
-import config from '../config'
+import tokenStoreFactory from './tokenStore/tokenStoreFactory'
 
 type RestClientBuilder<T> = (token: string) => T
 
 export const dataAccess = () => ({
   applicationInfo,
-  hmppsAuthClient: new HmppsAuthClient(
-    config.redis.enabled ? new RedisTokenStore(createRedisClient()) : new InMemoryTokenStore(),
-  ),
+  hmppsAuthClient: new HmppsAuthClient(tokenStoreFactory('systemToken:')),
   orchestrationApiClientBuilder: ((token: string) =>
     new OrchestrationApiClient(token)) as RestClientBuilder<OrchestrationApiClient>,
 })

--- a/server/data/tokenStore/redisTokenStore.test.ts
+++ b/server/data/tokenStore/redisTokenStore.test.ts
@@ -13,7 +13,7 @@ describe('tokenStore', () => {
   let tokenStore: TokenStore
 
   beforeEach(() => {
-    tokenStore = new TokenStore(redisClient as unknown as RedisClient)
+    tokenStore = new TokenStore(redisClient as unknown as RedisClient, 'systemToken:')
   })
 
   afterEach(() => {

--- a/server/data/tokenStore/redisTokenStore.ts
+++ b/server/data/tokenStore/redisTokenStore.ts
@@ -4,9 +4,10 @@ import logger from '../../../logger'
 import TokenStore from './tokenStore'
 
 export default class RedisTokenStore implements TokenStore {
-  private readonly prefix = 'systemToken:'
-
-  constructor(private readonly client: RedisClient) {
+  constructor(
+    private readonly client: RedisClient,
+    private readonly prefix: string,
+  ) {
     client.on('error', error => {
       logger.error(error, `Redis error`)
     })

--- a/server/data/tokenStore/tokenStoreFactory.ts
+++ b/server/data/tokenStore/tokenStoreFactory.ts
@@ -1,0 +1,18 @@
+import config from '../../config'
+import { createRedisClient } from '../redisClient'
+import InMemoryTokenStore from './inMemoryTokenStore'
+import RedisTokenStore from './redisTokenStore'
+import TokenStore from './tokenStore'
+
+let inMemoryTokenStore: InMemoryTokenStore
+
+const tokenStoreFactory = (prefix: string): TokenStore => {
+  if (config.redis.enabled) {
+    return new RedisTokenStore(createRedisClient(), prefix)
+  }
+
+  inMemoryTokenStore = new InMemoryTokenStore()
+  return inMemoryTokenStore
+}
+
+export default tokenStoreFactory

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
+import paths from './constants/paths'
 
 export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
@@ -8,7 +9,7 @@ export default function createErrorHandler(production: boolean) {
 
     if (error.status === 401 || error.status === 403) {
       logger.info('Logging user out')
-      return res.redirect('/sign-out')
+      return res.redirect(paths.SIGN_OUT)
     }
 
     res.locals.message = production ? 'Sorry, there is a problem with the service.' : error.message

--- a/server/middleware/populateCurrentBooker.test.ts
+++ b/server/middleware/populateCurrentBooker.test.ts
@@ -63,7 +63,7 @@ describe('populateCurrentBooker', () => {
     await populateCurrentBooker(bookerService)(req, res, next)
 
     expect(bookerService.getBookerReference).not.toHaveBeenCalled()
-    expect(res.redirect).toHaveBeenCalledWith('/sign-out')
+    expect(res.redirect).toHaveBeenCalledWith(paths.SIGN_OUT)
     expect(next).not.toHaveBeenCalled()
   })
 
@@ -77,7 +77,7 @@ describe('populateCurrentBooker', () => {
       email: res.locals.user.email,
       phoneNumber: res.locals.user.phone_number,
     })
-    expect(res.redirect).toHaveBeenCalledWith('/access-denied')
+    expect(res.redirect).toHaveBeenCalledWith(paths.ACCESS_DENIED)
     expect(next).not.toHaveBeenCalled()
     expect(logger.info).toHaveBeenCalledWith('Failed to retrieve booker reference for: user1')
   })

--- a/server/middleware/populateCurrentBooker.ts
+++ b/server/middleware/populateCurrentBooker.ts
@@ -8,7 +8,7 @@ export default function populateCurrentBooker(bookerService: BookerService): Req
   return async (req, res, next) => {
     try {
       if (!res.locals.user || !res.locals.user.sub || !res.locals.user.email) {
-        return res.redirect('/sign-out')
+        return res.redirect(paths.SIGN_OUT)
       }
 
       if (!req.session.booker) {
@@ -25,7 +25,7 @@ export default function populateCurrentBooker(bookerService: BookerService): Req
     } catch (error) {
       if (error.status === 404) {
         logger.info(`Failed to retrieve booker reference for: ${res.locals.user.sub}`)
-        return req.path === paths.ACCESS_DENIED ? next() : res.redirect('/access-denied')
+        return req.path === paths.ACCESS_DENIED ? next() : res.redirect(paths.ACCESS_DENIED)
       }
 
       return next(error)

--- a/server/middleware/setUpGovukOneLogin.ts
+++ b/server/middleware/setUpGovukOneLogin.ts
@@ -28,7 +28,7 @@ export default function setUpGovukOneLogin(): Router {
       return res.render('authError')
     })
 
-    router.get('/sign-in', (req, res, next) => {
+    router.get(paths.SIGN_IN, (req, res, next) => {
       passport.authenticate('oidc', { nonce: generators.nonce() })(req, res, next)
     })
 
@@ -40,7 +40,7 @@ export default function setUpGovukOneLogin(): Router {
       })(req, res, next)
     })
 
-    router.use('/sign-out', async (req, res, next) => {
+    router.use(paths.SIGN_OUT, async (req, res, next) => {
       if (req.user) {
         const idToken = await idTokenStore.getToken(encodeURIComponent(req.user.sub))
         req.logout(err => {

--- a/server/views/accessDenied.njk
+++ b/server/views/accessDenied.njk
@@ -11,7 +11,7 @@
       <p>This is a new service. Only people invited to test the service can use it.</p>
       
       <p>
-        If you have been invited to test it, <a href="/sign-out">sign out</a>. You can then sign in using the
+        If you have been invited to test it, <a href="{{ paths.SIGN_OUT }}">sign out</a>. You can then sign in using the
         email address you gave when applying to test the new service.
       </p>
 

--- a/server/views/authError.njk
+++ b/server/views/authError.njk
@@ -10,7 +10,7 @@
 
       <p>
         Try again later by
-        <a href="/sign-in">signing into the service using GOV.UK One Login</a>.
+        <a href="{{ paths.SIGN_IN }}">signing into the service using GOV.UK One Login</a>.
       </p>
 
     </div>

--- a/server/views/pages/signedOut.njk
+++ b/server/views/pages/signedOut.njk
@@ -10,7 +10,7 @@
 
       <p>
         You can book a visit or view your bookings by
-        <a href="/sign-in" class="govuk-link--no-visited-state">signing into the service using GOV.UK One Login</a>.
+        <a href="{{ paths.SIGN_IN }}" class="govuk-link--no-visited-state" data-test="sign-in">signing into the service using GOV.UK One Login</a>.
       </p>
 
     </div>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -21,7 +21,7 @@
   {{- activeLink if activeLink else 'home-link' -}}
 {%- endset %}
 {% set serviceName = applicationName %}
-{% set signOutLink = "/sign-out" %}
+{% set signOutLink = paths.SIGN_OUT %}
 
 {% block head %}
   {% if analyticsEnabled %}


### PR DESCRIPTION
Implement the `post_logout_redirect` GOV.UK One Login functionality (documented [here](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/managing-your-users-sessions/#log-your-user-out-of-gov-uk-one-login)) so that when a user signs out they are ultimately redirected back to `/sign-out` on our service. The previous behaviour was to end-up with a 'signed-out' page on One Login's domain.

Includes:
* refactor of `TokenStore` and a new `tokenStoreFactory` to get either an in-memory or Redis store with a customisable key prefix. This is needed because a user's `id_token` needs to be stored when they log in so that it is available for use in the log out process
* update of One Login wiremock endpoints to handle storing the `id_token` across requests
* tidy of remaining hard-coded paths