### PR TITLE
VB-3815 Show interruption card if visit will be CLOSED

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -10,5 +10,6 @@ $path: "/assets/images/";
 // GOV.UK One Login components
 @import './components/service-header-no-imports';
 
+@import './components/interruptionCard.scss';
 @import './components/visitsCalendar.scss';
 @import './local';

--- a/assets/scss/components/interruptionCard.scss
+++ b/assets/scss/components/interruptionCard.scss
@@ -1,0 +1,8 @@
+.interruption-card {
+  background-color: govuk-colour('blue');
+  padding: govuk-spacing(8) govuk-spacing(5);
+}
+
+.interruption-card__heading, .interruption-card__text {
+  color: govuk-colour('white');
+}

--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -111,6 +111,10 @@ context('Booking journey', () => {
     selectVisitorsPage.getVisitorLabel(3).contains('Child Two (5 years old)')
     selectVisitorsPage.selectVisitor(1)
     selectVisitorsPage.selectVisitor(3)
+    cy.task('stubGetSessionRestriction', {
+      prisonerId: prisoner.prisoner.prisonerNumber,
+      visitorIds: [1000, 3000],
+    })
 
     // Choose visit time
     cy.task('stubGetVisitSessions', {

--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -10,6 +10,7 @@ import SelectVisitorsPage from '../pages/bookVisit/selectVisitors'
 import MainContactPage from '../pages/bookVisit/mainContact'
 import CheckVisitDetailsPage from '../pages/bookVisit/checkVisitDetails'
 import VisitBookedPage from '../pages/bookVisit/visitBooked'
+import ClosedVisitPage from '../pages/bookVisit/closedVisit'
 
 context('Booking journey', () => {
   const today = new Date()
@@ -82,7 +83,7 @@ context('Booking journey', () => {
     cy.task('stubHmppsAuthToken')
   })
 
-  it('should complete the booking journey', () => {
+  it('should complete the booking journey (OPEN visit)', () => {
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners', { prisoners: [prisoner] })
     cy.signIn()
@@ -176,5 +177,46 @@ context('Booking journey', () => {
       .contains(
         'A text message confirming the visit will be sent to the main contact. This will include the booking reference.',
       )
+  })
+
+  it('should show closed visit interruption card (CLOSED visit)', () => {
+    cy.task('stubGetBookerReference')
+    cy.task('stubGetPrisoners', { prisoners: [prisoner] })
+    cy.signIn()
+
+    const bookerReference = TestData.bookerReference().value
+
+    // Home page - prisoner shown
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.prisonerName().contains('John Smith')
+
+    // Start booking journey
+    cy.task('stubGetPrison', prison)
+    cy.task('stubGetVisitors', { visitors })
+    homePage.startBooking()
+
+    // Select visitors page - choose visitors
+    const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
+    selectVisitorsPage.selectVisitor(1)
+    cy.task('stubGetSessionRestriction', {
+      prisonerId: prisoner.prisoner.prisonerNumber,
+      visitorIds: [1000],
+      sessionRestriction: 'CLOSED',
+    })
+    selectVisitorsPage.continue()
+
+    // Closed visit interruption card page
+    const closedVisitPage = Page.verifyOnPage(ClosedVisitPage)
+
+    // Choose visit time
+    cy.task('stubGetVisitSessions', {
+      prisonId: prisoner.prisoner.prisonId,
+      prisonerId: prisoner.prisoner.prisonerNumber,
+      visitorIds: [1000],
+      bookerReference,
+      visitSessions,
+    })
+    closedVisitPage.continue()
+    Page.verifyOnPage(ChooseVisitTimePage)
   })
 })

--- a/integration_tests/e2e/bookingJourneyDropOuts.cy.ts
+++ b/integration_tests/e2e/bookingJourneyDropOuts.cy.ts
@@ -56,6 +56,10 @@ context('Booking journey - drop-out points', () => {
       // Select visitors page - choose visitors
       const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
       selectVisitorsPage.selectVisitor(1)
+      cy.task('stubGetSessionRestriction', {
+        prisonerId: prisoner.prisoner.prisonerNumber,
+        visitorIds: [1000],
+      })
 
       // Choose visit time
       cy.task('stubGetVisitSessions', {
@@ -88,6 +92,10 @@ context('Booking journey - drop-out points', () => {
       // Select visitors page - choose visitors
       const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
       selectVisitorsPage.selectVisitor(1)
+      cy.task('stubGetSessionRestriction', {
+        prisonerId: prisoner.prisoner.prisonerNumber,
+        visitorIds: [1000],
+      })
 
       // Choose visit time
       cy.task('stubGetVisitSessions', {

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -10,6 +10,7 @@ import {
   VisitDto,
   VisitorInfoDto,
 } from '../../server/data/orchestrationApiTypes'
+import { SessionRestriction } from '../../server/data/orchestrationApiClient'
 
 export default {
   // orchestration-visits-controller
@@ -245,7 +246,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        urlPath: `/orchestration/visit-sessions/available`,
+        urlPath: '/orchestration/visit-sessions/available',
         queryParameters: {
           prisonId: { equalTo: prisonId },
           prisonerId: { equalTo: prisonerId },
@@ -267,6 +268,31 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: visitSessions,
+      },
+    }),
+
+  stubGetSessionRestriction: ({
+    prisonerId,
+    visitorIds,
+    sessionRestriction = 'OPEN',
+  }: {
+    prisonerId: string
+    visitorIds: number[]
+    sessionRestriction: SessionRestriction
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: '/orchestration/visit-sessions/available/restriction',
+        queryParameters: {
+          prisonerId: { equalTo: prisonerId },
+          visitors: { equalTo: visitorIds.join(',') },
+        },
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { sessionRestriction },
       },
     }),
 

--- a/integration_tests/pages/bookVisit/closedVisit.ts
+++ b/integration_tests/pages/bookVisit/closedVisit.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class ClosedVisitPage extends Page {
+  constructor() {
+    super('This will be a closed visit')
+  }
+
+  continue = (): void => {
+    cy.get('[data-test=closed-visit-continue]').click()
+  }
+}

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -1,3 +1,4 @@
+import { SessionRestriction } from '../data/orchestrationApiClient'
 import { AvailableVisitSessionDto, PrisonDto } from '../data/orchestrationApiTypes'
 import { Prisoner, Visitor } from '../services/bookerService'
 
@@ -19,6 +20,9 @@ export type BookingJourney = {
 
   // selected visitors for this visit
   selectedVisitors?: Visitor[]
+
+  // session restriction (OPEN/CLOSED) for this visit
+  sessionRestriction?: SessionRestriction
 
   // all available visit sessions
   allVisitSessionIds?: string[] // e.g. ['2024-05-28_session-ref']

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -20,6 +20,7 @@ const paths = {
     SELECT_PRISONER: '/book-visit/select-prisoner',
     CANNOT_BOOK: '/book-visit/visit-cannot-be-booked',
     SELECT_VISITORS: '/book-visit/select-visitors',
+    CLOSED_VISIT: '/book-visit/closed-visit',
     CHOOSE_TIME: '/book-visit/choose-visit-time',
     ADDITIONAL_SUPPORT: '/book-visit/additional-support',
     MAIN_CONTACT: '/book-visit/main-contact',

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -1,5 +1,6 @@
 const paths = {
   HOME: '/',
+  RETURN_HOME: '/return-home', // used to clear session and redirect to HOME
 
   ACCESS_DENIED: '/access-denied',
   SIGN_IN: '/sign-in',

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -277,7 +277,7 @@ describe('orchestrationApiClient', () => {
         visitorIds,
       })
 
-      expect(result).toStrictEqual(availableVisitSessionRestrictionDto.sessionRestriction)
+      expect(result).toBe(availableVisitSessionRestrictionDto.sessionRestriction)
     })
   })
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -13,8 +13,10 @@ import {
   BookerPrisonerInfoDto,
   VisitDto,
   VisitorInfoDto,
+  AvailableVisitSessionRestrictionDto,
 } from './orchestrationApiTypes'
-import { type SessionRestriction } from '../services/visitSessionsService'
+
+export type SessionRestriction = AvailableVisitSessionDto['sessionRestriction']
 
 export default class OrchestrationApiClient {
   private restClient: RestClient
@@ -165,6 +167,23 @@ export default class OrchestrationApiClient {
         ...(excludedApplicationReference && { excludedApplicationReference }),
       }).toString(),
     })
+  }
+
+  async getSessionRestriction({
+    prisonerId,
+    visitorIds,
+  }: {
+    prisonerId: string
+    visitorIds: number[]
+  }): Promise<SessionRestriction> {
+    const { sessionRestriction } = await this.restClient.get<AvailableVisitSessionRestrictionDto>({
+      path: '/visit-sessions/available/restriction',
+      query: new URLSearchParams({
+        prisonerId,
+        visitors: visitorIds.join(','),
+      }).toString(),
+    })
+    return sessionRestriction
   }
 
   // orchestration-prisons-config-controller

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -8,6 +8,8 @@ export type AuthDetailDto = components['schemas']['AuthDetailDto']
 
 export type AvailableVisitSessionDto = components['schemas']['AvailableVisitSessionDto']
 
+export type AvailableVisitSessionRestrictionDto = components['schemas']['AvailableVisitSessionRestrictionDto']
+
 export type BookingOrchestrationRequestDto = components['schemas']['BookingOrchestrationRequestDto']
 
 export type BookerPrisonerInfoDto = components['schemas']['BookerPrisonerInfoDto']

--- a/server/middleware/bookVisitSessionValidator.test.ts
+++ b/server/middleware/bookVisitSessionValidator.test.ts
@@ -87,6 +87,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'redirect' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'redirect' },
         ])('$method $path should call $expected', ({ method, path, expected }) => {
           req = createMockReq({ method, path })
           bookVisitSessionValidator()(req, res, next)
@@ -100,6 +101,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'redirect' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'redirect' },
         ])('$method $path should call $expected', ({ method, path, expected }) => {
           req = createMockReq({ method, path, bookingJourney: { prisoner } })
           bookVisitSessionValidator()(req, res, next)
@@ -113,6 +115,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'redirect' },
         ])('$method $path should call $expected', ({ method, path, expected }) => {
           req = createMockReq({
@@ -131,6 +134,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'redirect' },
         ])('$method $path should call $expected', ({ method, path, expected }) => {
@@ -155,6 +159,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.ADDITIONAL_SUPPORT, expected: 'redirect' },
@@ -182,6 +187,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.ADDITIONAL_SUPPORT, expected: 'next' },
@@ -213,6 +219,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.ADDITIONAL_SUPPORT, expected: 'next' },
@@ -247,6 +254,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.ADDITIONAL_SUPPORT, expected: 'next' },
@@ -287,6 +295,7 @@ describe('bookVisitSessionValidator', () => {
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'redirect' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'redirect' },
+          { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'redirect' },
           { method: 'POST', path: paths.BOOK_VISIT.CHOOSE_TIME, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.ADDITIONAL_SUPPORT, expected: 'redirect' },

--- a/server/middleware/bookVisitSessionValidator.test.ts
+++ b/server/middleware/bookVisitSessionValidator.test.ts
@@ -5,6 +5,7 @@ import bookVisitSessionValidator from './bookVisitSessionValidator'
 import paths from '../constants/paths'
 import { Booker, BookingConfirmed, BookingJourney } from '../@types/bapv'
 import logger from '../../logger'
+import { SessionRestriction } from '../data/orchestrationApiClient'
 
 jest.mock('../../logger')
 
@@ -18,6 +19,7 @@ describe('bookVisitSessionValidator', () => {
   const bookerReference = TestData.bookerReference().value
   const prisoner = TestData.prisoner()
   const visitor = TestData.visitor()
+  const sessionRestriction: SessionRestriction = 'OPEN'
   const visitSessionId = '2024-05-30_a'
   const visitSession = TestData.availableVisitSessionDto()
   const applicationReference = 'aaa-bbb-ccc'
@@ -128,7 +130,7 @@ describe('bookVisitSessionValidator', () => {
         })
       })
 
-      describe('...add selectedVisitors', () => {
+      describe('...add selectedVisitors and sessionRestriction', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
@@ -146,6 +148,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
             },
           })
           bookVisitSessionValidator()(req, res, next)
@@ -172,6 +175,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
             },
@@ -202,6 +206,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
               selectedVisitSession: visitSession,
@@ -236,6 +241,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
               selectedVisitSession: visitSession,
@@ -272,6 +278,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
               selectedVisitSession: visitSession,

--- a/server/middleware/bookVisitSessionValidator.ts
+++ b/server/middleware/bookVisitSessionValidator.ts
@@ -56,7 +56,10 @@ export default function bookVisitSessionValidator(): RequestHandler {
     if (
       (journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CLOSED_VISIT) ||
         journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CHOOSE_TIME)) &&
-      (!bookingJourney.prison || !bookingJourney.allVisitors?.length || !bookingJourney.selectedVisitors?.length)
+      (!bookingJourney.prison ||
+        !bookingJourney.allVisitors?.length ||
+        !bookingJourney.selectedVisitors?.length ||
+        !bookingJourney.sessionRestriction)
     ) {
       return logAndRedirect(res, method, requestPath, booker.reference)
     }

--- a/server/middleware/bookVisitSessionValidator.ts
+++ b/server/middleware/bookVisitSessionValidator.ts
@@ -7,6 +7,7 @@ const journeyOrder: string[] = [
   paths.BOOK_VISIT.SELECT_PRISONER,
   paths.BOOK_VISIT.CANNOT_BOOK,
   paths.BOOK_VISIT.SELECT_VISITORS,
+  paths.BOOK_VISIT.CLOSED_VISIT,
   paths.BOOK_VISIT.CHOOSE_TIME,
   paths.BOOK_VISIT.ADDITIONAL_SUPPORT,
   paths.BOOK_VISIT.MAIN_CONTACT,
@@ -51,9 +52,10 @@ export default function bookVisitSessionValidator(): RequestHandler {
       return logAndRedirect(res, method, requestPath, booker.reference)
     }
 
-    // Choose visit time page
+    // Closed visit & Choose visit time page
     if (
-      journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CHOOSE_TIME) &&
+      (journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CLOSED_VISIT) ||
+        journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CHOOSE_TIME)) &&
       (!bookingJourney.prison || !bookingJourney.allVisitors?.length || !bookingJourney.selectedVisitors?.length)
     ) {
       return logAndRedirect(res, method, requestPath, booker.reference)

--- a/server/routes/bookVisit/additionalSupportController.test.ts
+++ b/server/routes/bookVisit/additionalSupportController.test.ts
@@ -8,6 +8,7 @@ import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
 import config from '../../config'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -19,6 +20,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const visitor = TestData.visitor()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const visitSession = TestData.availableVisitSessionDto()
 
 afterEach(() => {
@@ -40,6 +42,7 @@ describe('Additional support needs', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
+          sessionRestriction,
           allVisitSessionIds: ['2024-05-30_a'],
           allVisitSessions: [visitSession],
           selectedVisitSession: visitSession,
@@ -189,6 +192,7 @@ describe('Additional support needs', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
+          sessionRestriction,
           allVisitSessionIds: ['2024-05-30_a'],
           allVisitSessions: [visitSession],
           selectedVisitSession: visitSession,

--- a/server/routes/bookVisit/cannotBookController.ts
+++ b/server/routes/bookVisit/cannotBookController.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from 'express'
+import { clearSession } from '../../utils/utils'
 
 export default class CannotBookController {
   public constructor() {}
@@ -6,7 +7,7 @@ export default class CannotBookController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { prisoner } = req.session.bookingJourney
-      delete req.session.bookingJourney
+      clearSession(req)
 
       return res.render('pages/bookVisit/cannotBook', { prisoner })
     }

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -11,6 +11,7 @@ import paths from '../../constants/paths'
 import logger from '../../../logger'
 import { ApplicationValidationErrorResponse } from '../../data/orchestrationApiTypes'
 import { SanitisedError } from '../../sanitisedError'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -23,6 +24,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const visitor = TestData.visitor()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const application = TestData.applicationDto()
 const visitSession = TestData.availableVisitSessionDto()
 const mainContact = {
@@ -38,6 +40,7 @@ beforeEach(() => {
       prison,
       allVisitors: [visitor],
       selectedVisitors: [visitor],
+      sessionRestriction,
       allVisitSessionIds: ['2024-05-30_a'],
       allVisitSessions: [visitSession],
       selectedVisitSession: visitSession,

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -86,7 +86,6 @@ describe('Choose visit time', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
-          allVisitSessions,
         },
       } as SessionData
 

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -5,7 +5,7 @@ import { SessionData } from 'express-session'
 import { FieldValidationError } from 'express-validator'
 import { BadRequest, InternalServerError } from 'http-errors'
 import { FlashData, FlashErrors, appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { createMockVisitService, createMockVisitSessionService } from '../../services/testutils/mocks'
+import { createMockVisitService, createMockVisitSessionsService } from '../../services/testutils/mocks'
 import TestData from '../testutils/testData'
 import { VisitSessionsCalendar } from '../../services/visitSessionsService'
 import paths from '../../constants/paths'
@@ -16,7 +16,7 @@ jest.mock('../../../logger')
 let app: Express
 
 const visitService = createMockVisitService()
-const visitSessionsService = createMockVisitSessionService()
+const visitSessionsService = createMockVisitSessionsService()
 let sessionData: SessionData
 
 const bookerReference = TestData.bookerReference().value

--- a/server/routes/bookVisit/chooseVisitTimeController.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.ts
@@ -39,6 +39,9 @@ export default class ChooseVisitTimeController {
         ? { visitSession: `${selectedVisitSession.sessionDate}_${selectedVisitSession.sessionTemplateReference}` }
         : {}
 
+      const backLinkHref =
+        bookingJourney.sessionRestriction === 'OPEN' ? paths.BOOK_VISIT.SELECT_VISITORS : paths.BOOK_VISIT.CLOSED_VISIT
+
       return res.render('pages/bookVisit/chooseVisitTime', {
         errors: req.flash('errors'),
         formValues,
@@ -46,6 +49,7 @@ export default class ChooseVisitTimeController {
         calendar,
         selectedDate: selectedVisitSession?.sessionDate ?? firstSessionDate,
         prisoner,
+        backLinkHref,
       })
     }
   }

--- a/server/routes/bookVisit/closedVisitController.test.ts
+++ b/server/routes/bookVisit/closedVisitController.test.ts
@@ -6,6 +6,7 @@ import { appWithAllRoutes } from '../testutils/appSetup'
 import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -17,6 +18,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const visitor = TestData.visitor()
+const sessionRestriction: SessionRestriction = 'OPEN'
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -27,7 +29,7 @@ describe('Closed visit', () => {
     beforeEach(() => {
       sessionData = {
         booker: { reference: bookerReference, prisoners: [prisoner] },
-        bookingJourney: { prisoner, prison, allVisitors: [visitor], selectedVisitors: [visitor] },
+        bookingJourney: { prisoner, prison, allVisitors: [visitor], selectedVisitors: [visitor], sessionRestriction },
       } as SessionData
 
       app = appWithAllRoutes({ sessionData })
@@ -62,7 +64,7 @@ describe('Closed visit', () => {
           expect($('[data-test=closed-visit-continue]').attr('href')).toBe(paths.BOOK_VISIT.CHOOSE_TIME)
 
           expect($('[data-test=closed-visit-cancel]').text().trim()).toBe('Cancel and return to the homepage')
-          expect($('[data-test=closed-visit-cancel]').attr('href')).toBe(paths.HOME)
+          expect($('[data-test=closed-visit-cancel]').attr('href')).toBe(paths.RETURN_HOME)
         })
     })
   })

--- a/server/routes/bookVisit/closedVisitController.test.ts
+++ b/server/routes/bookVisit/closedVisitController.test.ts
@@ -1,0 +1,69 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { SessionData } from 'express-session'
+import { appWithAllRoutes } from '../testutils/appSetup'
+import TestData from '../testutils/testData'
+import paths from '../../constants/paths'
+import logger from '../../../logger'
+
+jest.mock('../../../logger')
+
+let app: Express
+
+let sessionData: SessionData
+
+const bookerReference = TestData.bookerReference().value
+const prisoner = TestData.prisoner()
+const prison = TestData.prisonDto()
+const visitor = TestData.visitor()
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Closed visit', () => {
+  describe(`GET ${paths.BOOK_VISIT.CLOSED_VISIT}`, () => {
+    beforeEach(() => {
+      sessionData = {
+        booker: { reference: bookerReference, prisoners: [prisoner] },
+        bookingJourney: { prisoner, prison, allVisitors: [visitor], selectedVisitors: [visitor] },
+      } as SessionData
+
+      app = appWithAllRoutes({ sessionData })
+    })
+
+    it('should use the session validation middleware', () => {
+      sessionData.bookingJourney.prisoner = undefined
+
+      return request(app)
+        .get(paths.BOOK_VISIT.CLOSED_VISIT)
+        .expect(302)
+        .expect('Location', paths.HOME)
+        .expect(res => {
+          expect(logger.info).toHaveBeenCalledWith(expect.stringMatching('Session validation failed'))
+        })
+    })
+
+    it('should render page with closed visit interruption card', () => {
+      return request(app)
+        .get(paths.BOOK_VISIT.CLOSED_VISIT)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^This will be a closed visit -/)
+          expect($('#service-header__nav').length).toBe(0)
+          expect($('[data-test="back-link"]').length).toBe(0)
+
+          expect($('h1[data-test=closed-visit-heading]').text()).toBe('This will be a closed visit')
+          expect($('[data-test=closed-visit-text]').text()).toContain('On a closed visit, ')
+
+          expect($('[data-test=closed-visit-continue]').text().trim()).toBe('Continue to book')
+          expect($('[data-test=closed-visit-continue]').attr('href')).toBe(paths.BOOK_VISIT.CHOOSE_TIME)
+
+          expect($('[data-test=closed-visit-cancel]').text().trim()).toBe('Cancel and return to the homepage')
+          expect($('[data-test=closed-visit-cancel]').attr('href')).toBe(paths.HOME)
+        })
+    })
+  })
+})

--- a/server/routes/bookVisit/closedVisitController.ts
+++ b/server/routes/bookVisit/closedVisitController.ts
@@ -1,0 +1,11 @@
+import type { RequestHandler } from 'express'
+
+export default class ClosedVisitController {
+  public constructor() {}
+
+  public view(): RequestHandler {
+    return async (req, res) => {
+      res.render('pages/bookVisit/closedVisit')
+    }
+  }
+}

--- a/server/routes/bookVisit/index.ts
+++ b/server/routes/bookVisit/index.ts
@@ -13,6 +13,7 @@ import VisitBookedController from './visitBookedController'
 import paths from '../../constants/paths'
 import bookVisitSessionValidator from '../../middleware/bookVisitSessionValidator'
 import CannotBookController from './cannotBookController'
+import ClosedVisitController from './closedVisitController'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -24,7 +25,12 @@ export default function routes(services: Services): Router {
 
   const selectPrisonerController = new SelectPrisonerController()
   const cannotBookController = new CannotBookController()
-  const selectVisitorsController = new SelectVisitorsController(services.bookerService, services.prisonService)
+  const selectVisitorsController = new SelectVisitorsController(
+    services.bookerService,
+    services.prisonService,
+    services.visitSessionsService,
+  )
+  const closedVisitController = new ClosedVisitController()
   const chooseVisitTimeController = new ChooseVisitTimeController(services.visitService, services.visitSessionsService)
   const additionalSupportController = new AdditionalSupportController()
   const mainContactController = new MainContactController(services.visitService)
@@ -43,6 +49,8 @@ export default function routes(services: Services): Router {
     selectVisitorsController.validate(),
     selectVisitorsController.submit(),
   )
+
+  get(paths.BOOK_VISIT.CLOSED_VISIT, closedVisitController.view())
 
   get(paths.BOOK_VISIT.CHOOSE_TIME, chooseVisitTimeController.view())
   postWithValidation(

--- a/server/routes/bookVisit/mainContactController.test.ts
+++ b/server/routes/bookVisit/mainContactController.test.ts
@@ -8,6 +8,7 @@ import TestData from '../testutils/testData'
 import { createMockVisitService } from '../../services/testutils/mocks'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -19,6 +20,7 @@ let sessionData: SessionData
 const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const adultVisitor1 = TestData.visitor({ visitorDisplayId: 1, visitorId: 100 })
 const adultVisitor2 = TestData.visitor({ visitorDisplayId: 2, visitorId: 200 })
 const childVisitor = TestData.visitor({
@@ -37,6 +39,7 @@ beforeEach(() => {
       prison,
       allVisitors: [adultVisitor1, adultVisitor2, childVisitor],
       selectedVisitors: [adultVisitor1, childVisitor],
+      sessionRestriction,
       allVisitSessionIds: ['2024-05-30_a'],
       allVisitSessions: [visitSession],
       selectedVisitSession: visitSession,

--- a/server/routes/bookVisit/selectPrisonerController.ts
+++ b/server/routes/bookVisit/selectPrisonerController.ts
@@ -1,15 +1,14 @@
 import type { RequestHandler } from 'express'
 import { NotFound } from 'http-errors'
 import paths from '../../constants/paths'
+import { clearSession } from '../../utils/utils'
 
 export default class SelectPrisonerController {
   public constructor() {}
 
   public selectPrisoner(): RequestHandler {
     return async (req, res) => {
-      // clear booking journey in session
-      delete req.session.bookingJourney
-      delete req.session.bookingConfirmed
+      clearSession(req)
 
       const prisoner = req.session.booker.prisoners[0]
 

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -4,7 +4,11 @@ import * as cheerio from 'cheerio'
 import { SessionData } from 'express-session'
 import { FieldValidationError } from 'express-validator'
 import { FlashData, FlashErrors, FlashFormValues, appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { createMockBookerService, createMockPrisonService } from '../../services/testutils/mocks'
+import {
+  createMockBookerService,
+  createMockPrisonService,
+  createMockVisitSessionsService,
+} from '../../services/testutils/mocks'
 import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
@@ -15,6 +19,7 @@ let app: Express
 
 const bookerService = createMockBookerService()
 const prisonService = createMockPrisonService()
+const visitSessionsService = createMockVisitSessionsService()
 let sessionData: SessionData
 
 const bookerReference = TestData.bookerReference().value
@@ -266,15 +271,17 @@ describe('Select visitors', () => {
 
   describe(`POST ${paths.BOOK_VISIT.SELECT_VISITORS}`, () => {
     beforeEach(() => {
+      visitSessionsService.getSessionRestriction.mockResolvedValue('OPEN')
+
       sessionData = {
         booker: { reference: bookerReference, prisoners: [prisoner] },
         bookingJourney: { prisoner, prison, allVisitors: visitors },
       } as SessionData
 
-      app = appWithAllRoutes({ sessionData })
+      app = appWithAllRoutes({ services: { visitSessionsService }, sessionData })
     })
 
-    it('should should save selected visitors to session and redirect to select date and time page', () => {
+    it('should should save selected visitors to session and redirect to select date and time page (OPEN visit)', () => {
       return request(app)
         .post(paths.BOOK_VISIT.SELECT_VISITORS)
         .send({ visitorDisplayIds: [1, 3] })
@@ -294,6 +301,39 @@ describe('Select visitors', () => {
               selectedVisitors: [visitor1, visitor3],
             },
           } as SessionData)
+          expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
+            prisonerId: prisoner.prisonerNumber,
+            visitorIds: [visitor1.visitorId, visitor3.visitorId],
+          })
+        })
+    })
+
+    it('should should save selected visitors to session and redirect to closed visit page (CLOSED visit)', () => {
+      visitSessionsService.getSessionRestriction.mockResolvedValue('CLOSED')
+
+      return request(app)
+        .post(paths.BOOK_VISIT.SELECT_VISITORS)
+        .send({ visitorDisplayIds: [1, 3] })
+        .expect(302)
+        .expect('Location', paths.BOOK_VISIT.CLOSED_VISIT)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalled()
+          expect(sessionData).toStrictEqual({
+            booker: {
+              reference: bookerReference,
+              prisoners: [prisoner],
+            },
+            bookingJourney: {
+              prisoner,
+              prison,
+              allVisitors: visitors,
+              selectedVisitors: [visitor1, visitor3],
+            },
+          } as SessionData)
+          expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
+            prisonerId: prisoner.prisonerNumber,
+            visitorIds: [visitor1.visitorId, visitor3.visitorId],
+          })
         })
     })
 
@@ -317,6 +357,10 @@ describe('Select visitors', () => {
               selectedVisitors: [visitors[0], visitors[2]], // duplicate '1' & invalid ID '999' filtered out
             },
           } as SessionData)
+          expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
+            prisonerId: prisoner.prisonerNumber,
+            visitorIds: [visitor1.visitorId, visitor3.visitorId],
+          })
         })
     })
 

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -299,6 +299,7 @@ describe('Select visitors', () => {
               prison,
               allVisitors: visitors,
               selectedVisitors: [visitor1, visitor3],
+              sessionRestriction: 'OPEN',
             },
           } as SessionData)
           expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
@@ -328,6 +329,7 @@ describe('Select visitors', () => {
               prison,
               allVisitors: visitors,
               selectedVisitors: [visitor1, visitor3],
+              sessionRestriction: 'CLOSED',
             },
           } as SessionData)
           expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
@@ -355,6 +357,7 @@ describe('Select visitors', () => {
               prison,
               allVisitors: visitors,
               selectedVisitors: [visitors[0], visitors[2]], // duplicate '1' & invalid ID '999' filtered out
+              sessionRestriction: 'OPEN',
             },
           } as SessionData)
           expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -63,6 +63,7 @@ export default class SelectVisitorsController {
         prisonerId: bookingJourney.prisoner.prisonerNumber,
         visitorIds: selectedVisitors.map(visitor => visitor.visitorId),
       })
+      bookingJourney.sessionRestriction = sessionRestriction
 
       return res.redirect(sessionRestriction === 'OPEN' ? paths.BOOK_VISIT.CHOOSE_TIME : paths.BOOK_VISIT.CLOSED_VISIT)
     }

--- a/server/routes/bookings/index.ts
+++ b/server/routes/bookings/index.ts
@@ -10,16 +10,15 @@ export default function routes(services: Services): Router {
   const router = Router()
 
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  // const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
   const getWithValidation = (path: string | string[], validationChain: ValidationChain[], handler: RequestHandler) =>
     router.get(path, ...validationChain, asyncMiddleware(handler))
 
-  const bookings = new BookingsController(services.visitService)
+  const bookingsController = new BookingsController(services.visitService)
   const bookingDetailsController = new BookingDetailsController(services.bookerService)
 
-  get(paths.BOOKINGS.PAST, bookings.viewPast())
-  get(paths.BOOKINGS.CANCELLED, bookings.viewCancelled())
-  get(paths.BOOKINGS.HOME, bookings.viewFuture())
+  get(paths.BOOKINGS.PAST, bookingsController.viewPast())
+  get(paths.BOOKINGS.CANCELLED, bookingsController.viewCancelled())
+  get(paths.BOOKINGS.HOME, bookingsController.viewFuture())
 
   getWithValidation(
     `${paths.BOOKINGS.VISIT}/:visitNumber`,

--- a/server/routes/homeController.test.ts
+++ b/server/routes/homeController.test.ts
@@ -6,6 +6,7 @@ import { appWithAllRoutes } from './testutils/appSetup'
 import { createMockBookerService } from '../services/testutils/mocks'
 import TestData from './testutils/testData'
 import paths from '../constants/paths'
+import * as utils from '../utils/utils'
 
 let app: Express
 
@@ -76,6 +77,20 @@ describe('Home page', () => {
             prisoners: [],
           },
         } as SessionData)
+      })
+  })
+})
+
+describe('Return to Home page redirect', () => {
+  it('should call clearSession() and redirect to home', () => {
+    const clearSession = jest.spyOn(utils, 'clearSession')
+
+    return request(app)
+      .get(paths.RETURN_HOME)
+      .expect(302)
+      .expect('Location', paths.HOME)
+      .expect(() => {
+        expect(clearSession).toHaveBeenCalled()
       })
   })
 })

--- a/server/routes/homeController.ts
+++ b/server/routes/homeController.ts
@@ -1,5 +1,7 @@
 import type { RequestHandler } from 'express'
 import { BookerService } from '../services'
+import paths from '../constants/paths'
+import { clearSession } from '../utils/utils'
 
 export default class HomeController {
   public constructor(private readonly bookerService: BookerService) {}
@@ -11,6 +13,13 @@ export default class HomeController {
       booker.prisoners = prisoners
 
       res.render('pages/home', { prisoners: booker.prisoners, showServiceNav: true })
+    }
+  }
+
+  public returnHome(): RequestHandler {
+    return async (req, res) => {
+      clearSession(req)
+      res.redirect(paths.HOME)
     }
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -13,17 +13,14 @@ export default function routes(services: Services): Router {
 
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  const home = new HomeController(services.bookerService)
+  const homeController = new HomeController(services.bookerService)
+  const accessDeniedController = new AccessDeniedController()
+
+  get(paths.HOME, homeController.view())
+  get(paths.ACCESS_DENIED, accessDeniedController.view())
 
   router.use(bookingsRoutes(services))
-
-  const accessDenied = new AccessDeniedController()
-
-  get(paths.HOME, home.view())
-
   router.use(bookingJourneyRoutes(services))
-
-  router.get(paths.ACCESS_DENIED, accessDenied.view())
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -17,6 +17,7 @@ export default function routes(services: Services): Router {
   const accessDeniedController = new AccessDeniedController()
 
   get(paths.HOME, homeController.view())
+  get(paths.RETURN_HOME, homeController.returnHome())
   get(paths.ACCESS_DENIED, accessDeniedController.view())
 
   router.use(bookingsRoutes(services))

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -27,5 +27,5 @@ export const createMockPrisonService = () => new PrisonService(null, null) as je
 
 export const createMockVisitService = () => new VisitService(null, null) as jest.Mocked<VisitService>
 
-export const createMockVisitSessionService = () =>
+export const createMockVisitSessionsService = () =>
   new VisitSessionsService(null, null) as jest.Mocked<VisitSessionsService>

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -2,6 +2,7 @@ import TestData from '../routes/testutils/testData'
 import { createMockHmppsAuthClient, createMockOrchestrationApiClient } from '../data/testutils/mocks'
 import VisitSessionsService, { VisitSessionsCalendar } from './visitSessionsService'
 import { AvailableVisitSessionDto } from '../data/orchestrationApiTypes'
+import { SessionRestriction } from '../data/orchestrationApiClient'
 
 const token = 'some token'
 const bookerReference = TestData.bookerReference().value
@@ -162,6 +163,27 @@ describe('Visit sessions service', () => {
         bookerReference,
         excludedApplicationReference,
       })
+    })
+  })
+
+  describe('getSessionRestriction', () => {
+    it('should get session restriction for prisoner and visitors', async () => {
+      const sessionRestriction: SessionRestriction = 'OPEN'
+      orchestrationApiClient.getSessionRestriction.mockResolvedValue(sessionRestriction)
+
+      const { prisoner } = TestData.bookerPrisonerInfoDto()
+      const visitorIds = [1, 2]
+
+      const result = await visitSessionsService.getSessionRestriction({
+        prisonerId: prisoner.prisonerNumber,
+        visitorIds,
+      })
+
+      expect(orchestrationApiClient.getSessionRestriction).toHaveBeenCalledWith({
+        prisonerId: prisoner.prisonerNumber,
+        visitorIds,
+      })
+      expect(result).toBe(sessionRestriction)
     })
   })
 })

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -3,8 +3,6 @@ import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../d
 import { AvailableVisitSessionDto } from '../data/orchestrationApiTypes'
 import { DateFormats } from '../constants/dateFormats'
 
-export type SessionRestriction = AvailableVisitSessionDto['sessionRestriction']
-
 type VisitSession = { reference: string; startTime: string; endTime: string }
 
 // Keyed by month (yyyy-MM); all dates for each month(s), sessions for each day (keyed yyyy-MM-dd)

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -2,6 +2,7 @@ import { addDays, eachDayOfInterval, format } from 'date-fns'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
 import { AvailableVisitSessionDto } from '../data/orchestrationApiTypes'
 import { DateFormats } from '../constants/dateFormats'
+import { SessionRestriction } from '../data/orchestrationApiClient'
 
 type VisitSession = { reference: string; startTime: string; endTime: string }
 
@@ -102,5 +103,18 @@ export default class VisitSessionsService {
       bookerReference,
       excludedApplicationReference,
     })
+  }
+
+  async getSessionRestriction({
+    prisonerId,
+    visitorIds,
+  }: {
+    prisonerId: string
+    visitorIds: number[]
+  }): Promise<SessionRestriction> {
+    const token = await this.hmppsAuthClient.getSystemClientToken()
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+
+    return orchestrationApiClient.getSessionRestriction({ prisonerId, visitorIds })
   }
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,7 @@
+import { Request } from 'express'
+import { SessionData } from 'express-session'
 import {
+  clearSession,
   convertToTitleCase,
   formatDate,
   formatTime,
@@ -113,6 +116,21 @@ describe('pluralise', () => {
     })
     it('Is a child - on given date', () => {
       expect(isAdult('2000-01-02', new Date('2018-01-01'))).toEqual(false)
+    })
+  })
+
+  describe('Clear session data', () => {
+    it('should clear booking journey from the session', () => {
+      const sessionData: Partial<Record<keyof SessionData, string>> = {
+        booker: 'BOOKER DATA',
+        bookingJourney: 'BOOKING JOURNEY DATA',
+        bookingConfirmed: 'BOOKING CONFIRMATION DATA',
+      }
+      const req = { session: sessionData } as unknown as Request
+
+      clearSession(req)
+
+      expect(sessionData).toStrictEqual({ booker: 'BOOKER DATA' })
     })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,6 @@
+import { Request } from 'express'
 import { differenceInYears, format, formatDuration, intervalToDuration, parse, parseISO } from 'date-fns'
+import { SessionData } from 'express-session'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -71,4 +73,10 @@ export const pluralise = (word: string, count: string | number, plural = `${word
 export const isAdult = (dateOfBirth: string, referenceDate: Date = new Date()): boolean => {
   const dobDate = parseISO(dateOfBirth)
   return differenceInYears(referenceDate, dobDate) >= 18
+}
+
+export const clearSession = (req: Request): void => {
+  ;['bookingJourney', 'bookingConfirmed'].forEach((sessionItem: keyof SessionData) => {
+    delete req.session[sessionItem]
+  })
 }

--- a/server/views/components/interruptionCard/interruptionCard.njk
+++ b/server/views/components/interruptionCard/interruptionCard.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% macro interruptionCard(params) %}
+  <div class="interruption-card" data-test="{{ params.id }}">
+    <h1 class="govuk-heading-l interruption-card__heading" data-test="{{ params.id }}-heading">
+      {{- params.heading -}}
+    </h1>
+
+    <p class="govuk-body-l interruption-card__text" data-test="{{ params.id }}-text">
+      {{- params.text -}}
+    </p>
+
+    {{ govukButton({
+      text: params.continueButton.text,
+      classes: "govuk-button--secondary",
+      href: params.continueButton.href,
+      preventDoubleClick: true,
+      attributes: {
+        "data-test": params.id + "-continue"
+      }
+    }) }}
+
+    <p>
+      <a class="govuk-link--inverse" data-test="{{ params.id }}-cancel" href="{{ params.cancelLink.href }}">
+        {{- params.cancelLink.text -}}
+      </a>
+    </p>
+  </div>
+{% endmacro %}

--- a/server/views/pages/bookVisit/chooseVisitTime.njk
+++ b/server/views/pages/bookVisit/chooseVisitTime.njk
@@ -6,8 +6,6 @@
 
 {% set pageTitle = "Choose the visit time" %}
 
-{% set backLinkHref = paths.BOOK_VISIT.SELECT_VISITORS %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/server/views/pages/bookVisit/closedVisit.njk
+++ b/server/views/pages/bookVisit/closedVisit.njk
@@ -1,0 +1,26 @@
+{% extends "../../partials/layout.njk" %}
+{% from "components/interruptionCard/interruptionCard.njk" import interruptionCard %}
+
+{% set pageTitle = "This will be a closed visit" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      {{ interruptionCard({
+        id: "closed-visit",
+        heading: pageTitle,
+        text: "On a closed visit, the prisoner and visitors cannot have physical contact or pass any items.",
+        continueButton: {
+          text: "Continue to book",
+          href: paths.BOOK_VISIT.CHOOSE_TIME
+        },
+        cancelLink: {
+          text: "Cancel and return to the homepage",
+          href: paths.HOME
+        }
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/bookVisit/closedVisit.njk
+++ b/server/views/pages/bookVisit/closedVisit.njk
@@ -17,7 +17,7 @@
         },
         cancelLink: {
           text: "Cancel and return to the homepage",
-          href: paths.HOME
+          href: paths.RETURN_HOME
         }
       }) }}
 


### PR DESCRIPTION
* After selecting visitors, call new API endpoint  to determine if visit will be `OPEN /  CLOSED`
* If `CLOSED`, go to new `/book-visit/closed-visit` page with new 'interruption card' component that explains what a closed visit is, with the options to Continue or Cancel

(New `interruptionCard` component added as a reusable macro because other uses are coming soon.)