### PR TITLE
VB-4199 Use UUIDs for Prisoner and Visitor display IDs

### DIFF
--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -107,11 +107,11 @@ context('Booking journey', () => {
     selectVisitorsPage.visitorsMaxChildren().contains(prison.maxChildVisitors)
     selectVisitorsPage.visitorsAdultAge().eq(0).contains(prison.adultAgeYears)
     selectVisitorsPage.visitorsAdultAge().eq(1).contains(prison.adultAgeYears)
-    selectVisitorsPage.getVisitorLabel(1).contains('Adult One (25 years old)')
-    selectVisitorsPage.getVisitorLabel(2).contains('Child One (12 years old)')
-    selectVisitorsPage.getVisitorLabel(3).contains('Child Two (5 years old)')
-    selectVisitorsPage.selectVisitor(1)
-    selectVisitorsPage.selectVisitor(3)
+    selectVisitorsPage.getVisitorByNameLabel('Adult One').contains('Adult One (25 years old)')
+    selectVisitorsPage.getVisitorByNameLabel('Child One').contains('Child One (12 years old)')
+    selectVisitorsPage.getVisitorByNameLabel('Child Two').contains('Child Two (5 years old)')
+    selectVisitorsPage.selectVisitorByName('Adult One')
+    selectVisitorsPage.selectVisitorByName('Child Two')
     cy.task('stubGetSessionRestriction', {
       prisonerId: prisoner.prisoner.prisonerNumber,
       visitorIds: [1000, 3000],
@@ -141,8 +141,7 @@ context('Booking journey', () => {
 
     // Main contact
     const mainContactPage = Page.verifyOnPage(MainContactPage)
-    mainContactPage.getContactLabel(1).contains('Adult One')
-    mainContactPage.selectVisitor(1)
+    mainContactPage.selectVisitorByName('Adult One')
     mainContactPage.checkHasPhoneNumber()
     mainContactPage.enterPhoneNumber('01234 567 890')
     cy.task('stubChangeVisitApplication', {
@@ -197,7 +196,7 @@ context('Booking journey', () => {
 
     // Select visitors page - choose visitors
     const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
-    selectVisitorsPage.selectVisitor(1)
+    selectVisitorsPage.selectVisitorByName('Adult One')
     cy.task('stubGetSessionRestriction', {
       prisonerId: prisoner.prisoner.prisonerNumber,
       visitorIds: [1000],

--- a/integration_tests/e2e/bookingJourneyDropOuts.cy.ts
+++ b/integration_tests/e2e/bookingJourneyDropOuts.cy.ts
@@ -55,7 +55,7 @@ context('Booking journey - drop-out points', () => {
 
       // Select visitors page - choose visitors
       const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
-      selectVisitorsPage.selectVisitor(1)
+      selectVisitorsPage.selectVisitorByName('Adult One')
       cy.task('stubGetSessionRestriction', {
         prisonerId: prisoner.prisoner.prisonerNumber,
         visitorIds: [1000],
@@ -91,7 +91,7 @@ context('Booking journey - drop-out points', () => {
 
       // Select visitors page - choose visitors
       const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
-      selectVisitorsPage.selectVisitor(1)
+      selectVisitorsPage.selectVisitorByName('Adult One')
       cy.task('stubGetSessionRestriction', {
         prisonerId: prisoner.prisoner.prisonerNumber,
         visitorIds: [1000],

--- a/integration_tests/e2e/visitors.cy.ts
+++ b/integration_tests/e2e/visitors.cy.ts
@@ -7,10 +7,9 @@ import VisitorsPage from '../pages/visitors/visitors'
 
 context('Visitors page', () => {
   const visitors = [
-    TestData.visitor(),
-    TestData.visitor({
-      visitorDisplayId: 9,
-      visitorId: 8005,
+    TestData.visitorInfoDto(),
+    TestData.visitorInfoDto({
+      visitorId: 2000,
       firstName: 'Keith',
       lastName: 'Richards',
       dateOfBirth: '1990-05-05',
@@ -51,7 +50,7 @@ context('Visitors page', () => {
     homePage.startBooking()
 
     const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
-    selectVisitorsPage.getVisitorLabel(1).contains('Joan Phillips')
-    selectVisitorsPage.getVisitorLabel(2).should('not.exist')
+    selectVisitorsPage.getVisitorByNameLabel('Joan Phillips').should('exist')
+    selectVisitorsPage.getVisitorByNameLabel('Keith Richards').should('not.exist')
   })
 })

--- a/integration_tests/pages/bookVisit/mainContact.ts
+++ b/integration_tests/pages/bookVisit/mainContact.ts
@@ -9,11 +9,8 @@ export default class MainContactPage extends Page {
     })
   }
 
-  getContactLabel = (contactDisplayId: number): PageElement =>
-    cy.get(`input[name=contact][value=${contactDisplayId}] + label`)
-
-  selectVisitor = (contactDisplayId: number): void => {
-    cy.get(`input[name=contact][value=${contactDisplayId}]`).check()
+  selectVisitorByName = (name: string): void => {
+    cy.get('label').contains(name).siblings('input[name=contact]').check()
   }
 
   checkHasPhoneNumber = (): void => {

--- a/integration_tests/pages/bookVisit/selectVisitors.ts
+++ b/integration_tests/pages/bookVisit/selectVisitors.ts
@@ -17,11 +17,10 @@ export default class SelectVisitorsPage extends Page {
   visitorsAdultAge = (): PageElement => cy.get('[data-test=visitors-adult-age]')
 
   // visitor list
-  getVisitorLabel = (visitorDisplayId: number): PageElement =>
-    cy.get(`input[name=visitorDisplayIds][value=${visitorDisplayId}] + label`)
+  getVisitorByNameLabel = (name: string): PageElement => cy.get('input[name=visitorDisplayIds] + label').contains(name)
 
-  selectVisitor = (visitorDisplayId: number): void => {
-    cy.get(`input[name=visitorDisplayIds][value=${visitorDisplayId}]`).check()
+  selectVisitorByName = (name: string): void => {
+    cy.get('label').contains(name).siblings('input[name=visitorDisplayIds]').check()
   }
 
   continue = (): void => {

--- a/server/routes/bookVisit/mainContactController.test.ts
+++ b/server/routes/bookVisit/mainContactController.test.ts
@@ -21,10 +21,10 @@ const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner()
 const prison = TestData.prisonDto()
 const sessionRestriction: SessionRestriction = 'OPEN'
-const adultVisitor1 = TestData.visitor({ visitorDisplayId: 1, visitorId: 100 })
-const adultVisitor2 = TestData.visitor({ visitorDisplayId: 2, visitorId: 200 })
+const adultVisitor1 = TestData.visitor({ visitorDisplayId: 'uuidv4-1', visitorId: 100 })
+const adultVisitor2 = TestData.visitor({ visitorDisplayId: 'uuidv4-2', visitorId: 200 })
 const childVisitor = TestData.visitor({
-  visitorDisplayId: 3,
+  visitorDisplayId: 'uuidv4-3',
   visitorId: 300,
   dateOfBirth: `${new Date().getFullYear() - 2}-01-01`,
   adult: false,
@@ -91,7 +91,7 @@ describe('Main contact', () => {
           expect($('form[method=POST]').attr('action')).toBe(paths.BOOK_VISIT.MAIN_CONTACT)
           expect($('input[name="contact"]').length).toBe(2) // Only adult visitor and 'Someone else'
           expect($('input[name="contact"]:checked').length).toBe(0)
-          expect($('input[name="contact"][value=1] + label').text().trim()).toBe('Joan Phillips')
+          expect($('input[name="contact"][value=uuidv4-1] + label').text().trim()).toBe('Joan Phillips')
           expect($('input[name="contact"][value=someoneElse] + label').text().trim()).toBe('Someone else')
           expect($('#someoneElseName').prop('value')).toBeFalsy()
 
@@ -109,8 +109,8 @@ describe('Main contact', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('input[name="contact"][value=1]:checked').length).toBe(1)
-          expect($('input[name="contact"][value=1] + label').text().trim()).toBe('Joan Phillips')
+          expect($('input[name="contact"][value=uuidv4-1]:checked').length).toBe(1)
+          expect($('input[name="contact"][value=uuidv4-1] + label').text().trim()).toBe('Joan Phillips')
 
           expect($('input[name=hasPhoneNumber][value=yes]:checked').length).toBe(1)
           expect($('#phoneNumber').prop('value')).toBe('01234 567 890')
@@ -330,7 +330,7 @@ describe('Main contact', () => {
             msg: 'Enter a UK phone number, like 07700 900 982 or 01632 960 001',
           },
         ]
-        expectedFlashFormValues = { contact: '1', hasPhoneNumber: 'yes', phoneNumber: 'abcd1234' }
+        expectedFlashFormValues = { contact: 'uuidv4-1', hasPhoneNumber: 'yes', phoneNumber: 'abcd1234' }
 
         return request(app)
           .post(paths.BOOK_VISIT.MAIN_CONTACT)

--- a/server/routes/bookVisit/selectPrisonerController.ts
+++ b/server/routes/bookVisit/selectPrisonerController.ts
@@ -13,7 +13,7 @@ export default class SelectPrisonerController {
       const prisoner = req.session.booker.prisoners[0]
 
       const { prisonerDisplayId } = req.body
-      if (prisonerDisplayId.toString() !== prisoner.prisonerDisplayId.toString()) {
+      if (prisonerDisplayId !== prisoner.prisonerDisplayId) {
         throw new NotFound('Prisoner not found')
       }
 

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -29,56 +29,56 @@ const prison = TestData.prisonDto()
 const fakeDate = new Date('2024-05-02')
 
 const visitor1 = TestData.visitor({
-  visitorDisplayId: 1,
+  visitorDisplayId: 'uuidv4-1',
   visitorId: 1000,
   firstName: 'Visitor',
   lastName: 'Age 20y',
   dateOfBirth: '2004-04-01',
 })
 const visitor2 = TestData.visitor({
-  visitorDisplayId: 2,
+  visitorDisplayId: 'uuidv4-2',
   visitorId: 2000,
   firstName: 'Visitor',
   lastName: 'Age 18y',
   dateOfBirth: '2006-05-02', // 18 today
 })
 const visitor3 = TestData.visitor({
-  visitorDisplayId: 3,
+  visitorDisplayId: 'uuidv4-3',
   visitorId: 3000,
   firstName: 'Visitor',
   lastName: 'Age 17y',
   dateOfBirth: '2006-05-03', // 18 tomorrow
 })
 const visitor4 = TestData.visitor({
-  visitorDisplayId: 4,
+  visitorDisplayId: 'uuidv4-4',
   visitorId: 4000,
   firstName: 'Visitor',
   lastName: 'Age 16y',
   dateOfBirth: '2008-05-02', // 16 today
 })
 const visitor5 = TestData.visitor({
-  visitorDisplayId: 5,
+  visitorDisplayId: 'uuidv4-5',
   visitorId: 5000,
   firstName: 'Visitor',
   lastName: 'Age 15y',
   dateOfBirth: '2008-05-03', // 16 tomorrow
 })
 const visitor6 = TestData.visitor({
-  visitorDisplayId: 6,
+  visitorDisplayId: 'uuidv4-6',
   visitorId: 6000,
   firstName: 'Visitor',
   lastName: 'Age 10y',
   dateOfBirth: '2014-05-02',
 })
 const visitor7 = TestData.visitor({
-  visitorDisplayId: 7,
+  visitorDisplayId: 'uuidv4-7',
   visitorId: 7000,
   firstName: 'Visitor',
   lastName: 'Age 1y',
   dateOfBirth: '2023-05-02',
 })
 const visitor8 = TestData.visitor({
-  visitorDisplayId: 8,
+  visitorDisplayId: 'uuidv4-8',
   visitorId: 8000,
   firstName: 'Visitor',
   lastName: 'Age 4m',
@@ -147,14 +147,30 @@ describe('Select visitors', () => {
           expect($('form[method=POST]').attr('action')).toBe(paths.BOOK_VISIT.SELECT_VISITORS)
           expect($('input[name=visitorDisplayIds]').length).toBe(8)
           expect($('input[name=visitorDisplayIds]:checked').length).toBe(0)
-          expect($('input[name=visitorDisplayIds][value=1]+label').text().trim()).toBe('Visitor Age 20y (20 years old)')
-          expect($('input[name=visitorDisplayIds][value=2]+label').text().trim()).toBe('Visitor Age 18y (18 years old)')
-          expect($('input[name=visitorDisplayIds][value=3]+label').text().trim()).toBe('Visitor Age 17y (17 years old)')
-          expect($('input[name=visitorDisplayIds][value=4]+label').text().trim()).toBe('Visitor Age 16y (16 years old)')
-          expect($('input[name=visitorDisplayIds][value=5]+label').text().trim()).toBe('Visitor Age 15y (15 years old)')
-          expect($('input[name=visitorDisplayIds][value=6]+label').text().trim()).toBe('Visitor Age 10y (10 years old)')
-          expect($('input[name=visitorDisplayIds][value=7]+label').text().trim()).toBe('Visitor Age 1y (1 year old)')
-          expect($('input[name=visitorDisplayIds][value=8]+label').text().trim()).toBe('Visitor Age 4m (4 months old)')
+          expect($('input[name=visitorDisplayIds][value=uuidv4-1]+label').text().trim()).toBe(
+            'Visitor Age 20y (20 years old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-2]+label').text().trim()).toBe(
+            'Visitor Age 18y (18 years old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-3]+label').text().trim()).toBe(
+            'Visitor Age 17y (17 years old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-4]+label').text().trim()).toBe(
+            'Visitor Age 16y (16 years old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-5]+label').text().trim()).toBe(
+            'Visitor Age 15y (15 years old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-6]+label').text().trim()).toBe(
+            'Visitor Age 10y (10 years old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-7]+label').text().trim()).toBe(
+            'Visitor Age 1y (1 year old)',
+          )
+          expect($('input[name=visitorDisplayIds][value=uuidv4-8]+label').text().trim()).toBe(
+            'Visitor Age 4m (4 months old)',
+          )
 
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 
@@ -185,15 +201,15 @@ describe('Select visitors', () => {
           const $ = cheerio.load(res.text)
           expect($('input[name=visitorDisplayIds]').length).toBe(8)
           expect($('input[name=visitorDisplayIds]:checked').length).toBe(3)
-          expect($('input[name=visitorDisplayIds][value=1]:checked + label').length).toBe(1)
-          expect($('input[name=visitorDisplayIds][value=4]:checked + label').length).toBe(1)
-          expect($('input[name=visitorDisplayIds][value=8]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=uuidv4-1]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=uuidv4-4]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=uuidv4-8]:checked + label').length).toBe(1)
         })
     })
 
     it('should pre-populate with data in formValues overriding that in session', () => {
       sessionData.bookingJourney.selectedVisitors = [visitor1, visitor4, visitor8]
-      const formValues = { visitorDisplayIds: [2, 7] }
+      const formValues = { visitorDisplayIds: ['uuidv4-2', 'uuidv4-7'] }
       flashData = { formValues: [formValues] }
 
       return request(app)
@@ -203,8 +219,8 @@ describe('Select visitors', () => {
           const $ = cheerio.load(res.text)
           expect($('input[name=visitorDisplayIds]').length).toBe(8)
           expect($('input[name=visitorDisplayIds]:checked').length).toBe(2)
-          expect($('input[name=visitorDisplayIds][value=2]:checked + label').length).toBe(1)
-          expect($('input[name=visitorDisplayIds][value=7]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=uuidv4-7]:checked + label').length).toBe(1)
+          expect($('input[name=visitorDisplayIds][value=uuidv4-2]:checked + label').length).toBe(1)
         })
     })
 
@@ -284,7 +300,7 @@ describe('Select visitors', () => {
     it('should should save selected visitors to session and redirect to select date and time page (OPEN visit)', () => {
       return request(app)
         .post(paths.BOOK_VISIT.SELECT_VISITORS)
-        .send({ visitorDisplayIds: [1, 3] })
+        .send({ visitorDisplayIds: ['uuidv4-1', 'uuidv4-3'] })
         .expect(302)
         .expect('Location', paths.BOOK_VISIT.CHOOSE_TIME)
         .expect(() => {
@@ -314,7 +330,7 @@ describe('Select visitors', () => {
 
       return request(app)
         .post(paths.BOOK_VISIT.SELECT_VISITORS)
-        .send({ visitorDisplayIds: [1, 3] })
+        .send({ visitorDisplayIds: ['uuidv4-1', 'uuidv4-3'] })
         .expect(302)
         .expect('Location', paths.BOOK_VISIT.CLOSED_VISIT)
         .expect(() => {
@@ -342,7 +358,7 @@ describe('Select visitors', () => {
     it('should filter out invalid or duplicate visitor IDs', () => {
       return request(app)
         .post(paths.BOOK_VISIT.SELECT_VISITORS)
-        .send({ visitorDisplayIds: [1, 1, 999, 3] })
+        .send({ visitorDisplayIds: ['uuidv4-1', 'uuidv4-1', 'uuidv4-999', 'uuidv4-3'] })
         .expect(302)
         .expect('Location', paths.BOOK_VISIT.CHOOSE_TIME)
         .expect(() => {
@@ -409,7 +425,7 @@ describe('Select visitors', () => {
       })
 
       it('should set a validation error and redirect to original page when max total visitors exceeded', () => {
-        const visitorDisplayIds = [1, 2, 5, 6, 7]
+        const visitorDisplayIds = ['uuidv4-1', 'uuidv4-2', 'uuidv4-5', 'uuidv4-6', 'uuidv4-7']
         expectedFlashErrors[0].msg = 'Select no more than 4 visitors'
         expectedFlashErrors[0].value = visitorDisplayIds
         expectedFlashFormValues.visitorDisplayIds = visitorDisplayIds
@@ -427,7 +443,7 @@ describe('Select visitors', () => {
       })
 
       it('should set a validation error and redirect to original page when max total adult age visitors exceeded', () => {
-        const visitorDisplayIds = [1, 2, 3]
+        const visitorDisplayIds = ['uuidv4-1', 'uuidv4-2', 'uuidv4-3']
         expectedFlashErrors[0].msg = 'Select no more than 2 visitors 16 years old or older'
         expectedFlashErrors[0].value = visitorDisplayIds
         expectedFlashFormValues.visitorDisplayIds = visitorDisplayIds
@@ -445,7 +461,7 @@ describe('Select visitors', () => {
       })
 
       it('should set a validation error and redirect to original page when max total child age visitors exceeded', () => {
-        const visitorDisplayIds = [5, 6, 7, 8]
+        const visitorDisplayIds = ['uuidv4-5', 'uuidv4-6', 'uuidv4-7', 'uuidv4-8']
         expectedFlashErrors[0].msg = 'Select no more than 3 visitors under 16 years old'
         expectedFlashErrors[0].value = visitorDisplayIds
         expectedFlashFormValues.visitorDisplayIds = visitorDisplayIds
@@ -463,7 +479,7 @@ describe('Select visitors', () => {
       })
 
       it('should set a validation error and redirect to original page no visitor over 18 is selected', () => {
-        const visitorDisplayIds = [3]
+        const visitorDisplayIds = ['uuidv4-3']
         expectedFlashErrors[0].msg = 'Add a visitor who is 18 years old or older'
         expectedFlashErrors[0].value = visitorDisplayIds
         expectedFlashFormValues.visitorDisplayIds = visitorDisplayIds

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -51,7 +51,7 @@ export default class SelectVisitorsController {
       }
 
       const { bookingJourney } = req.session
-      const { visitorDisplayIds } = matchedData<{ visitorDisplayIds: number[] }>(req)
+      const { visitorDisplayIds } = matchedData<{ visitorDisplayIds: string[] }>(req)
 
       const selectedVisitors = bookingJourney.eligibleVisitors.filter(visitor =>
         visitorDisplayIds.includes(visitor.visitorDisplayId),
@@ -73,9 +73,8 @@ export default class SelectVisitorsController {
     return [
       body('visitorDisplayIds')
         .toArray()
-        .toInt()
         // filter out any invalid or duplicate visitorDisplayId values
-        .customSanitizer((visitorDisplayIds: number[], { req }: Meta & { req: Express.Request }) => {
+        .customSanitizer((visitorDisplayIds: string[], { req }: Meta & { req: Express.Request }) => {
           const allVisitorDisplaysIds = req.session.bookingJourney.eligibleVisitors.map(
             visitor => visitor.visitorDisplayId,
           )
@@ -91,7 +90,7 @@ export default class SelectVisitorsController {
         .withMessage('No visitors selected')
         .bail()
         // validate visitor totals
-        .custom((visitorDisplayIds: number[], { req }: Meta & { req: Express.Request }) => {
+        .custom((visitorDisplayIds: string[], { req }: Meta & { req: Express.Request }) => {
           const { adultAgeYears, maxAdultVisitors, maxChildVisitors, maxTotalVisitors } =
             req.session.bookingJourney.prison
 

--- a/server/routes/homeController.test.ts
+++ b/server/routes/homeController.test.ts
@@ -39,7 +39,7 @@ describe('Home page', () => {
         expect($('h1').text()).toBe('Book a visit')
         expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
         expect($('form[method=POST]').attr('action')).toBe(paths.BOOK_VISIT.SELECT_PRISONER)
-        expect($('input[name=prisonerDisplayId]').val()).toBe('1')
+        expect($('input[name=prisonerDisplayId]').val()).toBe('uuidv4-1')
         expect($('[data-test="start-booking"]').text().trim()).toBe('Start')
 
         expect(bookerService.getPrisoners).toHaveBeenCalledWith(bookerReference)

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -139,7 +139,6 @@ export default class TestData {
     reference = 'ab-cd-ef-gh',
     prisonerId = 'A1234BC',
     prisonId = 'HEI',
-    prisonName = 'Hewell (HMP)', // TODO does this come through (e.g. on /book)?
     sessionTemplateReference = 'v9d.7ed.7u',
     visitRoom = '',
     visitType = 'SOCIAL',
@@ -158,7 +157,6 @@ export default class TestData {
       reference,
       prisonerId,
       prisonId,
-      prisonName,
       sessionTemplateReference,
       visitRoom,
       visitType,

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -188,7 +188,7 @@ export default class TestData {
   })
 
   static visitor = ({
-    visitorDisplayId = 1,
+    visitorDisplayId = 'uuidv4-1',
     visitorId = 1234,
     firstName = 'Joan',
     lastName = 'Phillips',

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -117,7 +117,7 @@ export default class TestData {
     }) as PrisonDto
 
   static prisoner = ({
-    prisonerDisplayId = 1,
+    prisonerDisplayId = 'uuidv4-1',
     prisonerNumber = 'A1234BC',
     firstName = 'JOHN',
     lastName = 'SMITH',

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -4,6 +4,16 @@ import { createMockHmppsAuthClient, createMockOrchestrationApiClient } from '../
 
 const token = 'some token'
 
+jest.mock('uuid', () => {
+  let count = 0
+  return {
+    v4: () => {
+      count += 1
+      return `uuidv4-${count}`
+    },
+  }
+})
+
 describe('Booker service', () => {
   const hmppsAuthClient = createMockHmppsAuthClient()
 
@@ -37,7 +47,7 @@ describe('Booker service', () => {
   })
 
   describe('getPrisoners', () => {
-    it('should return prisoners for the given booker reference, with sequential display ID added', async () => {
+    it('should return prisoners for the given booker reference, with UUID display IDs added', async () => {
       const bookerReference = TestData.bookerReference()
       const prisoner1 = {
         prisonerNumber: 'A',
@@ -61,8 +71,8 @@ describe('Booker service', () => {
       ]
 
       const expectedPrisoners: Prisoner[] = [
-        { prisonerDisplayId: 1, ...prisoner1 },
-        { prisonerDisplayId: 2, ...prisoner2 },
+        { prisonerDisplayId: 'uuidv4-1', ...prisoner1 },
+        { prisonerDisplayId: 'uuidv4-2', ...prisoner2 },
       ]
 
       orchestrationApiClient.getPrisoners.mockResolvedValue(bookerPrisonerInfoDtos)

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -4,12 +4,12 @@ import { createMockHmppsAuthClient, createMockOrchestrationApiClient } from '../
 
 const token = 'some token'
 
+let uuidCount: number
 jest.mock('uuid', () => {
-  let count = 0
   return {
     v4: () => {
-      count += 1
-      return `uuidv4-${count}`
+      uuidCount += 1
+      return `uuidv4-${uuidCount}`
     },
   }
 })
@@ -23,6 +23,7 @@ describe('Booker service', () => {
   let bookerService: BookerService
 
   beforeEach(() => {
+    uuidCount = 0
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
 
     orchestrationApiClientFactory.mockReturnValue(orchestrationApiClient)
@@ -93,8 +94,8 @@ describe('Booker service', () => {
         TestData.visitorInfoDto({ visitorId: 200, dateOfBirth: `${new Date().getFullYear() - 2}-01-01` }), // a child
       ]
       const expectedVisitors: Visitor[] = [
-        { ...visitorInfoDtos[0], visitorDisplayId: 1, adult: true },
-        { ...visitorInfoDtos[1], visitorDisplayId: 2, adult: false },
+        { ...visitorInfoDtos[0], visitorDisplayId: 'uuidv4-1', adult: true },
+        { ...visitorInfoDtos[1], visitorDisplayId: 'uuidv4-2', adult: false },
       ]
 
       orchestrationApiClient.getVisitors.mockResolvedValue(visitorInfoDtos)
@@ -114,7 +115,7 @@ describe('Booker service', () => {
         TestData.visitorInfoDto({ visitorId: 100 }),
         TestData.visitorInfoDto({ visitorId: 200, visitorRestrictions: [{ restrictionType: 'BAN' }] }),
       ]
-      const expectedVisitors: Visitor[] = [{ ...visitorInfoDtos[0], visitorDisplayId: 1, adult: true }]
+      const expectedVisitors: Visitor[] = [{ ...visitorInfoDtos[0], visitorDisplayId: 'uuidv4-1', adult: true }]
 
       orchestrationApiClient.getVisitors.mockResolvedValue(visitorInfoDtos)
 

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -1,10 +1,11 @@
+import { v4 as uuidv4 } from 'uuid'
 import logger from '../../logger'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
 import { AuthDetailDto, VisitorInfoDto } from '../data/orchestrationApiTypes'
 import { isAdult } from '../utils/utils'
 
 export type Prisoner = {
-  prisonerDisplayId: number
+  prisonerDisplayId: string
   prisonerNumber: string
   firstName: string
   lastName: string
@@ -38,9 +39,9 @@ export default class BookerService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
     const prisoners = await orchestrationApiClient.getPrisoners(bookerReference)
-    return prisoners.map((prisoner, index) => {
+    return prisoners.map(prisoner => {
       return {
-        prisonerDisplayId: index + 1,
+        prisonerDisplayId: uuidv4(),
         prisonerNumber: prisoner.prisoner.prisonerNumber,
         firstName: prisoner.prisoner.firstName,
         lastName: prisoner.prisoner.lastName,

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -14,7 +14,7 @@ export type Prisoner = {
   nextAvailableVoDate: string
 }
 export interface Visitor extends VisitorInfoDto {
-  visitorDisplayId: number
+  visitorDisplayId: string
   adult: boolean
 }
 
@@ -57,8 +57,8 @@ export default class BookerService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
     const visitors = await orchestrationApiClient.getVisitors(bookerReference, prisonerNumber)
 
-    return visitors.map((visitor, index) => {
-      return { ...visitor, visitorDisplayId: index + 1, adult: isAdult(visitor.dateOfBirth) }
+    return visitors.map(visitor => {
+      return { ...visitor, visitorDisplayId: uuidv4(), adult: isAdult(visitor.dateOfBirth) }
     })
   }
 


### PR DESCRIPTION
In web forms, a `displayId` is used for Prisoner and Visitor objects. This is to avoid using the real database ID. 

Previously, this value was just a sequential integer. This change uses a UUID instead for these values.

(Actual code change very small and pretty much just in `server/services/bookerService.ts` - rest is updating tests...)