### PR TITLE
Add UI e2e tests for better coverage on main changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ workflows:
       - acceptance_tests_public_ui:
           <<: *feature_branch
           requires:
-            - request-acceptance-tests-public-approval
+            - request-acceptance-tests-staging-preview-public-approval
           context: visits-public-e2e-tests
 
       - request-acceptance-tests-staging-preview-public-approval:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,35 @@ jobs:
       - store_artifacts:
           path: integration_tests/screenshots
 
+  acceptance_tests_public_ui_main:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.44.1-jammy
+    circleci_ip_ranges: true
+
+    steps:
+      - run:
+          name: Checkout VSIP Public UI Tests
+          command: git clone https://github.com/ministryofjustice/hmpps-book-a-prison-visit-ui-tests
+      - run:
+          name: get git status
+          command: |
+            cd hmpps-book-a-prison-visit-ui-tests
+            git checkout main
+            git pull
+            git status
+      - attach_workspace:
+          at: ~/app
+      - run:
+          name: Install Dependencies
+          command: |
+            cd hmpps-book-a-prison-visit-ui-tests
+            npm ci --no-audit
+      - run:
+          name: Run Playwright Tests
+          command: |
+            cd hmpps-book-a-prison-visit-ui-tests
+            npm run test:ci
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -179,6 +208,18 @@ workflows:
           requires:
             - request-staging-preview-approval
 
+      - acceptance_tests_public_ui_staging_preview:
+          <<: *feature_branch
+          requires:
+            - request-acceptance-tests-public-approval
+          context: visits-public-e2e-tests
+
+      - request-acceptance-tests-staging-preview-public-approval:
+          <<: *feature_branch
+          type: approval
+          requires:
+            - deploy_staging_preview
+
       - hmpps/deploy_env:
           <<: *main_branch
           name: deploy_dev
@@ -206,6 +247,18 @@ workflows:
             - hmpps-book-a-prison-visit-ui-stage
           requires:
             - deploy_dev
+
+      - acceptance_tests_public_ui_main:
+          <<: *main_branch
+          requires:
+            - request-acceptance-tests-public-approval
+          context: visits-public-e2e-tests
+
+      - request-acceptance-tests-public-approval:
+          <<: *main_branch
+          type: approval
+          requires:
+            - deploy_staging
 
       - request-preprod-approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,6 @@ workflows:
           requires:
             - request-prod-approval
 
-
   security:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - store_artifacts:
           path: integration_tests/screenshots
 
-  acceptance_tests_public_ui_main:
+  acceptance_tests_public_ui:
     docker:
       - image: mcr.microsoft.com/playwright:v1.44.1-jammy
     circleci_ip_ranges: true
@@ -208,7 +208,7 @@ workflows:
           requires:
             - request-staging-preview-approval
 
-      - acceptance_tests_public_ui_staging_preview:
+      - acceptance_tests_public_ui:
           <<: *feature_branch
           requires:
             - request-acceptance-tests-public-approval
@@ -248,7 +248,7 @@ workflows:
           requires:
             - deploy_dev
 
-      - acceptance_tests_public_ui_main:
+      - acceptance_tests_public_ui:
           <<: *main_branch
           requires:
             - request-acceptance-tests-public-approval


### PR DESCRIPTION
Add the new e2e tests to our public UI service for better coverage on merges to main.