### PR TITLE
Hide cancel visit button when visit is already cancelled

### DIFF
--- a/server/routes/bookings/bookingDetailsController.test.ts
+++ b/server/routes/bookings/bookingDetailsController.test.ts
@@ -46,6 +46,16 @@ afterEach(() => {
 
 describe('View a single booking', () => {
   describe('Future booking', () => {
+    const fakeDate = new Date('2024-05-28')
+
+    beforeEach(() => {
+      jest.useFakeTimers({ advanceTimers: true, now: fakeDate })
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+      jest.useRealTimers()
+    })
     it('should render the booking details page', () => {
       bookings.type = 'future'
 
@@ -74,6 +84,9 @@ describe('View a single booking', () => {
           expect($('[data-test="prison-website"]').attr('href')).toBe(prison.webAddress)
           expect($('[data-test=no-prison-phone-number]').length).toBeFalsy()
           expect($('[data-test="booking-reference-changes"]').text()).toBe('ab-cd-ef-gh')
+
+          expect($('[data-test="cancel-visit"]').text()).toContain('Cancel booking')
+          expect($('[data-test="cancel-visit"]').attr('href')).toBe(`/bookings/cancel-booking/${visitDisplayId}`)
 
           expect(bookerService.getPrisoners).not.toHaveBeenCalled()
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)
@@ -117,6 +130,9 @@ describe('View a single booking', () => {
           expect($('[data-test="prison-website"]').length).toBeFalsy()
           expect($('[data-test="booking-reference-changes"]').length).toBeFalsy()
 
+          expect($('[data-test="cancel-visit"]').text()).toBeFalsy()
+          expect($('[data-test="cancel-visit"]').attr('href')).toBeFalsy()
+
           expect(bookerService.getPrisoners).not.toHaveBeenCalled()
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)
         })
@@ -146,6 +162,9 @@ describe('View a single booking', () => {
           expect($('[data-test="minutes-before-visit"]').length).toBeFalsy()
           expect($('[data-test="prison-website"]').length).toBeFalsy()
           expect($('[data-test="booking-reference-changes"]').length).toBeFalsy()
+
+          expect($('[data-test="cancel-visit"]').text()).toBeFalsy()
+          expect($('[data-test="cancel-visit"]').attr('href')).toBeFalsy()
 
           expect(bookerService.getPrisoners).not.toHaveBeenCalled()
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)

--- a/server/routes/bookings/bookingDetailsController.test.ts
+++ b/server/routes/bookings/bookingDetailsController.test.ts
@@ -73,6 +73,7 @@ describe('View a single booking', () => {
           expect($('[data-test="minutes-before-visit"]').text()).toBe('45')
           expect($('[data-test="prison-website"]').attr('href')).toBe(prison.webAddress)
           expect($('[data-test=no-prison-phone-number]').length).toBeFalsy()
+          expect($('[data-test="booking-reference-changes"]').text()).toBe('ab-cd-ef-gh')
 
           expect(bookerService.getPrisoners).not.toHaveBeenCalled()
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)
@@ -114,6 +115,7 @@ describe('View a single booking', () => {
           expect($('[data-test="prison-phone-number"]').length).toBeFalsy()
           expect($('[data-test="minutes-before-visit"]').length).toBeFalsy()
           expect($('[data-test="prison-website"]').length).toBeFalsy()
+          expect($('[data-test="booking-reference-changes"]').length).toBeFalsy()
 
           expect(bookerService.getPrisoners).not.toHaveBeenCalled()
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)
@@ -143,6 +145,7 @@ describe('View a single booking', () => {
           expect($('[data-test="prison-phone-number"]').length).toBeFalsy()
           expect($('[data-test="minutes-before-visit"]').length).toBeFalsy()
           expect($('[data-test="prison-website"]').length).toBeFalsy()
+          expect($('[data-test="booking-reference-changes"]').length).toBeFalsy()
 
           expect(bookerService.getPrisoners).not.toHaveBeenCalled()
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)

--- a/server/routes/bookings/bookingDetailsController.ts
+++ b/server/routes/bookings/bookingDetailsController.ts
@@ -32,7 +32,7 @@ export default class BookingDetailsController {
 
       const nowTimestamp = new Date()
       const visitStartTimestamp = new Date(visit.startTimestamp)
-      const showCancel = nowTimestamp < visitStartTimestamp
+      const showCancel = nowTimestamp < visitStartTimestamp && visit.visitStatus !== 'CANCELLED'
 
       return res.render('pages/bookings/visit', {
         booker,

--- a/server/views/partials/howToChangeBooking.njk
+++ b/server/views/partials/howToChangeBooking.njk
@@ -1,4 +1,10 @@
 <h2 class="govuk-heading-m" data-test="change-booking-heading">How to change your booking</h2>
+{% set visitRef = '' %}
+{% if bookingConfirmed.visitReference %}
+  {% set visitRef = bookingConfirmed.visitReference %}
+{% elif visit.reference %}
+  {% set visitRef = visit.reference %}
+{% endif %}
 
 {% if prison.phoneNumber %}
   <p>
@@ -14,6 +20,6 @@
   </p>
 {% endif %}
 
-<p>You will need the booking reference to make changes. Your booking reference is <span data-test="booking-reference-changes">{{ bookingConfirmed.visitReference }}</span>.</p>
+<p>You will need the booking reference to make changes. {% if visitRef !== '' %}Your booking reference is <span data-test="booking-reference-changes">{{ visitRef }}</span>.{% endif %}</p>
 
 <p data-test="cancel-visit-content">Or you can cancel your booking from <a class="govuk-link--no-visited-state" href="{{ paths.BOOKINGS.HOME }}">the bookings page</a>.</p>

--- a/server/views/partials/howToChangeBooking.njk
+++ b/server/views/partials/howToChangeBooking.njk
@@ -1,10 +1,5 @@
 <h2 class="govuk-heading-m" data-test="change-booking-heading">How to change your booking</h2>
-{% set visitRef = '' %}
-{% if bookingConfirmed.visitReference %}
-  {% set visitRef = bookingConfirmed.visitReference %}
-{% elif visit.reference %}
-  {% set visitRef = visit.reference %}
-{% endif %}
+{% set visitRef = bookingConfirmed.visitReference if bookingConfirmed.visitReference else visit.reference %}
 
 {% if prison.phoneNumber %}
   <p>
@@ -20,6 +15,6 @@
   </p>
 {% endif %}
 
-<p>You will need the booking reference to make changes. {% if visitRef !== '' %}Your booking reference is <span data-test="booking-reference-changes">{{ visitRef }}</span>.{% endif %}</p>
+<p>You will need the booking reference to make changes. {% if visitRef %}Your booking reference is <span data-test="booking-reference-changes">{{ visitRef }}</span>.{% endif %}</p>
 
 <p data-test="cancel-visit-content">Or you can cancel your booking from <a class="govuk-link--no-visited-state" href="{{ paths.BOOKINGS.HOME }}">the bookings page</a>.</p>


### PR DESCRIPTION
Hide cancel visit button when visit is already cancelled
(Visits in the past already don't display the button)

Fix logic on the howToChangeBooking import, to deal with 'visit details page' and the 'future visits list page'
Both of these don't have the 'bookingConfirmed' object, so this PR deals with the different available visit references, and outputs them IF that line should be displayed