### PR TITLE
VB-4199 Use UUIDs for referencing visit bookings in URL parameters

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,6 +1,6 @@
 import { ValidationError } from 'express-validator'
 import { Booker, BookingConfirmed, BookingJourney } from '../bapv'
-import { OrchestrationVisitDto } from '../../data/orchestrationApiTypes'
+import { VisitDetails } from '../../services/visitService'
 
 export default {}
 
@@ -12,12 +12,12 @@ declare module 'express-session' {
 
     booker: Booker
 
-    bookingsFuture?: OrchestrationVisitDto[]
-    bookingsPast?: OrchestrationVisitDto[]
-    bookingsCancelled?: OrchestrationVisitDto[]
-
     bookingJourney?: BookingJourney
     bookingConfirmed?: BookingConfirmed
+
+    bookingsFuture?: VisitDetails[]
+    bookingsPast?: VisitDetails[]
+    bookingsCancelled?: VisitDetails[]
   }
 }
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -15,9 +15,10 @@ declare module 'express-session' {
     bookingJourney?: BookingJourney
     bookingConfirmed?: BookingConfirmed
 
-    bookingsFuture?: VisitDetails[]
-    bookingsPast?: VisitDetails[]
-    bookingsCancelled?: VisitDetails[]
+    bookings?: {
+      type: 'future' | 'past' | 'cancelled'
+      visits: VisitDetails[]
+    }
   }
 }
 

--- a/server/routes/bookings/bookingDetailsController.test.ts
+++ b/server/routes/bookings/bookingDetailsController.test.ts
@@ -2,148 +2,185 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { SessionData } from 'express-session'
+import { randomUUID } from 'crypto'
 import { appWithAllRoutes } from '../testutils/appSetup'
-import { createMockBookerService, createMockVisitService } from '../../services/testutils/mocks'
+import { createMockBookerService } from '../../services/testutils/mocks'
 import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
+import getPrisonInformation from '../../constants/prisonInformation'
+import { VisitDetails } from '../../services/visitService'
 
 let app: Express
 
 const bookerService = createMockBookerService()
-const visitService = createMockVisitService()
-const orchestrationVisitDto = TestData.orchestrationVisitDto()
-const pastVisitDto = TestData.orchestrationVisitDto({
-  startTimestamp: '2023-05-30T10:00:00',
-  endTimestamp: '2023-05-30T11:30:00',
-})
-const cancelledVisitDto = TestData.orchestrationVisitDto({
-  visitStatus: 'CANCELLED',
-  outcomeStatus: 'ESTABLISHMENT_CANCELLED',
-})
+
 const bookerReference = TestData.bookerReference().value
 const prisoner = TestData.prisoner({ prisonId: 'DHI' })
+const visitDisplayId = randomUUID()
+
 let sessionData: SessionData
+let bookings: SessionData['bookings']
+let visitDetails: VisitDetails
 
 beforeEach(() => {
+  visitDetails = TestData.visitDetails({ visitDisplayId })
+  bookings = { type: undefined, visits: [visitDetails] }
+
   sessionData = {
     booker: {
       reference: bookerReference,
       prisoners: [prisoner],
     },
-    bookingsFuture: [orchestrationVisitDto],
-    bookingsPast: [pastVisitDto],
-    bookingsCancelled: [cancelledVisitDto],
+    bookings,
   } as SessionData
-  visitService.getFuturePublicVisits.mockResolvedValue([orchestrationVisitDto])
-  app = appWithAllRoutes({ services: { bookerService, visitService }, sessionData })
+
+  app = appWithAllRoutes({ services: { bookerService }, sessionData })
 })
 
 afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('View single booking', () => {
-  it('should render the booking details page', () => {
-    return request(app)
-      .get(`${paths.BOOKINGS.VISIT}/1`)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Visit booking details -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.HOME)
-        expect($('h1').text()).toBe('Visit booking details')
-        expect($('[data-test="booking-reference"]').text()).toContain('ab-cd-ef-gh')
-        expect($('[data-test="visit-date"]').text()).toContain('Thursday 30 May 2024')
-        expect($('[data-test="visit-start-time"]').text()).toContain('10am')
-        expect($('[data-test="visit-end-time"]').text()).toContain('11:30am')
-        expect($('[data-test="prisoner-name"]').text()).toContain('John Smith')
-        expect($('[data-test="visitor-name-1"]').text()).toContain('Keith Phillips')
-        expect($('[data-test="additional-support"]').text()).toContain('Wheelchair access requested')
-        expect($('[data-test="main-contact-name"]').text()).toContain('Joan Phillips')
-        expect($('[data-test="main-contact-number"]').text()).toContain('01234 567890')
-        expect($('[data-test="prison-name"]').text()).toContain('Drake Hall (HMP & YOI)')
-        expect($('[data-test="prison-phone-number"]').text()).toContain('0121 661 2101')
-        expect($('[data-test="minutes-before-visit"]').text()).toContain('45')
-        expect($('[data-test="prison-website"]').attr('href')).toContain(
-          'https://www.gov.uk/guidance/drake-hall-prison',
-        )
-      })
+describe('View a single booking', () => {
+  describe('Future booking', () => {
+    it('should render the booking details page', () => {
+      bookings.type = 'future'
+
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Visit booking details -/)
+          expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.HOME)
+          expect($('h1').text()).toBe('Visit booking details')
+
+          expect($('[data-test="booking-reference"]').text()).toBe('ab-cd-ef-gh')
+          expect($('[data-test="visit-date"]').text()).toBe('Thursday 30 May 2024')
+          expect($('[data-test="visit-start-time"]').text()).toBe('10am')
+          expect($('[data-test="visit-end-time"]').text()).toBe('11:30am')
+          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+          expect($('[data-test="visitor-name-1"]').text()).toBe('Keith Phillips')
+          expect($('[data-test="additional-support"]').text()).toBe('Wheelchair access requested')
+          expect($('[data-test="main-contact-name"]').text()).toBe('Joan Phillips')
+          expect($('[data-test="main-contact-number"]').text()).toBe('01234 567890')
+
+          expect($('[data-test="prison-name"]').text()).toBe(getPrisonInformation('DHI').prisonName)
+          expect($('[data-test="prison-phone-number"]').text()).toBe(getPrisonInformation('DHI').prisonPhoneNumber)
+          expect($('[data-test="minutes-before-visit"]').text()).toBe('45')
+          expect($('[data-test="prison-website"]').attr('href')).toBe(getPrisonInformation('DHI').prisonWebsite)
+        })
+    })
   })
 
-  it('should render the booking details page - visit date in the past', () => {
-    return request(app)
-      .get(`${paths.BOOKINGS.VISIT_PAST}/1`)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Visit booking details -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.PAST)
-        expect($('h1').text()).toBe('Visit booking details')
-        expect($('[data-test="booking-reference"]').text()).toContain('ab-cd-ef-gh')
-        expect($('[data-test="visit-date"]').text()).toContain('Tuesday 30 May 2023')
-        expect($('[data-test="prison-name"]').text()).not.toContain('Drake Hall (HMP & YOI)')
-        expect($('[data-test="prison-website"]').length).toBe(0)
-      })
+  describe('Past booking', () => {
+    it('should render the booking details page', () => {
+      bookings.type = 'past'
+
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT_PAST}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Visit booking details -/)
+          expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.PAST)
+          expect($('h1').text()).toBe('Visit booking details')
+
+          expect($('[data-test="booking-reference"]').text()).toBe('ab-cd-ef-gh')
+
+          expect($('[data-test="prison-name"]').length).toBeFalsy()
+          expect($('[data-test="prison-phone-number"]').length).toBeFalsy()
+          expect($('[data-test="minutes-before-visit"]').length).toBeFalsy()
+          expect($('[data-test="prison-website"]').length).toBeFalsy()
+        })
+    })
   })
 
-  it('should render the booking details page - cancelled by prison', () => {
-    return request(app)
-      .get(`${paths.BOOKINGS.VISIT_CANCELLED}/1`)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Visit booking details -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.CANCELLED)
-        expect($('h1').text()).toBe('Visit booking details')
-        expect($('[data-test="booking-reference"]').text()).toContain('ab-cd-ef-gh')
-        expect($('[data-test="visit-date"]').text()).toContain('Thursday 30 May 2024')
-        expect($('[data-test="prison-name"]').text()).not.toContain('Drake Hall (HMP & YOI)')
-        expect($('[data-test="prison-website"]').length).toBe(0)
-        expect($('[data-test="visit-cancelled-type"]').text()).toContain('This visit was cancelled by the prison.')
-      })
+  describe('Cancelled booking', () => {
+    it('should render the booking details page - cancelled by prison', () => {
+      bookings.type = 'cancelled'
+      visitDetails.visitStatus = 'CANCELLED'
+      visitDetails.outcomeStatus = 'ESTABLISHMENT_CANCELLED'
+
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT_CANCELLED}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Visit booking details -/)
+          expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.CANCELLED)
+          expect($('h1').text()).toBe('Visit booking details')
+
+          expect($('[data-test="booking-reference"]').text()).toBe('ab-cd-ef-gh')
+          expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by the prison.')
+
+          expect($('[data-test="prison-name"]').length).toBeFalsy()
+          expect($('[data-test="prison-phone-number"]').length).toBeFalsy()
+          expect($('[data-test="minutes-before-visit"]').length).toBeFalsy()
+          expect($('[data-test="prison-website"]').length).toBeFalsy()
+        })
+    })
+
+    it('should render the booking details page - cancelled by prisoner', () => {
+      bookings.type = 'cancelled'
+      visitDetails.visitStatus = 'CANCELLED'
+      visitDetails.outcomeStatus = 'PRISONER_CANCELLED'
+
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT_CANCELLED}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by the prisoner.')
+        })
+    })
+
+    it('should render the booking details page - cancelled by visitor', () => {
+      bookings.type = 'cancelled'
+      visitDetails.visitStatus = 'CANCELLED'
+      visitDetails.outcomeStatus = 'VISITOR_CANCELLED'
+
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT_CANCELLED}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by a visitor.')
+        })
+    })
   })
 
-  it('should render the booking details page - cancelled by prisoner', () => {
-    sessionData.bookingsCancelled[0].outcomeStatus = 'PRISONER_CANCELLED'
-    return request(app)
-      .get(`${paths.BOOKINGS.VISIT_CANCELLED}/1`)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Visit booking details -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.CANCELLED)
-        expect($('h1').text()).toBe('Visit booking details')
-        expect($('[data-test="booking-reference"]').text()).toContain('ab-cd-ef-gh')
-        expect($('[data-test="visit-date"]').text()).toContain('Thursday 30 May 2024')
-        expect($('[data-test="prison-name"]').text()).not.toContain('Drake Hall (HMP & YOI)')
-        expect($('[data-test="prison-website"]').length).toBe(0)
-        expect($('[data-test="visit-cancelled-type"]').text()).toContain('This visit was cancelled by the prisoner.')
-      })
-  })
+  describe('Validation', () => {
+    it('should look up prisoner details if not present in session', () => {
+      sessionData.booker.prisoners = []
+      bookings.type = 'future'
 
-  it('should render the booking details page - cancelled by visitor', () => {
-    sessionData.bookingsCancelled[0].outcomeStatus = 'VISITOR_CANCELLED'
-    return request(app)
-      .get(`${paths.BOOKINGS.VISIT_CANCELLED}/1`)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Visit booking details -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.CANCELLED)
-        expect($('h1').text()).toBe('Visit booking details')
-        expect($('[data-test="booking-reference"]').text()).toContain('ab-cd-ef-gh')
-        expect($('[data-test="visit-date"]').text()).toContain('Thursday 30 May 2024')
-        expect($('[data-test="prison-name"]').text()).not.toContain('Drake Hall (HMP & YOI)')
-        expect($('[data-test="prison-website"]').length).toBe(0)
-        expect($('[data-test="visit-cancelled-type"]').text()).toContain('This visit was cancelled by a visitor.')
-      })
-  })
+      bookerService.getPrisoners.mockResolvedValue([prisoner])
 
-  it('should redirect to bookings homepage if number higher than expected entered in address bar', () => {
-    return request(app).get(`${paths.BOOKINGS.VISIT}/50`).expect(302).expect('Location', paths.BOOKINGS.HOME)
-  })
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('Visit booking details')
+          expect($('[data-test="booking-reference"]').text()).toBe('ab-cd-ef-gh')
 
-  it('should redirect to bookings homepage if number less than 1 entered in address bar', () => {
-    return request(app).get(`${paths.BOOKINGS.VISIT}/0`).expect(302).expect('Location', paths.BOOKINGS.HOME)
+          expect(bookerService.getPrisoners).toHaveBeenCalledWith(bookerReference)
+        })
+    })
+
+    it('should redirect to bookings home page if an invalid visitDisplayId is passed', () => {
+      bookings.type = 'future'
+      return request(app).get(`${paths.BOOKINGS.VISIT}/NOT-A-UUID`).expect(302).expect('location', paths.BOOKINGS.HOME)
+    })
+
+    it('should redirect to bookings home page if an unrecognised (not in session) visitDisplayId is passed', () => {
+      bookings.type = 'future'
+      const unrecognisedUUID = randomUUID()
+      return request(app)
+        .get(`${paths.BOOKINGS.VISIT}/${unrecognisedUUID}`)
+        .expect(302)
+        .expect('location', paths.BOOKINGS.HOME)
+    })
   })
 })

--- a/server/routes/bookings/bookingDetailsController.ts
+++ b/server/routes/bookings/bookingDetailsController.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express'
-import { ValidationChain, matchedData, param, validationResult } from 'express-validator'
+import { Meta, ValidationChain, matchedData, param, validationResult } from 'express-validator'
+import { SessionData } from 'express-session'
 import { BookerService } from '../../services'
 import getPrisonInformation from '../../constants/prisonInformation'
 import paths from '../../constants/paths'
@@ -7,12 +8,13 @@ import paths from '../../constants/paths'
 export default class BookingDetailsController {
   public constructor(private readonly bookerService: BookerService) {}
 
-  public viewFuture(): RequestHandler {
+  public view(type: SessionData['bookings']['type']): RequestHandler {
     return async (req, res) => {
-      const { booker, bookingsFuture } = req.session
+      const { booker, bookings } = req.session
+      const { visits } = bookings
 
       const errors = validationResult(req)
-      if (!errors.isEmpty() || !bookingsFuture?.length) {
+      if (!errors.isEmpty() || bookings.type !== type) {
         return res.redirect(paths.BOOKINGS.HOME)
       }
 
@@ -20,15 +22,11 @@ export default class BookingDetailsController {
         ? booker.prisoners?.[0]
         : (await this.bookerService.getPrisoners(booker.reference))?.[0]
 
-      const { visitNumber } = matchedData<{ visitNumber: number }>(req)
-      // if manual number entered (larger than current number of visits in session data)
-      // redirect to bookings page
-      if (visitNumber > bookingsFuture.length) {
-        return res.redirect(paths.BOOKINGS.HOME)
-      }
-      const visit = bookingsFuture[visitNumber - 1]
+      const { visitDisplayId } = matchedData<{ visitDisplayId: string }>(req)
 
-      const { prisonName, prisonPhoneNumber, prisonWebsite } = getPrisonInformation(visit.prisonId)
+      const visit = visits.find(v => v.visitDisplayId === visitDisplayId)
+
+      const { prisonName, prisonPhoneNumber, prisonWebsite } = getPrisonInformation(prisoner.prisonId)
 
       return res.render('pages/bookings/visit', {
         visit,
@@ -37,85 +35,23 @@ export default class BookingDetailsController {
         prisonName,
         prisonPhoneNumber,
         prisonWebsite,
-        fromController: 'future',
-        showServiceNav: true,
-      })
-    }
-  }
-
-  public viewPast(): RequestHandler {
-    return async (req, res) => {
-      const { booker, bookingsPast } = req.session
-
-      const errors = validationResult(req)
-      if (!errors.isEmpty() || !bookingsPast?.length) {
-        return res.redirect(paths.BOOKINGS.HOME)
-      }
-
-      const prisoner = booker.prisoners?.[0]
-        ? booker.prisoners?.[0]
-        : (await this.bookerService.getPrisoners(booker.reference))?.[0]
-
-      const { visitNumber } = matchedData<{ visitNumber: number }>(req)
-      // if manual number entered (larger than current number of visits in session data)
-      // redirect to bookings page
-      if (visitNumber > bookingsPast.length) {
-        return res.redirect(paths.BOOKINGS.HOME)
-      }
-      const visit = bookingsPast[visitNumber - 1]
-
-      const { prisonName, prisonPhoneNumber, prisonWebsite } = getPrisonInformation(visit.prisonId)
-
-      return res.render('pages/bookings/visit', {
-        visit,
-        booker,
-        prisoner,
-        prisonName,
-        prisonPhoneNumber,
-        prisonWebsite,
-        fromController: 'past',
-        showServiceNav: true,
-      })
-    }
-  }
-
-  public viewCancelled(): RequestHandler {
-    return async (req, res) => {
-      const { booker, bookingsCancelled } = req.session
-
-      const errors = validationResult(req)
-      if (!errors.isEmpty() || !bookingsCancelled?.length) {
-        return res.redirect(paths.BOOKINGS.HOME)
-      }
-
-      const prisoner = booker.prisoners?.[0]
-        ? booker.prisoners?.[0]
-        : (await this.bookerService.getPrisoners(booker.reference))?.[0]
-
-      const { visitNumber } = matchedData<{ visitNumber: number }>(req)
-      // if manual number entered (larger than current number of visits in session data)
-      // redirect to bookings page
-      if (visitNumber > bookingsCancelled.length) {
-        return res.redirect(paths.BOOKINGS.HOME)
-      }
-      const visit = bookingsCancelled[visitNumber - 1]
-
-      const { prisonName, prisonPhoneNumber, prisonWebsite } = getPrisonInformation(visit.prisonId)
-
-      return res.render('pages/bookings/visit', {
-        visit,
-        booker,
-        prisoner,
-        prisonName,
-        prisonPhoneNumber,
-        prisonWebsite,
-        fromController: 'cancelled',
+        type,
         showServiceNav: true,
       })
     }
   }
 
   public validate(): ValidationChain[] {
-    return [param('visitNumber').toInt().isInt({ min: 1 })]
+    return [
+      param('visitDisplayId')
+        .isUUID()
+        .bail()
+        .custom((visitDisplayId: string, { req }: Meta & { req: Express.Request }) => {
+          const { bookings } = req.session
+          const visits = bookings?.visits ?? []
+
+          return visits.some(visit => visit.visitDisplayId === visitDisplayId)
+        }),
+    ]
   }
 }

--- a/server/routes/bookings/bookingsController.test.ts
+++ b/server/routes/bookings/bookingsController.test.ts
@@ -51,7 +51,7 @@ describe('Bookings homepage (future visits)', () => {
           `${paths.BOOKINGS.VISIT}/${futureVisitDetails.visitDisplayId}`,
         )
 
-        expect($('h2').text()).toContain('How to change your booking')
+        expect($('[data-test=change-booking-heading]').length).toBeTruthy()
         expect($('[data-test="prison-name"]').text()).toBe(getPrisonInformation('DHI').prisonName)
         expect($('[data-test="prison-phone-number"]').text()).toBe(getPrisonInformation('DHI').prisonPhoneNumber)
         expect($('[data-test="no-visits"]').length).toBeFalsy()
@@ -79,7 +79,7 @@ describe('Bookings homepage (future visits)', () => {
         const $ = cheerio.load(res.text)
         expect($('h1').text()).toBe('Bookings')
         expect($('[data-test="visit-date-1"]').length).toBeFalsy()
-        expect($('h2').text()).not.toContain('How to change your booking')
+        expect($('[data-test=change-booking-heading]').length).toBeFalsy()
         expect($('[data-test="no-visits"]').length).toBeTruthy()
       })
   })

--- a/server/routes/bookings/bookingsController.test.ts
+++ b/server/routes/bookings/bookingsController.test.ts
@@ -62,7 +62,10 @@ describe('Bookings homepage (future visits)', () => {
           booker: {
             reference: bookerReference,
           },
-          bookingsFuture: [futureVisitDetails],
+          bookings: {
+            type: 'future',
+            visits: [futureVisitDetails],
+          },
         } as SessionData)
       })
   })
@@ -74,6 +77,7 @@ describe('Bookings homepage (future visits)', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
+        expect($('h1').text()).toBe('Bookings')
         expect($('[data-test="visit-date-1"]').length).toBeFalsy()
         expect($('h2').text()).not.toContain('How to change your booking')
         expect($('[data-test="no-visits"]').length).toBeTruthy()
@@ -110,7 +114,10 @@ describe('Past visits page', () => {
           booker: {
             reference: bookerReference,
           },
-          bookingsPast: [pastVisitDetails],
+          bookings: {
+            type: 'past',
+            visits: [pastVisitDetails],
+          },
         } as SessionData)
       })
   })
@@ -122,6 +129,7 @@ describe('Past visits page', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
+        expect($('h1').text()).toBe('Past visits')
         expect($('[data-test="visit-date-1"]').length).toBeFalsy()
         expect($('[data-test="no-visits"]').length).toBeTruthy()
       })
@@ -157,7 +165,10 @@ describe('Cancelled visits page', () => {
           booker: {
             reference: bookerReference,
           },
-          bookingsCancelled: [cancelledVisitDetails],
+          bookings: {
+            type: 'cancelled',
+            visits: [cancelledVisitDetails],
+          },
         } as SessionData)
       })
   })
@@ -169,6 +180,7 @@ describe('Cancelled visits page', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
+        expect($('h1').text()).toBe('Cancelled visits')
         expect($('[data-test="visit-date-1"]').length).toBeFalsy()
         expect($('[data-test="no-visits"]').length).toBeTruthy()
       })

--- a/server/routes/bookings/bookingsController.test.ts
+++ b/server/routes/bookings/bookingsController.test.ts
@@ -6,25 +6,19 @@ import { appWithAllRoutes } from '../testutils/appSetup'
 import { createMockVisitService } from '../../services/testutils/mocks'
 import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
+import getPrisonInformation from '../../constants/prisonInformation'
 
 let app: Express
 
 const visitService = createMockVisitService()
-const orchestrationVisitDto = TestData.orchestrationVisitDto()
-const pastVisitDto = TestData.orchestrationVisitDto({
-  startTimestamp: '2023-05-30T10:00:00',
-  endTimestamp: '2023-05-30T11:30:00',
-})
-const cancelledVisitDto = TestData.orchestrationVisitDto({ outcomeStatus: 'ESTABLISHMENT_CANCELLED' })
 const bookerReference = TestData.bookerReference().value
-const prisoner = TestData.prisoner({ prisonId: 'DHI' })
+
 let sessionData: SessionData
 
 beforeEach(() => {
   sessionData = {
     booker: {
       reference: bookerReference,
-      prisoners: [prisoner],
     },
   } as SessionData
 
@@ -35,9 +29,11 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('Bookings homepage', () => {
+describe('Bookings homepage (future visits)', () => {
+  const futureVisitDetails = TestData.visitDetails()
+
   it('should render the bookings home page - with a future visit', () => {
-    visitService.getFuturePublicVisits.mockResolvedValue([orchestrationVisitDto])
+    visitService.getFuturePublicVisits.mockResolvedValue([futureVisitDetails])
     return request(app)
       .get(paths.BOOKINGS.HOME)
       .expect('Content-Type', /html/)
@@ -46,20 +42,27 @@ describe('Bookings homepage', () => {
         expect($('title').text()).toMatch(/^Bookings -/)
         expect($('[data-test="back-link"]').length).toBe(0)
         expect($('h1').text()).toBe('Bookings')
-        expect($('h2').text()).toContain('How to change your booking')
+
         expect($('[data-test="visit-date-1"]').text()).toBe('Thursday 30 May 2024')
         expect($('[data-test="visit-start-time-1"]').text()).toBe('10am')
         expect($('[data-test="visit-end-time-1"]').text()).toBe('11:30am')
         expect($('[data-test="visit-reference-1"]').text()).toBe('ab-cd-ef-gh')
+        expect($('[data-test="visit-link-1"]').attr('href')).toBe(
+          `${paths.BOOKINGS.VISIT}/${futureVisitDetails.visitDisplayId}`,
+        )
+
+        expect($('h2').text()).toContain('How to change your booking')
+        expect($('[data-test="prison-name"]').text()).toBe(getPrisonInformation('DHI').prisonName)
+        expect($('[data-test="prison-phone-number"]').text()).toBe(getPrisonInformation('DHI').prisonPhoneNumber)
+        expect($('[data-test="no-visits"]').length).toBeFalsy()
 
         expect(visitService.getFuturePublicVisits).toHaveBeenCalledWith(bookerReference)
 
         expect(sessionData).toStrictEqual({
           booker: {
             reference: bookerReference,
-            prisoners: [prisoner],
           },
-          bookingsFuture: [orchestrationVisitDto],
+          bookingsFuture: [futureVisitDetails],
         } as SessionData)
       })
   })
@@ -71,60 +74,18 @@ describe('Bookings homepage', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Bookings -/)
-        expect($('[data-test="back-link"]').length).toBe(0)
-        expect($('h1').text()).toBe('Bookings')
+        expect($('[data-test="visit-date-1"]').length).toBeFalsy()
         expect($('h2').text()).not.toContain('How to change your booking')
-        expect($('[data-test="no-visits"]').text()).toBe('You do not have any future bookings.')
-      })
-  })
-})
-
-describe('Cancelled visits page', () => {
-  it('should render the cancelled visits page', () => {
-    visitService.getCancelledPublicVisits.mockResolvedValue([cancelledVisitDto])
-    return request(app)
-      .get(paths.BOOKINGS.CANCELLED)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Cancelled visits -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.HOME)
-        expect($('h1').text()).toBe('Cancelled visits')
-        expect($('[data-test="visit-date-1"]').text()).toBe('Thursday 30 May 2024')
-        expect($('[data-test="visit-start-time-1"]').text()).toBe('10am')
-        expect($('[data-test="visit-end-time-1"]').text()).toBe('11:30am')
-
-        expect(visitService.getCancelledPublicVisits).toHaveBeenCalledWith(bookerReference)
-
-        expect(sessionData).toStrictEqual({
-          booker: {
-            reference: bookerReference,
-            prisoners: [prisoner],
-          },
-          bookingsCancelled: [cancelledVisitDto],
-        } as SessionData)
-      })
-  })
-
-  it('should render the cancelled visits page - with no cancelled visits', () => {
-    visitService.getCancelledPublicVisits.mockResolvedValue([])
-    return request(app)
-      .get(paths.BOOKINGS.CANCELLED)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Cancelled visits -/)
-        expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.HOME)
-        expect($('h1').text()).toBe('Cancelled visits')
-        expect($('[data-test="no-visits"]').text()).toBe('You do not have any cancelled bookings.')
+        expect($('[data-test="no-visits"]').length).toBeTruthy()
       })
   })
 })
 
 describe('Past visits page', () => {
+  const pastVisitDetails = TestData.visitDetails()
+
   it('should render the past visits page', () => {
-    visitService.getPastPublicVisits.mockResolvedValue([pastVisitDto])
+    visitService.getPastPublicVisits.mockResolvedValue([pastVisitDetails])
     return request(app)
       .get(paths.BOOKINGS.PAST)
       .expect('Content-Type', /html/)
@@ -133,18 +94,23 @@ describe('Past visits page', () => {
         expect($('title').text()).toMatch(/^Past visits -/)
         expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.HOME)
         expect($('h1').text()).toBe('Past visits')
-        expect($('[data-test="visit-date-1"]').text()).toBe('Tuesday 30 May 2023')
+
+        expect($('[data-test="visit-date-1"]').text()).toBe('Thursday 30 May 2024')
         expect($('[data-test="visit-start-time-1"]').text()).toBe('10am')
         expect($('[data-test="visit-end-time-1"]').text()).toBe('11:30am')
+        expect($('[data-test="visit-link-1"]').attr('href')).toBe(
+          `${paths.BOOKINGS.VISIT_PAST}/${pastVisitDetails.visitDisplayId}`,
+        )
+
+        expect($('[data-test="no-visits"]').length).toBeFalsy()
 
         expect(visitService.getPastPublicVisits).toHaveBeenCalledWith(bookerReference)
 
         expect(sessionData).toStrictEqual({
           booker: {
             reference: bookerReference,
-            prisoners: [prisoner],
           },
-          bookingsPast: [pastVisitDto],
+          bookingsPast: [pastVisitDetails],
         } as SessionData)
       })
   })
@@ -156,10 +122,55 @@ describe('Past visits page', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('title').text()).toMatch(/^Past visits -/)
+        expect($('[data-test="visit-date-1"]').length).toBeFalsy()
+        expect($('[data-test="no-visits"]').length).toBeTruthy()
+      })
+  })
+})
+
+describe('Cancelled visits page', () => {
+  const cancelledVisitDetails = TestData.visitDetails({ outcomeStatus: 'ESTABLISHMENT_CANCELLED' })
+
+  it('should render the cancelled visits page', () => {
+    visitService.getCancelledPublicVisits.mockResolvedValue([cancelledVisitDetails])
+    return request(app)
+      .get(paths.BOOKINGS.CANCELLED)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('title').text()).toMatch(/^Cancelled visits -/)
         expect($('[data-test="back-link"]').attr('href')).toBe(paths.BOOKINGS.HOME)
-        expect($('h1').text()).toBe('Past visits')
-        expect($('[data-test="no-visits"]').text()).toBe('You do not have any past bookings.')
+        expect($('h1').text()).toBe('Cancelled visits')
+
+        expect($('[data-test="visit-date-1"]').text()).toBe('Thursday 30 May 2024')
+        expect($('[data-test="visit-start-time-1"]').text()).toBe('10am')
+        expect($('[data-test="visit-end-time-1"]').text()).toBe('11:30am')
+        expect($('[data-test="visit-link-1"]').attr('href')).toBe(
+          `${paths.BOOKINGS.VISIT_CANCELLED}/${cancelledVisitDetails.visitDisplayId}`,
+        )
+
+        expect($('[data-test="no-visits"]').length).toBeFalsy()
+
+        expect(visitService.getCancelledPublicVisits).toHaveBeenCalledWith(bookerReference)
+
+        expect(sessionData).toStrictEqual({
+          booker: {
+            reference: bookerReference,
+          },
+          bookingsCancelled: [cancelledVisitDetails],
+        } as SessionData)
+      })
+  })
+
+  it('should render the cancelled visits page - with no cancelled visits', () => {
+    visitService.getCancelledPublicVisits.mockResolvedValue([])
+    return request(app)
+      .get(paths.BOOKINGS.CANCELLED)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="visit-date-1"]').length).toBeFalsy()
+        expect($('[data-test="no-visits"]').length).toBeTruthy()
       })
   })
 })

--- a/server/routes/bookings/index.ts
+++ b/server/routes/bookings/index.ts
@@ -16,24 +16,24 @@ export default function routes(services: Services): Router {
   const bookingsController = new BookingsController(services.visitService)
   const bookingDetailsController = new BookingDetailsController(services.bookerService)
 
-  get(paths.BOOKINGS.PAST, bookingsController.viewPast())
-  get(paths.BOOKINGS.CANCELLED, bookingsController.viewCancelled())
-  get(paths.BOOKINGS.HOME, bookingsController.viewFuture())
+  get(paths.BOOKINGS.HOME, bookingsController.view('future'))
+  get(paths.BOOKINGS.PAST, bookingsController.view('past'))
+  get(paths.BOOKINGS.CANCELLED, bookingsController.view('cancelled'))
 
   getWithValidation(
-    `${paths.BOOKINGS.VISIT}/:visitNumber`,
+    `${paths.BOOKINGS.VISIT}/:visitDisplayId`,
     bookingDetailsController.validate(),
-    bookingDetailsController.viewFuture(),
+    bookingDetailsController.view('future'),
   )
 
   getWithValidation(
-    `${paths.BOOKINGS.VISIT_PAST}/:visitNumber`,
+    `${paths.BOOKINGS.VISIT_PAST}/:visitDisplayId`,
     bookingDetailsController.validate(),
     bookingDetailsController.viewPast(),
   )
 
   getWithValidation(
-    `${paths.BOOKINGS.VISIT_CANCELLED}/:visitNumber`,
+    `${paths.BOOKINGS.VISIT_CANCELLED}/:visitDisplayId`,
     bookingDetailsController.validate(),
     bookingDetailsController.viewCancelled(),
   )

--- a/server/routes/bookings/index.ts
+++ b/server/routes/bookings/index.ts
@@ -29,13 +29,13 @@ export default function routes(services: Services): Router {
   getWithValidation(
     `${paths.BOOKINGS.VISIT_PAST}/:visitDisplayId`,
     bookingDetailsController.validate(),
-    bookingDetailsController.viewPast(),
+    bookingDetailsController.view('past'),
   )
 
   getWithValidation(
     `${paths.BOOKINGS.VISIT_CANCELLED}/:visitDisplayId`,
     bookingDetailsController.validate(),
-    bookingDetailsController.viewCancelled(),
+    bookingDetailsController.view('cancelled'),
   )
 
   return router

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -11,6 +11,7 @@ import type {
   VisitorInfoDto,
 } from '../../data/orchestrationApiTypes'
 import { Prisoner, Visitor } from '../../services/bookerService'
+import { VisitDetails } from '../../services/visitService'
 
 export default class TestData {
   static applicationDto = ({
@@ -89,6 +90,31 @@ export default class TestData {
     hasPhoneNumber = true,
   }: Partial<BookingConfirmed> = {}): BookingConfirmed => ({ prisonCode, prisonName, visitReference, hasPhoneNumber })
 
+  static orchestrationVisitDto = ({
+    reference = 'ab-cd-ef-gh',
+    prisonerId = 'A1234BC',
+    prisonId = 'DHI',
+    visitStatus = 'BOOKED',
+    outcomeStatus = undefined,
+    startTimestamp = '2024-05-30T10:00:00',
+    endTimestamp = '2024-05-30T11:30:00',
+    visitContact = { name: 'Joan Phillips', telephone: '01234 567890' },
+    visitors = [{ nomisPersonId: 1234, firstName: 'Keith', lastName: 'Phillips' }],
+    visitorSupport = { description: 'Wheelchair access requested' },
+  }: Partial<OrchestrationVisitDto> = {}): OrchestrationVisitDto =>
+    ({
+      reference,
+      prisonerId,
+      prisonId,
+      visitStatus,
+      outcomeStatus,
+      startTimestamp,
+      endTimestamp,
+      visitContact,
+      visitors,
+      visitorSupport,
+    }) as OrchestrationVisitDto
+
   static prisonDto = ({
     code = 'HEI',
     prisonName = 'Hewell (HMP)',
@@ -132,6 +158,32 @@ export default class TestData {
     prisonId,
     availableVos,
     nextAvailableVoDate,
+  })
+
+  static visitDetails = ({
+    visitDisplayId = 'uuidv4-1',
+    reference = 'ab-cd-ef-gh',
+    prisonerId = 'A1234BC',
+    prisonId = 'DHI',
+    visitStatus = 'BOOKED',
+    outcomeStatus = undefined,
+    startTimestamp = '2024-05-30T10:00:00',
+    endTimestamp = '2024-05-30T11:30:00',
+    visitContact = { name: 'Joan Phillips', telephone: '01234 567890' },
+    visitors = [{ nomisPersonId: 1234, firstName: 'Keith', lastName: 'Phillips' }],
+    visitorSupport = { description: 'Wheelchair access requested' },
+  }: Partial<VisitDetails> = {}): VisitDetails => ({
+    visitDisplayId,
+    reference,
+    prisonerId,
+    prisonId,
+    visitStatus,
+    outcomeStatus,
+    startTimestamp,
+    endTimestamp,
+    visitContact,
+    visitors,
+    visitorSupport,
   })
 
   static visitDto = ({
@@ -202,29 +254,4 @@ export default class TestData {
     visitorRestrictions,
     adult,
   })
-
-  static orchestrationVisitDto = ({
-    reference = 'ab-cd-ef-gh',
-    prisonerId = 'A1234BC',
-    prisonId = 'DHI',
-    visitStatus = 'BOOKED',
-    outcomeStatus = undefined,
-    startTimestamp = '2024-05-30T10:00:00',
-    endTimestamp = '2024-05-30T11:30:00',
-    visitContact = { name: 'Joan Phillips', telephone: '01234 567890' },
-    visitors = [{ nomisPersonId: 1234, firstName: 'Keith', lastName: 'Phillips' }],
-    visitorSupport = { description: 'Wheelchair access requested' },
-  }: Partial<OrchestrationVisitDto> = {}): OrchestrationVisitDto =>
-    ({
-      reference,
-      prisonerId,
-      prisonId,
-      visitStatus,
-      outcomeStatus,
-      startTimestamp,
-      endTimestamp,
-      visitContact,
-      visitors,
-      visitorSupport,
-    }) as OrchestrationVisitDto
 }

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -188,10 +188,7 @@ describe('Visit service', () => {
 
     describe('getPastPublicVisits', () => {
       it('should retrieve all past visits for a booker', async () => {
-        const pastVisit = TestData.orchestrationVisitDto({
-          startTimestamp: '2023-05-30T10:00:00',
-          endTimestamp: '2023-05-30T11:30:00',
-        })
+        const pastVisit = TestData.orchestrationVisitDto()
         const expectedVisitDetails = TestData.visitDetails({ ...pastVisit })
         orchestrationApiClient.getPastPublicVisits.mockResolvedValue([pastVisit])
 

--- a/server/views/pages/bookings/cancelled.njk
+++ b/server/views/pages/bookings/cancelled.njk
@@ -25,7 +25,7 @@
               <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
             </p>
             <p>
-              <a href="{{ paths.BOOKINGS.VISIT_CANCELLED }}/{{ loop.index }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
+              <a href="{{ paths.BOOKINGS.VISIT_CANCELLED }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
             </p>
           </div>
           

--- a/server/views/pages/bookings/future.njk
+++ b/server/views/pages/bookings/future.njk
@@ -24,20 +24,20 @@
             </p>
             <p>Booking reference: <span data-test="visit-reference-{{ loop.index }}">{{ visit.reference }}</span></p>  
             <p>
-              <a href="{{ paths.BOOKINGS.VISIT }}/{{ loop.index }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
+              <a href="{{ paths.BOOKINGS.VISIT }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
             </p>
           </div>
           
         {% endfor %}
 
-      <h2 class="govuk-heading-m">How to change your booking</h2>
-      <p>
-        To update or cancel your booking, call
-        <span data-test="prison-name">{{ prisonName }}</span>
-        on <span data-test="prison-phone-number">{{ prisonPhoneNumber }}</span>
-        between 9am and 5pm, Monday to Friday.
-      </p>
-      <p>You will need the booking reference to make changes.</p>
+        <h2 class="govuk-heading-m">How to change your booking</h2>
+        <p>
+          To update or cancel your booking, call
+          <span data-test="prison-name">{{ prisonName }}</span>
+          on <span data-test="prison-phone-number">{{ prisonPhoneNumber }}</span>
+          between 9am and 5pm, Monday to Friday.
+        </p>
+        <p>You will need the booking reference to make changes.</p>
 
       {% else %}
         <p data-test="no-visits">You do not have any future bookings.</p>

--- a/server/views/pages/bookings/future.njk
+++ b/server/views/pages/bookings/future.njk
@@ -30,7 +30,7 @@
           
         {% endfor %}
 
-        <h2 class="govuk-heading-m">How to change your booking</h2>
+        <h2 class="govuk-heading-m" data-test="change-booking-heading">How to change your booking</h2>
         <p>
           To update or cancel your booking, call
           <span data-test="prison-name">{{ prisonName }}</span>

--- a/server/views/pages/bookings/past.njk
+++ b/server/views/pages/bookings/past.njk
@@ -25,7 +25,7 @@
               <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
             </p>
             <p>
-              <a href="{{ paths.BOOKINGS.VISIT_PAST }}/{{ loop.index }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
+              <a href="{{ paths.BOOKINGS.VISIT_PAST }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
             </p>
           </div>
           

--- a/server/views/pages/bookings/visit.njk
+++ b/server/views/pages/bookings/visit.njk
@@ -5,16 +5,7 @@
 
 {% set pageTitle = "Visit booking details" %}
 
-{%- set backLinkHref -%}
-  {%- if fromController === 'future' -%}
-    {{- paths.BOOKINGS.HOME -}}
-  {%- elif fromController === 'past' -%}
-    {{- paths.BOOKINGS.PAST -}}
-  {%- elif fromController === 'cancelled' -%}
-    {{- paths.BOOKINGS.CANCELLED -}}
-  {%- endif -%}
-{%- endset -%}
-
+{% set backLinkHref = paths.BOOKINGS.PAST if type === 'past' else (paths.BOOKINGS.CANCELLED if type === 'cancelled' else paths.BOOKINGS.HOME) %}
 
 {% block content %}
 
@@ -27,16 +18,16 @@
       {% if visit.visitStatus === "CANCELLED" %}
 
         {% set status = visit.outcomeStatus %}
-            
+
         {% set cancelledBy %}
-          {% if status === 'VISITOR_CANCELLED' %}
-            {{- 'This visit was cancelled by a visitor.' -}}
-          {% elif status === 'PRISONER_CANCELLED' %}
-            {{- 'This visit was cancelled by the prisoner.' -}}
-          {% else %}
-            {{- 'This visit was cancelled by the prison.' -}}
-          {% endif %}
-        {% endset %}
+          {%- if status === 'VISITOR_CANCELLED' %}
+            {{- 'This visit was cancelled by a visitor.' }}
+          {%- elif status === 'PRISONER_CANCELLED' %}
+            {{- 'This visit was cancelled by the prisoner.' }}
+          {%- else %}
+            {{- 'This visit was cancelled by the prison.' }}
+          {%- endif %}
+        {%- endset %}
 
         {% set cancelledVisitBannerHtml %}
           {{ govukWarningText({
@@ -72,7 +63,7 @@
 
       <div class="bookings-content-block">
         {% for visitor in visit.visitors %}
-          <p data-test="visitor-name-{{ loop.index }}">{{ visitor.firstName }} {{ visitor.lastName }}
+          <p data-test="visitor-name-{{ loop.index }}">{{ visitor.firstName }} {{ visitor.lastName }}</p>
         {% endfor %}
       </div>
 
@@ -86,7 +77,7 @@
         <p data-test="main-contact-number">{{ visit.visitContact.telephone | d("No phone number provided", true) }}</p>
       </div>
 
-      {% if fromController === 'future' %}
+      {% if type === 'future' %}
         <h2 class="govuk-heading-m">How to change your booking</h2>
         <p>
           To update or cancel your booking, call


### PR DESCRIPTION
For bookings listing pages of future / past / cancelled visits, individual visits are referenced by a URL parameter. To avoid using the actual visit reference, this was previously just a sequential integer.

This change is to instead use a UUID as a URL parameter to reference a temporary cache of visits in the session.

Additionally, refactoring of controllers for booking listings and booking details to remove duplication.