### PR TITLE
VB-4504 Update handling of Visitors to incorporate visitorRestrictions

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -15,8 +15,8 @@ export type BookingJourney = {
   // prison for this visit
   prison?: PrisonDto
 
-  // all possible visitors for this visit
-  allVisitors?: Visitor[]
+  // all eligible visitors for this visit
+  eligibleVisitors?: Visitor[]
 
   // selected visitors for this visit
   selectedVisitors?: Visitor[]

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -1174,29 +1174,29 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject'][]
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject'][]
-      /** Format: int32 */
-      pageSize?: number
+      unpaged?: boolean
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
     }
     SortObject: {
       direction?: string
@@ -1624,6 +1624,23 @@ export interface components {
        * @example 2000-01-31
        */
       dateOfBirth?: string
+      /** @description Relevant visitor restrictions that impact visits or empty list if none */
+      visitorRestrictions: components['schemas']['VisitorRestrictionDto'][]
+    }
+    /** @description Visitor restriction */
+    VisitorRestrictionDto: {
+      /**
+       * @description Restriction Type
+       * @example BAN
+       * @enum {string}
+       */
+      restrictionType: 'BAN'
+      /**
+       * Format: date
+       * @description Restriction Expiry
+       * @example 2029-12-31
+       */
+      expiryDate?: string
     }
     /** @description AlertDto returned from orchestration, made of fields from AlertResponseDto from Alerts API call */
     AlertDto: {

--- a/server/middleware/bookVisitSessionValidator.test.ts
+++ b/server/middleware/bookVisitSessionValidator.test.ts
@@ -111,7 +111,7 @@ describe('bookVisitSessionValidator', () => {
         })
       })
 
-      describe('...add prison and allVisitors', () => {
+      describe('...add prison and eligibleVisitors', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
@@ -123,7 +123,7 @@ describe('bookVisitSessionValidator', () => {
           req = createMockReq({
             method,
             path,
-            bookingJourney: { prisoner, prison: TestData.prisonDto(), allVisitors: [visitor] },
+            bookingJourney: { prisoner, prison: TestData.prisonDto(), eligibleVisitors: [visitor] },
           })
           bookVisitSessionValidator()(req, res, next)
           runAssertions(expected)
@@ -146,7 +146,7 @@ describe('bookVisitSessionValidator', () => {
             bookingJourney: {
               prisoner,
               prison: TestData.prisonDto(),
-              allVisitors: [visitor],
+              eligibleVisitors: [visitor],
               selectedVisitors: [visitor],
               sessionRestriction,
             },
@@ -173,7 +173,7 @@ describe('bookVisitSessionValidator', () => {
             bookingJourney: {
               prisoner,
               prison: TestData.prisonDto(),
-              allVisitors: [visitor],
+              eligibleVisitors: [visitor],
               selectedVisitors: [visitor],
               sessionRestriction,
               allVisitSessionIds: [visitSessionId],
@@ -204,7 +204,7 @@ describe('bookVisitSessionValidator', () => {
             bookingJourney: {
               prisoner,
               prison: TestData.prisonDto(),
-              allVisitors: [visitor],
+              eligibleVisitors: [visitor],
               selectedVisitors: [visitor],
               sessionRestriction,
               allVisitSessionIds: [visitSessionId],
@@ -239,7 +239,7 @@ describe('bookVisitSessionValidator', () => {
             bookingJourney: {
               prisoner,
               prison: TestData.prisonDto(),
-              allVisitors: [visitor],
+              eligibleVisitors: [visitor],
               selectedVisitors: [visitor],
               sessionRestriction,
               allVisitSessionIds: [visitSessionId],
@@ -276,7 +276,7 @@ describe('bookVisitSessionValidator', () => {
             bookingJourney: {
               prisoner,
               prison: TestData.prisonDto(),
-              allVisitors: [visitor],
+              eligibleVisitors: [visitor],
               selectedVisitors: [visitor],
               sessionRestriction,
               allVisitSessionIds: [visitSessionId],

--- a/server/middleware/bookVisitSessionValidator.ts
+++ b/server/middleware/bookVisitSessionValidator.ts
@@ -47,7 +47,7 @@ export default function bookVisitSessionValidator(): RequestHandler {
     if (
       journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.SELECT_VISITORS) &&
       method === 'POST' &&
-      (!bookingJourney.prison || !bookingJourney.allVisitors?.length)
+      (!bookingJourney.prison || !bookingJourney.eligibleVisitors?.length)
     ) {
       return logAndRedirect(res, method, requestPath, booker.reference)
     }
@@ -57,7 +57,7 @@ export default function bookVisitSessionValidator(): RequestHandler {
       (journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CLOSED_VISIT) ||
         journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CHOOSE_TIME)) &&
       (!bookingJourney.prison ||
-        !bookingJourney.allVisitors?.length ||
+        !bookingJourney.eligibleVisitors?.length ||
         !bookingJourney.selectedVisitors?.length ||
         !bookingJourney.sessionRestriction)
     ) {

--- a/server/routes/bookVisit/additionalSupportController.test.ts
+++ b/server/routes/bookVisit/additionalSupportController.test.ts
@@ -40,7 +40,7 @@ describe('Additional support needs', () => {
         bookingJourney: {
           prisoner,
           prison,
-          allVisitors: [visitor],
+          eligibleVisitors: [visitor],
           selectedVisitors: [visitor],
           sessionRestriction,
           allVisitSessionIds: ['2024-05-30_a'],
@@ -190,7 +190,7 @@ describe('Additional support needs', () => {
         bookingJourney: {
           prisoner,
           prison,
-          allVisitors: [visitor],
+          eligibleVisitors: [visitor],
           selectedVisitors: [visitor],
           sessionRestriction,
           allVisitSessionIds: ['2024-05-30_a'],

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
     bookingJourney: {
       prisoner,
       prison,
-      allVisitors: [visitor],
+      eligibleVisitors: [visitor],
       selectedVisitors: [visitor],
       sessionRestriction,
       allVisitSessionIds: ['2024-05-30_a'],

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -23,7 +23,7 @@ let sessionData: SessionData
 const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto({ policyNoticeDaysMax: 6 }) // small booking window for testing
-const visitor = TestData.visitorInfoDto()
+const visitor = TestData.visitor()
 const sessionRestriction: SessionRestriction = 'OPEN'
 const firstSessionDate = '2024-05-30'
 const calendar: VisitSessionsCalendar = {

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -86,7 +86,7 @@ describe('Choose visit time', () => {
         bookingJourney: {
           prisoner,
           prison,
-          allVisitors: [visitor],
+          eligibleVisitors: [visitor],
           selectedVisitors: [visitor],
           sessionRestriction,
         },
@@ -287,7 +287,7 @@ describe('Choose visit time', () => {
         bookingJourney: {
           prisoner,
           prison,
-          allVisitors: [visitor],
+          eligibleVisitors: [visitor],
           selectedVisitors: [visitor],
           sessionRestriction,
           allVisitSessionIds,

--- a/server/routes/bookVisit/closedVisitController.test.ts
+++ b/server/routes/bookVisit/closedVisitController.test.ts
@@ -29,7 +29,13 @@ describe('Closed visit', () => {
     beforeEach(() => {
       sessionData = {
         booker: { reference: bookerReference, prisoners: [prisoner] },
-        bookingJourney: { prisoner, prison, allVisitors: [visitor], selectedVisitors: [visitor], sessionRestriction },
+        bookingJourney: {
+          prisoner,
+          prison,
+          eligibleVisitors: [visitor],
+          selectedVisitors: [visitor],
+          sessionRestriction,
+        },
       } as SessionData
 
       app = appWithAllRoutes({ sessionData })

--- a/server/routes/bookVisit/mainContactController.test.ts
+++ b/server/routes/bookVisit/mainContactController.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
     bookingJourney: {
       prisoner,
       prison,
-      allVisitors: [adultVisitor1, adultVisitor2, childVisitor],
+      eligibleVisitors: [adultVisitor1, adultVisitor2, childVisitor],
       selectedVisitors: [adultVisitor1, childVisitor],
       sessionRestriction,
       allVisitSessionIds: ['2024-05-30_a'],

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -169,7 +169,7 @@ describe('Select visitors', () => {
             bookingJourney: {
               prisoner,
               prison,
-              allVisitors: visitors,
+              eligibleVisitors: visitors,
             },
           } as SessionData)
         })
@@ -262,7 +262,7 @@ describe('Select visitors', () => {
             bookingJourney: {
               prisoner,
               prison,
-              allVisitors: [],
+              eligibleVisitors: [],
             },
           } as SessionData)
         })
@@ -275,7 +275,7 @@ describe('Select visitors', () => {
 
       sessionData = {
         booker: { reference: bookerReference, prisoners: [prisoner] },
-        bookingJourney: { prisoner, prison, allVisitors: visitors },
+        bookingJourney: { prisoner, prison, eligibleVisitors: visitors },
       } as SessionData
 
       app = appWithAllRoutes({ services: { visitSessionsService }, sessionData })
@@ -297,7 +297,7 @@ describe('Select visitors', () => {
             bookingJourney: {
               prisoner,
               prison,
-              allVisitors: visitors,
+              eligibleVisitors: visitors,
               selectedVisitors: [visitor1, visitor3],
               sessionRestriction: 'OPEN',
             },
@@ -327,7 +327,7 @@ describe('Select visitors', () => {
             bookingJourney: {
               prisoner,
               prison,
-              allVisitors: visitors,
+              eligibleVisitors: visitors,
               selectedVisitors: [visitor1, visitor3],
               sessionRestriction: 'CLOSED',
             },
@@ -355,7 +355,7 @@ describe('Select visitors', () => {
             bookingJourney: {
               prisoner,
               prison,
-              allVisitors: visitors,
+              eligibleVisitors: visitors,
               selectedVisitors: [visitors[0], visitors[2]], // duplicate '1' & invalid ID '999' filtered out
               sessionRestriction: 'OPEN',
             },

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -100,7 +100,7 @@ describe('Select visitors', () => {
     let flashData: FlashData
 
     beforeEach(() => {
-      bookerService.getVisitors.mockResolvedValue(visitors)
+      bookerService.getEligibleVisitors.mockResolvedValue(visitors)
       prisonService.getPrison.mockResolvedValue(prison)
 
       flashData = {}
@@ -158,7 +158,7 @@ describe('Select visitors', () => {
 
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 
-          expect(bookerService.getVisitors).toHaveBeenCalledWith(bookerReference, prisoner.prisonerNumber)
+          expect(bookerService.getEligibleVisitors).toHaveBeenCalledWith(bookerReference, prisoner.prisonerNumber)
           expect(prisonService.getPrison).toHaveBeenCalledWith(prisoner.prisonId)
 
           expect(sessionData).toStrictEqual({
@@ -231,7 +231,7 @@ describe('Select visitors', () => {
     })
 
     it('should handle booker having no visitors for this prisoner', () => {
-      bookerService.getVisitors.mockResolvedValue([])
+      bookerService.getEligibleVisitors.mockResolvedValue([])
 
       return request(app)
         .get(paths.BOOK_VISIT.SELECT_VISITORS)
@@ -251,7 +251,7 @@ describe('Select visitors', () => {
 
           expect($('[data-test="continue-button"]').length).toBe(0)
 
-          expect(bookerService.getVisitors).toHaveBeenCalledWith(bookerReference, prisoner.prisonerNumber)
+          expect(bookerService.getEligibleVisitors).toHaveBeenCalledWith(bookerReference, prisoner.prisonerNumber)
           expect(prisonService.getPrison).toHaveBeenCalledWith(prisoner.prisonId)
 
           expect(sessionData).toStrictEqual({

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -19,7 +19,7 @@ export default class SelectVisitorsController {
       if (!bookingJourney.prison) {
         ;[bookingJourney.prison, bookingJourney.allVisitors] = await Promise.all([
           this.prisonService.getPrison(bookingJourney.prisoner.prisonId),
-          this.bookerService.getVisitors(booker.reference, booker.prisoners[0].prisonerNumber),
+          this.bookerService.getEligibleVisitors(booker.reference, booker.prisoners[0].prisonerNumber),
         ])
       }
 

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -178,7 +178,14 @@ export default class TestData {
     firstName = 'Joan',
     lastName = 'Phillips',
     dateOfBirth = '1980-02-21',
-  }: Partial<VisitorInfoDto> = {}): VisitorInfoDto => ({ visitorId, firstName, lastName, dateOfBirth })
+    visitorRestrictions = [],
+  }: Partial<VisitorInfoDto> = {}): VisitorInfoDto => ({
+    visitorId,
+    firstName,
+    lastName,
+    dateOfBirth,
+    visitorRestrictions,
+  })
 
   static visitor = ({
     visitorDisplayId = 1,
@@ -186,8 +193,17 @@ export default class TestData {
     firstName = 'Joan',
     lastName = 'Phillips',
     dateOfBirth = '1980-02-21',
+    visitorRestrictions = [],
     adult = true,
-  }: Partial<Visitor> = {}): Visitor => ({ visitorDisplayId, visitorId, lastName, firstName, dateOfBirth, adult })
+  }: Partial<Visitor> = {}): Visitor => ({
+    visitorDisplayId,
+    visitorId,
+    lastName,
+    firstName,
+    dateOfBirth,
+    visitorRestrictions,
+    adult,
+  })
 
   static orchestrationVisitDto = ({
     reference = 'ab-cd-ef-gh',

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -82,7 +82,7 @@ describe('Booker service', () => {
         TestData.visitorInfoDto({ visitorId: 100, dateOfBirth: '2000-01-01' }), // an adult
         TestData.visitorInfoDto({ visitorId: 200, dateOfBirth: `${new Date().getFullYear() - 2}-01-01` }), // a child
       ]
-      const visitors: Visitor[] = [
+      const expectedVisitors: Visitor[] = [
         { ...visitorInfoDtos[0], visitorDisplayId: 1, adult: true },
         { ...visitorInfoDtos[1], visitorDisplayId: 2, adult: false },
       ]
@@ -92,7 +92,26 @@ describe('Booker service', () => {
       const results = await bookerService.getVisitors(bookerReference.value, prisonerNumber)
 
       expect(orchestrationApiClient.getVisitors).toHaveBeenCalledWith(bookerReference.value, prisonerNumber)
-      expect(results).toStrictEqual(visitors)
+      expect(results).toStrictEqual(expectedVisitors)
+    })
+  })
+
+  describe('getEligibleVisitors', () => {
+    it('should return eligible visitors (those having no restrictions) for the given booker reference and prisoner number', async () => {
+      const bookerReference = TestData.bookerReference()
+      const { prisonerNumber } = TestData.bookerPrisonerInfoDto().prisoner
+      const visitorInfoDtos = [
+        TestData.visitorInfoDto({ visitorId: 100 }),
+        TestData.visitorInfoDto({ visitorId: 200, visitorRestrictions: [{ restrictionType: 'BAN' }] }),
+      ]
+      const expectedVisitors: Visitor[] = [{ ...visitorInfoDtos[0], visitorDisplayId: 1, adult: true }]
+
+      orchestrationApiClient.getVisitors.mockResolvedValue(visitorInfoDtos)
+
+      const results = await bookerService.getEligibleVisitors(bookerReference.value, prisonerNumber)
+
+      expect(orchestrationApiClient.getVisitors).toHaveBeenCalledWith(bookerReference.value, prisonerNumber)
+      expect(results).toStrictEqual(expectedVisitors)
     })
   })
 })

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -60,4 +60,9 @@ export default class BookerService {
       return { ...visitor, visitorDisplayId: index + 1, adult: isAdult(visitor.dateOfBirth) }
     })
   }
+
+  async getEligibleVisitors(bookerReference: string, prisonerNumber: string): Promise<Visitor[]> {
+    const allVisitors = await this.getVisitors(bookerReference, prisonerNumber)
+    return allVisitors.filter(visitor => visitor.visitorRestrictions.length === 0)
+  }
 }

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -49,7 +49,7 @@ describe('Visit service', () => {
       bookingJourney = {
         prisoner: TestData.prisoner(),
         prison: TestData.prisonDto(),
-        allVisitors: [visitorOne, visitorTwo, visitorThree],
+        eligibleVisitors: [visitorOne, visitorTwo, visitorThree],
         selectedVisitors: [visitorOne, visitorTwo],
         allVisitSessionIds: ['2024-05-30_a'],
         allVisitSessions: [visitSession],


### PR DESCRIPTION
* List of permitted visitors for a booker/prisoner now includes `visitorRestrictions` for each visitor. Currently the only `BAN` is included
* Refactor to filter only visitors with no restrictions for use during **booking journey** 
* Rename `allVisitors` in the `bookingJourney` session data to be `eligibleVisitors` for clarity