### PR TITLE
VB-4415 Choose visit time page - update back link for CLOSED visit

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -1,3 +1,4 @@
+import { SessionRestriction } from '../data/orchestrationApiClient'
 import { AvailableVisitSessionDto, PrisonDto } from '../data/orchestrationApiTypes'
 import { Prisoner, Visitor } from '../services/bookerService'
 
@@ -19,6 +20,9 @@ export type BookingJourney = {
 
   // selected visitors for this visit
   selectedVisitors?: Visitor[]
+
+  // session restriction (OPEN/CLOSED) for this visit
+  sessionRestriction?: SessionRestriction
 
   // all available visit sessions
   allVisitSessionIds?: string[] // e.g. ['2024-05-28_session-ref']

--- a/server/middleware/bookVisitSessionValidator.test.ts
+++ b/server/middleware/bookVisitSessionValidator.test.ts
@@ -5,6 +5,7 @@ import bookVisitSessionValidator from './bookVisitSessionValidator'
 import paths from '../constants/paths'
 import { Booker, BookingConfirmed, BookingJourney } from '../@types/bapv'
 import logger from '../../logger'
+import { SessionRestriction } from '../data/orchestrationApiClient'
 
 jest.mock('../../logger')
 
@@ -18,6 +19,7 @@ describe('bookVisitSessionValidator', () => {
   const bookerReference = TestData.bookerReference().value
   const prisoner = TestData.prisoner()
   const visitor = TestData.visitor()
+  const sessionRestriction: SessionRestriction = 'OPEN'
   const visitSessionId = '2024-05-30_a'
   const visitSession = TestData.availableVisitSessionDto()
   const applicationReference = 'aaa-bbb-ccc'
@@ -128,7 +130,7 @@ describe('bookVisitSessionValidator', () => {
         })
       })
 
-      describe('...add selectedVisitors', () => {
+      describe('...add selectedVisitors and sessionRestriction', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
@@ -146,6 +148,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
             },
           })
           bookVisitSessionValidator()(req, res, next)
@@ -172,6 +175,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
             },
@@ -202,6 +206,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
               selectedVisitSession: visitSession,
@@ -236,6 +241,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
               selectedVisitSession: visitSession,
@@ -272,6 +278,7 @@ describe('bookVisitSessionValidator', () => {
               prison: TestData.prisonDto(),
               allVisitors: [visitor],
               selectedVisitors: [visitor],
+              sessionRestriction,
               allVisitSessionIds: [visitSessionId],
               allVisitSessions: [visitSession],
               selectedVisitSession: visitSession,

--- a/server/middleware/bookVisitSessionValidator.ts
+++ b/server/middleware/bookVisitSessionValidator.ts
@@ -56,7 +56,10 @@ export default function bookVisitSessionValidator(): RequestHandler {
     if (
       (journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CLOSED_VISIT) ||
         journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CHOOSE_TIME)) &&
-      (!bookingJourney.prison || !bookingJourney.allVisitors?.length || !bookingJourney.selectedVisitors?.length)
+      (!bookingJourney.prison ||
+        !bookingJourney.allVisitors?.length ||
+        !bookingJourney.selectedVisitors?.length ||
+        !bookingJourney.sessionRestriction)
     ) {
       return logAndRedirect(res, method, requestPath, booker.reference)
     }

--- a/server/routes/bookVisit/additionalSupportController.test.ts
+++ b/server/routes/bookVisit/additionalSupportController.test.ts
@@ -8,6 +8,7 @@ import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
 import config from '../../config'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -19,6 +20,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const visitor = TestData.visitor()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const visitSession = TestData.availableVisitSessionDto()
 
 afterEach(() => {
@@ -40,6 +42,7 @@ describe('Additional support needs', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
+          sessionRestriction,
           allVisitSessionIds: ['2024-05-30_a'],
           allVisitSessions: [visitSession],
           selectedVisitSession: visitSession,
@@ -189,6 +192,7 @@ describe('Additional support needs', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
+          sessionRestriction,
           allVisitSessionIds: ['2024-05-30_a'],
           allVisitSessions: [visitSession],
           selectedVisitSession: visitSession,

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -11,6 +11,7 @@ import paths from '../../constants/paths'
 import logger from '../../../logger'
 import { ApplicationValidationErrorResponse } from '../../data/orchestrationApiTypes'
 import { SanitisedError } from '../../sanitisedError'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -23,6 +24,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const visitor = TestData.visitor()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const application = TestData.applicationDto()
 const visitSession = TestData.availableVisitSessionDto()
 const mainContact = {
@@ -38,6 +40,7 @@ beforeEach(() => {
       prison,
       allVisitors: [visitor],
       selectedVisitors: [visitor],
+      sessionRestriction,
       allVisitSessionIds: ['2024-05-30_a'],
       allVisitSessions: [visitSession],
       selectedVisitSession: visitSession,

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -175,6 +175,21 @@ describe('Choose visit time', () => {
         })
     })
 
+    it('should have back link to closed visit page if sessionRestriction is CLOSED', () => {
+      sessionData.bookingJourney.sessionRestriction = 'CLOSED'
+
+      return request(app)
+        .get(paths.BOOK_VISIT.CHOOSE_TIME)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Choose the visit time -/)
+          expect($('#service-header__nav').length).toBe(0)
+          expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOK_VISIT.CLOSED_VISIT)
+          expect($('h1').text()).toBe('Choose the visit time')
+        })
+    })
+
     it('should render info message if set in flash', () => {
       const message = 'Your visit time is no longer available. Select a new time.'
       flashData = { message: [message] }

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -10,6 +10,7 @@ import TestData from '../testutils/testData'
 import { VisitSessionsCalendar } from '../../services/visitSessionsService'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -23,6 +24,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto({ policyNoticeDaysMax: 6 }) // small booking window for testing
 const visitor = TestData.visitorInfoDto()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const firstSessionDate = '2024-05-30'
 const calendar: VisitSessionsCalendar = {
   '2024-05': {
@@ -86,6 +88,7 @@ describe('Choose visit time', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
+          sessionRestriction,
         },
       } as SessionData
 
@@ -271,6 +274,7 @@ describe('Choose visit time', () => {
           prison,
           allVisitors: [visitor],
           selectedVisitors: [visitor],
+          sessionRestriction,
           allVisitSessionIds,
           allVisitSessions,
         },

--- a/server/routes/bookVisit/chooseVisitTimeController.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.ts
@@ -39,6 +39,9 @@ export default class ChooseVisitTimeController {
         ? { visitSession: `${selectedVisitSession.sessionDate}_${selectedVisitSession.sessionTemplateReference}` }
         : {}
 
+      const backLinkHref =
+        bookingJourney.sessionRestriction === 'OPEN' ? paths.BOOK_VISIT.SELECT_VISITORS : paths.BOOK_VISIT.CLOSED_VISIT
+
       return res.render('pages/bookVisit/chooseVisitTime', {
         errors: req.flash('errors'),
         formValues,
@@ -46,6 +49,7 @@ export default class ChooseVisitTimeController {
         calendar,
         selectedDate: selectedVisitSession?.sessionDate ?? firstSessionDate,
         prisoner,
+        backLinkHref,
       })
     }
   }

--- a/server/routes/bookVisit/closedVisitController.test.ts
+++ b/server/routes/bookVisit/closedVisitController.test.ts
@@ -6,6 +6,7 @@ import { appWithAllRoutes } from '../testutils/appSetup'
 import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -17,6 +18,7 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const visitor = TestData.visitor()
+const sessionRestriction: SessionRestriction = 'OPEN'
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -27,7 +29,7 @@ describe('Closed visit', () => {
     beforeEach(() => {
       sessionData = {
         booker: { reference: bookerReference, prisoners: [prisoner] },
-        bookingJourney: { prisoner, prison, allVisitors: [visitor], selectedVisitors: [visitor] },
+        bookingJourney: { prisoner, prison, allVisitors: [visitor], selectedVisitors: [visitor], sessionRestriction },
       } as SessionData
 
       app = appWithAllRoutes({ sessionData })

--- a/server/routes/bookVisit/mainContactController.test.ts
+++ b/server/routes/bookVisit/mainContactController.test.ts
@@ -8,6 +8,7 @@ import TestData from '../testutils/testData'
 import { createMockVisitService } from '../../services/testutils/mocks'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
+import { SessionRestriction } from '../../data/orchestrationApiClient'
 
 jest.mock('../../../logger')
 
@@ -19,6 +20,7 @@ let sessionData: SessionData
 const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
+const sessionRestriction: SessionRestriction = 'OPEN'
 const adultVisitor1 = TestData.visitor({ visitorDisplayId: 1, visitorId: 100 })
 const adultVisitor2 = TestData.visitor({ visitorDisplayId: 2, visitorId: 200 })
 const childVisitor = TestData.visitor({
@@ -37,6 +39,7 @@ beforeEach(() => {
       prison,
       allVisitors: [adultVisitor1, adultVisitor2, childVisitor],
       selectedVisitors: [adultVisitor1, childVisitor],
+      sessionRestriction,
       allVisitSessionIds: ['2024-05-30_a'],
       allVisitSessions: [visitSession],
       selectedVisitSession: visitSession,

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -299,6 +299,7 @@ describe('Select visitors', () => {
               prison,
               allVisitors: visitors,
               selectedVisitors: [visitor1, visitor3],
+              sessionRestriction: 'OPEN',
             },
           } as SessionData)
           expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
@@ -328,6 +329,7 @@ describe('Select visitors', () => {
               prison,
               allVisitors: visitors,
               selectedVisitors: [visitor1, visitor3],
+              sessionRestriction: 'CLOSED',
             },
           } as SessionData)
           expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({
@@ -355,6 +357,7 @@ describe('Select visitors', () => {
               prison,
               allVisitors: visitors,
               selectedVisitors: [visitors[0], visitors[2]], // duplicate '1' & invalid ID '999' filtered out
+              sessionRestriction: 'OPEN',
             },
           } as SessionData)
           expect(visitSessionsService.getSessionRestriction).toHaveBeenCalledWith({

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -63,6 +63,7 @@ export default class SelectVisitorsController {
         prisonerId: bookingJourney.prisoner.prisonerNumber,
         visitorIds: selectedVisitors.map(visitor => visitor.visitorId),
       })
+      bookingJourney.sessionRestriction = sessionRestriction
 
       return res.redirect(sessionRestriction === 'OPEN' ? paths.BOOK_VISIT.CHOOSE_TIME : paths.BOOK_VISIT.CLOSED_VISIT)
     }

--- a/server/views/pages/bookVisit/chooseVisitTime.njk
+++ b/server/views/pages/bookVisit/chooseVisitTime.njk
@@ -6,8 +6,6 @@
 
 {% set pageTitle = "Choose the visit time" %}
 
-{% set backLinkHref = paths.BOOK_VISIT.SELECT_VISITORS %}
-
 {% block content %}
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
If the visit booking is going to be `CLOSED`, make the Back link on Choose visit time page go back to the closed visit interruption card page. For `OPEN` go back to Select visitors page.