### PR TITLE
VB-4536 - Remove h2 from cancelled visits and past visits page in public service

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,11 +1,3 @@
 .govuk-main-wrapper {
   min-height: 300px;
 }
-
-.bookings-content-block > p, .bookings-content-block > h3 {
-  margin-bottom: govuk-spacing(1);
-}
-.bookings-content-block {
-  margin-top: govuk-spacing(4);
-  margin-bottom: govuk-spacing(6);
-}

--- a/server/views/pages/bookings/cancelled.njk
+++ b/server/views/pages/bookings/cancelled.njk
@@ -13,8 +13,6 @@
 
       <p>Only bookings made using GOV.UK One Login are shown.</p>
 
-      <h2 class="govuk-heading-m">{{ pageTitle }}</h2>
-
       {% if visits | length %}
         {% for visit in visits %}
           <div class="bookings-content-block">

--- a/server/views/pages/bookings/cancelled.njk
+++ b/server/views/pages/bookings/cancelled.njk
@@ -15,18 +15,15 @@
 
       {% if visits | length %}
         {% for visit in visits %}
-          <div class="bookings-content-block">
-            <h3 class="govuk-heading-s" data-test="visit-date-{{ loop.index }}">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</h3>
-            <p>
-              <span data-test="visit-start-time-{{ loop.index }}">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
-              to
-              <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
-            </p>
-            <p>
-              <a href="{{ paths.BOOKINGS.VISIT_CANCELLED }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
-            </p>
-          </div>
-          
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1" data-test="visit-date-{{ loop.index }}">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</h2>
+          <p class="govuk-!-margin-bottom-1">
+            <span data-test="visit-start-time-{{ loop.index }}">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
+            to
+            <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
+          </p>
+          <p>
+            <a href="{{ paths.BOOKINGS.VISIT_CANCELLED }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
+          </p>
         {% endfor %}
 
       {% else %}

--- a/server/views/pages/bookings/future.njk
+++ b/server/views/pages/bookings/future.njk
@@ -15,19 +15,18 @@
 
       {% if visits | length %}
         {% for visit in visits %}
-          <div class="bookings-content-block">
-            <h3 class="govuk-heading-s" data-test="visit-date-{{ loop.index }}">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</h3>
-            <p>
-              <span data-test="visit-start-time-{{ loop.index }}">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
-              to
-              <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
-            </p>
-            <p>Booking reference: <span data-test="visit-reference-{{ loop.index }}">{{ visit.reference }}</span></p>  
-            <p>
-              <a href="{{ paths.BOOKINGS.VISIT }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
-            </p>
-          </div>
-          
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1" data-test="visit-date-{{ loop.index }}">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</h3>
+          <p class="govuk-!-margin-bottom-1">
+            <span data-test="visit-start-time-{{ loop.index }}">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
+            to
+            <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
+          </p>
+          <p class="govuk-!-margin-bottom-1">
+            Booking reference: <span data-test="visit-reference-{{ loop.index }}">{{ visit.reference }}</span>
+          </p>
+          <p>
+            <a href="{{ paths.BOOKINGS.VISIT }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
+          </p>
         {% endfor %}
 
         <h2 class="govuk-heading-m" data-test="change-booking-heading">How to change your booking</h2>

--- a/server/views/pages/bookings/past.njk
+++ b/server/views/pages/bookings/past.njk
@@ -15,18 +15,15 @@
 
       {% if visits | length %}
         {% for visit in visits %}
-          <div class="bookings-content-block">
-            <h3 class="govuk-heading-s" data-test="visit-date-{{ loop.index }}">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</h3>
-            <p>
-              <span data-test="visit-start-time-{{ loop.index }}">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
-              to
-              <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
-            </p>
-            <p>
-              <a href="{{ paths.BOOKINGS.VISIT_PAST }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
-            </p>
-          </div>
-          
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1" data-test="visit-date-{{ loop.index }}">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</h2>
+          <p class="govuk-!-margin-bottom-1">
+            <span data-test="visit-start-time-{{ loop.index }}">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
+            to
+            <span data-test="visit-end-time-{{ loop.index }}">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
+          </p>
+          <p>
+            <a href="{{ paths.BOOKINGS.VISIT_PAST }}/{{ visit.visitDisplayId }}" class="govuk-link--no-visited-state" data-test="visit-link-{{ loop.index }}">View booking details</a>
+          </p>
         {% endfor %}
 
       {% else %}

--- a/server/views/pages/bookings/past.njk
+++ b/server/views/pages/bookings/past.njk
@@ -13,8 +13,6 @@
 
       <p>Only bookings made using GOV.UK One Login are shown.</p>
 
-      <h2 class="govuk-heading-m">{{ pageTitle }}</h2>
-
       {% if visits | length %}
         {% for visit in visits %}
           <div class="bookings-content-block">

--- a/server/views/pages/bookings/visit.njk
+++ b/server/views/pages/bookings/visit.njk
@@ -46,14 +46,12 @@
 
       <h2 class="govuk-heading-m">Date and time</h2>
 
-      <div class="bookings-content-block">
-        <p data-test="visit-date">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</p>
-        <p>
-          <span data-test="visit-start-time">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
-          to
-          <span data-test="visit-end-time">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
-        </p>
-      </div>
+      <p class="govuk-!-margin-bottom-1" data-test="visit-date">{{ visit.startTimestamp | formatDate(dateFormats.PRETTY_DATE) }}</p>
+      <p>
+        <span data-test="visit-start-time">{{ visit.startTimestamp | formatTimeFromDateTime }}</span>
+        to
+        <span data-test="visit-end-time">{{ visit.endTimestamp | formatTimeFromDateTime }}</span>
+      </p>
 
       <h2 class="govuk-heading-m">Prisoner</h2>
 
@@ -61,21 +59,17 @@
 
       <h2 class="govuk-heading-m">Visitors</h2>
 
-      <div class="bookings-content-block">
-        {% for visitor in visit.visitors %}
-          <p data-test="visitor-name-{{ loop.index }}">{{ visitor.firstName }} {{ visitor.lastName }}</p>
-        {% endfor %}
-      </div>
+      {% for visitor in visit.visitors %}
+        <p class="govuk-!-margin-bottom-1" data-test="visitor-name-{{ loop.index }}">{{ visitor.firstName }} {{ visitor.lastName }}</p>
+      {% endfor %}
 
       <h2 class="govuk-heading-m">Additional support requests</h2>
 
       <p data-test="additional-support">{{ visit.visitorSupport.description | d("None", true) }}</p>
       
       <h2 class="govuk-heading-m">Main contact</h2>
-      <div class="bookings-content-block">
-        <p data-test="main-contact-name">{{ visit.visitContact.name }}</p>
-        <p data-test="main-contact-number">{{ visit.visitContact.telephone | d("No phone number provided", true) }}</p>
-      </div>
+      <p class="govuk-!-margin-bottom-1" data-test="main-contact-name">{{ visit.visitContact.name }}</p>
+      <p data-test="main-contact-number">{{ visit.visitContact.telephone | d("No phone number provided", true) }}</p>
 
       {% if type === 'future' %}
         <h2 class="govuk-heading-m">How to change your booking</h2>


### PR DESCRIPTION
Updated pages to remove the H2 that were not in the original designs.