### PR TITLE
VB-4264 Remove analytics cookies when declining cookie consent

### DIFF
--- a/assets/js/cookieBanner.js
+++ b/assets/js/cookieBanner.js
@@ -1,4 +1,4 @@
-(() => {
+;(() => {
   function confirmCookiesChoice(acceptAnalytics) {
     document.getElementById('cookie-banner-main').hidden = true
 
@@ -21,10 +21,22 @@
   }
 
   function hideCookiesConfirmation(banner) {
-    banner.querySelectorAll('#cookie-banner-accepted, #cookie-banner-rejected')
-      .forEach(message => message.hidden = true)
+    banner
+      .querySelectorAll('#cookie-banner-accepted, #cookie-banner-rejected')
+      .forEach(message => (message.hidden = true))
 
-      banner.hidden = true
+    banner.hidden = true
+  }
+
+  function removeAnalyticsCookies() {
+    const domain = location.hostname === 'localhost' ? 'localhost' : 'justice.gov.uk'
+    const expires = new Date(0).toUTCString()
+    const gaID = document
+      .querySelector('[data-google-analytics-id]')
+      ?.getAttribute('data-google-analytics-id')
+      .replace('G-', '')
+    document.cookie = `_ga=; domain=${domain}; expires=${expires}; path=/;`
+    document.cookie = `_ga_${gaID}=; domain=${domain}; expires=${expires}; path=/;`
   }
 
   function setAnalyticsPreferenceCookie(acceptAnalytics) {
@@ -34,6 +46,10 @@
     const cookie = `cookie_policy=${cookieValue}; expires=${expires.toUTCString()}; path=/; Secure`
 
     document.cookie = cookie
+
+    if (acceptAnalytics === 'no') {
+      removeAnalyticsCookies()
+    }
   }
 
   const cookieBanner = document.getElementById('cookie-banner')
@@ -44,9 +60,8 @@
       button.addEventListener('click', () => confirmCookiesChoice(button.value))
     })
 
-    cookieBanner.querySelectorAll('#cookie-banner-accepted button, #cookie-banner-rejected button')
-      .forEach(button => {
-        button.addEventListener('click', () => hideCookiesConfirmation(cookieBanner))
-      })
+    cookieBanner.querySelectorAll('#cookie-banner-accepted button, #cookie-banner-rejected button').forEach(button => {
+      button.addEventListener('click', () => hideCookiesConfirmation(cookieBanner))
+    })
   }
 })()

--- a/integration_tests/e2e/cookieConsent.cy.ts
+++ b/integration_tests/e2e/cookieConsent.cy.ts
@@ -54,6 +54,31 @@ context('Cookie consent and analytics', () => {
       cookiesPage.cookieBanner().should('not.exist')
       cookiesPage.rejectAnalyticsRadio().should('be.checked')
     })
+
+    it('should remove previously set analytics cookies when rejecting', () => {
+      // Home page - accept analytics
+      const homePage = Page.verifyOnPage(HomePage)
+      homePage.acceptAnalytics()
+      homePage.hideAnalyticsAcceptedMessage()
+      checkCookie({ acceptAnalytics: 'yes' })
+
+      // go to Cookies page - analytics cookies should be present
+      homePage.goToFooterLinkByName('Cookies')
+      const cookiesPage = Page.verifyOnPage(CookiesPage)
+      cookiesPage.cookieBanner().should('not.exist')
+      cy.getCookie('_ga').should('exist')
+      cookiesPage.getAnalyticsCookieName().then(cookie => cy.getCookie(cookie.text()).should('exist'))
+
+      // reject analytics
+      cookiesPage.rejectAnalyticsRadio().check()
+      cookiesPage.saveCookieSettings()
+
+      // cookie preference should be set and analytics cookies removed
+      cookiesPage.checkOnPage()
+      checkCookie({ acceptAnalytics: 'no' })
+      cy.getCookie('_ga').should('not.exist')
+      cookiesPage.getAnalyticsCookieName().then(cookie => cy.getCookie(cookie.text()).should('not.exist'))
+    })
   })
 })
 

--- a/integration_tests/e2e/futureVisits.cy.ts
+++ b/integration_tests/e2e/futureVisits.cy.ts
@@ -1,7 +1,7 @@
-import paths from '../../server/constants/paths'
 import TestData from '../../server/routes/testutils/testData'
 import BookingsPage from '../pages/bookings'
 import VisitDetailsPage from '../pages/bookings/visit'
+import HomePage from '../pages/home'
 import Page from '../pages/page'
 
 context('Bookings home page', () => {
@@ -29,7 +29,8 @@ context('Bookings home page', () => {
       visits: [orchestrationVisitDto],
     })
 
-    cy.visit(paths.BOOKINGS.HOME)
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.goToServiceHeaderLinkByName('Bookings')
     const bookingsPage = Page.verifyOnPage(BookingsPage)
     bookingsPage.visitDate(1).contains('Thursday 21 May 2026')
     bookingsPage.visitStartTime(1).contains('10am')

--- a/integration_tests/e2e/govukOneLogin.cy.ts
+++ b/integration_tests/e2e/govukOneLogin.cy.ts
@@ -59,10 +59,10 @@ context('Sign in with GOV.UK One Login', () => {
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners', {})
     cy.signIn()
-    const indexPage = Page.verifyOnPage(HomePage)
+    const homePage = Page.verifyOnPage(HomePage)
 
     cy.task('stubSignOut')
-    indexPage.signOut().click()
+    homePage.signOut()
     const signedOutPage = Page.verifyOnPage(SignedOutPage)
     signedOutPage.signInLink().should('have.attr', 'href', paths.SIGN_IN)
   })

--- a/integration_tests/pages/cookiesPage.ts
+++ b/integration_tests/pages/cookiesPage.ts
@@ -5,7 +5,13 @@ export default class CookiesPage extends Page {
     super('Cookies')
   }
 
+  getAnalyticsCookieName = (): PageElement => cy.get('[data-test="ga-cookie-name"]')
+
   acceptAnalyticsRadio = (): PageElement => cy.get('input[name=acceptAnalytics][value=yes]')
 
   rejectAnalyticsRadio = (): PageElement => cy.get('input[name=acceptAnalytics][value=no]')
+
+  saveCookieSettings = (): void => {
+    cy.get('[data-test="save-cookie-settings"]').click()
+  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -65,11 +65,13 @@ export default abstract class Page {
 
   oneLoginHeader = (): PageElement => cy.get('.one-login-header')
 
-  signOut = (): PageElement => cy.get('.one-login-header').contains('a', 'Sign out')
+  signOut = (): PageElement => cy.get('.one-login-header').contains('a', 'Sign out').click()
+
+  goToServiceHeaderLinkByName = (name: string): PageElement => cy.get('.service-header').contains('a', name).click()
 
   backLink = (): PageElement => cy.get('[data-test="back-link"]')
 
-  goToFooterLinkByName = (name: string): PageElement => cy.get('.govuk-footer__link').contains(name).click()
+  goToFooterLinkByName = (name: string): PageElement => cy.get('.govuk-footer__link').contains('a', name).click()
 
   protected clickDisabledOnSubmitButton = (dataTestName: string): void => {
     cy.get(`[data-test=${dataTestName}]`).within(bookButton => {

--- a/server/routes/cookiesController.test.ts
+++ b/server/routes/cookiesController.test.ts
@@ -128,13 +128,35 @@ describe('Cookies page', () => {
         .expect('Set-Cookie', `cookie_policy={"acceptAnalytics":"yes"}; Path=/; Expires=${expectedCookieExpiry}`)
     })
 
-    it('should set cookie with correct parameters when analytics rejected', () => {
+    it('should set cookie with correct parameters when analytics rejected and clear existing analytics cookies (localhost)', () => {
+      const acceptAnalyticsNoCookie = `cookie_policy={"acceptAnalytics":"no"}; Path=/; Expires=${expectedCookieExpiry}`
+      const clearGACookie = '_ga=; Domain=localhost; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+      const clearGAIDCookie = '_ga_SSLMWLQYHQ=; Domain=localhost; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+
       return request(app)
         .post(paths.COOKIES)
         .send({ acceptAnalytics: 'no' })
         .expect(302)
         .expect('Location', paths.COOKIES)
-        .expect('Set-Cookie', `cookie_policy={"acceptAnalytics":"no"}; Path=/; Expires=${expectedCookieExpiry}`)
+        .expect('Set-Cookie', `${acceptAnalyticsNoCookie},${clearGACookie},${clearGAIDCookie}`)
+    })
+
+    it('should set cookie with correct parameters when analytics rejected and clear existing analytics cookies (justice domain)', () => {
+      const replacedProp = jest.replaceProperty(config, 'domain', 'https://visit-dev.prison.service.justice.gov.uk')
+
+      const acceptAnalyticsNoCookie = `cookie_policy={"acceptAnalytics":"no"}; Path=/; Expires=${expectedCookieExpiry}`
+      const clearGACookie = '_ga=; Domain=justice.gov.uk; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+      const clearGAIDCookie = '_ga_SSLMWLQYHQ=; Domain=justice.gov.uk; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+
+      return request(app)
+        .post(paths.COOKIES)
+        .send({ acceptAnalytics: 'no' })
+        .expect(302)
+        .expect('Location', paths.COOKIES)
+        .expect('Set-Cookie', `${acceptAnalyticsNoCookie},${clearGACookie},${clearGAIDCookie}`)
+        .expect(() => {
+          replacedProp.replaceValue('domain')
+        })
     })
 
     describe('Validation errors', () => {

--- a/server/routes/cookiesController.ts
+++ b/server/routes/cookiesController.ts
@@ -35,6 +35,18 @@ export default class CookiesController {
         httpOnly: false,
         encode: String,
       })
+
+      if (acceptAnalytics === 'no') {
+        const domain = config.domain.includes('localhost') ? 'localhost' : 'justice.gov.uk'
+
+        res.clearCookie('_ga', { domain, secure: false, httpOnly: false })
+        res.clearCookie(`_ga_${config.analytics.googleAnalyticsId.replace('G-', '')}`, {
+          domain,
+          secure: false,
+          httpOnly: false,
+        })
+      }
+
       return res.redirect(paths.COOKIES)
     }
   }

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -23,6 +23,10 @@
 {% set serviceName = applicationName %}
 {% set signOutLink = paths.SIGN_OUT %}
 
+{% set bodyAttributes = {
+  "data-google-analytics-id": googleAnalyticsId
+} %}
+
 {% block head %}
   {% if analyticsEnabled %}
     <!-- Google tag (gtag.js) -->


### PR DESCRIPTION
If a user has previously accepted Google Analytics but then subsequently chooses to reject it, they are left with `_ga and _ga_[containerId]` cookies still set.

This change removes these two cookies when analytics consent is declined, either by the form on the Cookies page (so it's done server-side) or via the cookie banner (so done client-side).