### PR TITLE
VB-4265 Add tests for Cookie banner and cookie consent

### DIFF
--- a/integration_tests/e2e/cookieConsent.cy.ts
+++ b/integration_tests/e2e/cookieConsent.cy.ts
@@ -1,0 +1,72 @@
+import TestData from '../../server/routes/testutils/testData'
+import CookiesPage from '../pages/cookiesPage'
+import HomePage from '../pages/home'
+import Page from '../pages/page'
+
+context('Cookie consent and analytics', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubHmppsAuthToken')
+    cy.task('stubGetBookerReference')
+    cy.task('stubGetPrisoners', { prisoners: [TestData.bookerPrisonerInfoDto()] })
+
+    cy.signIn()
+  })
+
+  describe('Cookie banner', () => {
+    it('should show cookie banner, set cookie when analytics accepted and load analytics', () => {
+      // Home page - analytics script should not be present initially
+      const homePage = Page.verifyOnPage(HomePage)
+      homePage.googleAnalytics().should('not.exist')
+
+      // Cookie banner - accept analytics
+      homePage.acceptAnalytics()
+      cy.contains('accepted analytics cookies')
+      homePage.hideAnalyticsAcceptedMessage()
+      homePage.cookieBanner().should('not.be.visible')
+      checkCookie({ acceptAnalytics: 'yes' })
+
+      // go to Cookies page - should be no banner and analytics should load
+      homePage.goToFooterLinkByName('Cookies')
+      const cookiesPage = Page.verifyOnPage(CookiesPage)
+      cookiesPage.googleAnalytics().should('exist')
+      cookiesPage.cookieBanner().should('not.exist')
+      cookiesPage.acceptAnalyticsRadio().should('be.checked')
+    })
+
+    it('should show cookie banner, set cookie when analytics rejected and not load analytics', () => {
+      // Home page - analytics script should not be present initially
+      const homePage = Page.verifyOnPage(HomePage)
+      homePage.googleAnalytics().should('not.exist')
+
+      // Cookie banner - reject analytics
+      homePage.rejectAnalytics()
+      cy.contains('rejected analytics cookies')
+      homePage.hideAnalyticsRejectedMessage()
+      homePage.cookieBanner().should('not.be.visible')
+      checkCookie({ acceptAnalytics: 'no' })
+
+      // go to Cookies page - should be no banner and analytics should not load
+      homePage.goToFooterLinkByName('Cookies')
+      const cookiesPage = Page.verifyOnPage(CookiesPage)
+      cookiesPage.googleAnalytics().should('not.exist')
+      cookiesPage.cookieBanner().should('not.exist')
+      cookiesPage.rejectAnalyticsRadio().should('be.checked')
+    })
+  })
+})
+
+function checkCookie({ acceptAnalytics }) {
+  cy.getCookie('cookie_policy').then(cookie => {
+    cy.wrap(cookie).should('have.a.property', 'path', '/')
+    cy.wrap(cookie).should('have.a.property', 'value', JSON.stringify({ acceptAnalytics }))
+
+    const expectedExpiry = new Date()
+    expectedExpiry.setFullYear(expectedExpiry.getFullYear() + 1)
+
+    const actualCookieExpiryDate = new Date(cookie.expiry * 1000).toDateString()
+
+    cy.wrap(actualCookieExpiryDate).should('equal', expectedExpiry.toDateString())
+  })
+}

--- a/integration_tests/pages/cookiesPage.ts
+++ b/integration_tests/pages/cookiesPage.ts
@@ -1,0 +1,11 @@
+import Page, { PageElement } from './page'
+
+export default class CookiesPage extends Page {
+  constructor() {
+    super('Cookies')
+  }
+
+  acceptAnalyticsRadio = (): PageElement => cy.get('input[name=acceptAnalytics][value=yes]')
+
+  rejectAnalyticsRadio = (): PageElement => cy.get('input[name=acceptAnalytics][value=no]')
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -43,6 +43,26 @@ export default abstract class Page {
     )
   }
 
+  googleAnalytics = (): PageElement => cy.get('[data-test=google-analytics]')
+
+  cookieBanner = (): PageElement => cy.get('#cookie-banner')
+
+  acceptAnalytics = (): void => {
+    cy.get('[data-test=accept-analytics]').click()
+  }
+
+  rejectAnalytics = (): void => {
+    cy.get('[data-test=reject-analytics]').click()
+  }
+
+  hideAnalyticsAcceptedMessage = (): void => {
+    cy.get('[data-test=hide-cookies-accepted]').click()
+  }
+
+  hideAnalyticsRejectedMessage = (): void => {
+    cy.get('[data-test=hide-cookies-rejected]').click()
+  }
+
   oneLoginHeader = (): PageElement => cy.get('.one-login-header')
 
   signOut = (): PageElement => cy.get('.one-login-header').contains('a', 'Sign out')

--- a/server/middleware/analyticsConsent.test.ts
+++ b/server/middleware/analyticsConsent.test.ts
@@ -1,0 +1,54 @@
+import type { Request, Response } from 'express'
+import analyticsConsent from './analyticsConsent'
+
+describe('analyticsConsent', () => {
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    req = {} as Request
+
+    res = {
+      locals: {},
+    } as Response
+  })
+
+  it('should set res.locals.analyticsEnabled to true if consent cookie set to yes', async () => {
+    req.cookies = { cookie_policy: JSON.stringify({ acceptAnalytics: 'yes' }) }
+
+    await analyticsConsent()(req, res, next)
+
+    expect(res.locals.analyticsEnabled).toBe(true)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should set res.locals.analyticsEnabled to false if consent cookie set to no', async () => {
+    req.cookies = { cookie_policy: JSON.stringify({ acceptAnalytics: 'no' }) }
+
+    await analyticsConsent()(req, res, next)
+
+    expect(res.locals.analyticsEnabled).toBe(false)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should set res.locals.analyticsEnabled to undefined if consent cookie set to invalid value', async () => {
+    req.cookies = { cookie_policy: 'NOT-A-JSON-STRING' }
+
+    await analyticsConsent()(req, res, next)
+
+    expect(res.locals.analyticsEnabled).toBe(undefined)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should set res.locals.analyticsEnabled to undefined if consent cookie is not set', async () => {
+    req.cookies = undefined
+
+    await analyticsConsent()(req, res, next)
+
+    expect(res.locals.analyticsEnabled).toBe(undefined)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/cookiesController.test.ts
+++ b/server/routes/cookiesController.test.ts
@@ -1,0 +1,173 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { FieldValidationError } from 'express-validator'
+import { appWithAllRoutes, FlashData, FlashErrors, flashProvider } from './testutils/appSetup'
+import paths from '../constants/paths'
+import config from '../config'
+
+let app: Express
+
+const analyticsCookieName = `_ga_${config.analytics.googleAnalyticsId.replace('G-', '')}`
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Cookies page', () => {
+  describe(`GET ${paths.COOKIES}`, () => {
+    it('should render cookies page with banner, no analytics and radios unchecked when no consent cookie', () => {
+      app = appWithAllRoutes({})
+
+      return request(app)
+        .get(paths.COOKIES)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Cookies -/)
+          expect($('[data-test="back-link"]').length).toBe(0)
+          expect($('h1').text()).toBe('Cookies')
+
+          expect($('script[data-test=google-analytics]').length).toBe(0)
+          expect($('#cookie-banner').length).toBe(1)
+          expect($('[data-test=ga-cookie-name]').text()).toBe(analyticsCookieName)
+          expect($('input[name=acceptAnalytics]:checked').length).toBe(0)
+        })
+    })
+
+    it('should render cookies page with no banner, no analytics script and radio checked when consent cookie set to NO', () => {
+      app = appWithAllRoutes({
+        cookies: {
+          cookie_policy: JSON.stringify({ acceptAnalytics: 'no' }),
+        },
+      })
+
+      return request(app)
+        .get(paths.COOKIES)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Cookies -/)
+          expect($('h1').text()).toBe('Cookies')
+
+          expect($('script[data-test=google-analytics]').length).toBe(0)
+          expect($('#cookie-banner').length).toBe(0)
+          expect($('[data-test=ga-cookie-name]').text()).toBe(analyticsCookieName)
+          expect($('input[name=acceptAnalytics][value=no]').prop('checked')).toBe(true)
+        })
+    })
+
+    it('should render cookies page with no banner, load analytics script and radio checked when consent cookie set to YES', () => {
+      app = appWithAllRoutes({
+        cookies: {
+          cookie_policy: JSON.stringify({ acceptAnalytics: 'yes' }),
+        },
+      })
+
+      return request(app)
+        .get(paths.COOKIES)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Cookies -/)
+          expect($('h1').text()).toBe('Cookies')
+
+          expect($('script[data-test=google-analytics]').length).toBe(1)
+          expect($('#cookie-banner').length).toBe(0)
+          expect($('[data-test=ga-cookie-name]').text()).toBe(analyticsCookieName)
+          expect($('input[name=acceptAnalytics][value=yes]').prop('checked')).toBe(true)
+        })
+    })
+
+    it('should render validation errors', () => {
+      const validationError: FieldValidationError = {
+        type: 'field',
+        location: 'body',
+        path: 'acceptAnalytics',
+        value: [],
+        msg: 'No answer selected',
+      }
+      const flashData: FlashData = { errors: [validationError] }
+      flashProvider.mockImplementation((key: keyof FlashData) => flashData[key])
+
+      app = appWithAllRoutes({})
+
+      return request(app)
+        .get(paths.COOKIES)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Error: Cookies -/)
+          expect($('h1').text()).toBe('Cookies')
+
+          expect($('.govuk-error-summary a[href="#acceptAnalytics-error"]').text()).toBe('No answer selected')
+          expect($('#acceptAnalytics-error').text()).toContain('No answer selected')
+        })
+    })
+  })
+
+  describe(`POST ${paths.COOKIES}`, () => {
+    const fakeDate = new Date('2024-07-24T16:30:15.000Z')
+    const expectedCookieExpiry = 'Thu, 24 Jul 2025 16:30:15 GMT' // expiry in 1 year
+
+    beforeEach(() => {
+      jest.useFakeTimers({ now: new Date(fakeDate) })
+      app = appWithAllRoutes({})
+    })
+
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+
+    it('should set cookie with correct parameters when analytics accepted', () => {
+      return request(app)
+        .post(paths.COOKIES)
+        .send({ acceptAnalytics: 'yes' })
+        .expect(302)
+        .expect('Location', paths.COOKIES)
+        .expect('Set-Cookie', `cookie_policy={"acceptAnalytics":"yes"}; Path=/; Expires=${expectedCookieExpiry}`)
+    })
+
+    it('should set cookie with correct parameters when analytics rejected', () => {
+      return request(app)
+        .post(paths.COOKIES)
+        .send({ acceptAnalytics: 'no' })
+        .expect(302)
+        .expect('Location', paths.COOKIES)
+        .expect('Set-Cookie', `cookie_policy={"acceptAnalytics":"no"}; Path=/; Expires=${expectedCookieExpiry}`)
+    })
+
+    describe('Validation errors', () => {
+      it('should set validation error and not set cookie when no choice made', () => {
+        const expectedFlashErrors: FlashErrors = [
+          { type: 'field', location: 'body', path: 'acceptAnalytics', value: undefined, msg: 'No answer selected' },
+        ]
+
+        return request(app)
+          .post(paths.COOKIES)
+          .expect(302)
+          .expect('Location', paths.COOKIES)
+          .expect(res => {
+            expect(res.headers).not.toHaveProperty('set-cookie')
+            expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
+          })
+      })
+
+      it('should set validation error and not set cookie when invalid choice made', () => {
+        const expectedFlashErrors: FlashErrors = [
+          { type: 'field', location: 'body', path: 'acceptAnalytics', value: 'INVALID', msg: 'No answer selected' },
+        ]
+
+        return request(app)
+          .post(paths.COOKIES)
+          .send({ acceptAnalytics: 'INVALID' })
+          .expect(302)
+          .expect('Location', paths.COOKIES)
+          .expect(res => {
+            expect(res.headers).not.toHaveProperty('set-cookie')
+            expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
+          })
+      })
+    })
+  })
+})

--- a/server/views/partials/cookieBanner.njk
+++ b/server/views/partials/cookieBanner.njk
@@ -30,12 +30,18 @@
         {
           text: "Accept analytics cookies",
           type: "button",
-          value: "yes"
+          value: "yes",
+          attributes: {
+            "data-test": "accept-analytics"
+          }
         },
         {
           text: "Reject analytics cookies",
           type: "button",
-          value: "no"
+          value: "no",
+          attributes: {
+            "data-test": "reject-analytics"
+          }
         },
         {
           text: "View cookies",
@@ -52,7 +58,10 @@
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "button",
+          attributes: {
+            "data-test": "hide-cookies-accepted"
+          }
         }
       ]
     },
@@ -65,7 +74,10 @@
       actions: [
         {
           text: "Hide cookie message",
-          type: "button"
+          type: "button",
+          attributes: {
+            "data-test": "hide-cookies-rejected"
+          }
         }
       ]
     }

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -26,7 +26,7 @@
 {% block head %}
   {% if analyticsEnabled %}
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalyticsId }}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalyticsId }}" data-test="google-analytics"></script>
     <script nonce="{{ cspNonce }}">
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Follow-up to #131:
* Unit tests for cookie consent page
* Unit tests for `analyticsConsent` middleware
* Cypress tests for cookie banner and accepting/rejecting
  * Checks cookie is set and that Google Analytics is loaded (or not) as appropriate