### PR TITLE
VB-4524 Add service navigation when user not signed in

### DIFF
--- a/server/routes/unauthenticatedRoutes.test.ts
+++ b/server/routes/unauthenticatedRoutes.test.ts
@@ -64,7 +64,7 @@ describe('Accessibility statement', () => {
 
         expect($('header.govuk-header').length).toBe(1)
         expect($('header .one-login-header').length).toBe(0)
-        expect($('.govuk-header__content').text().trim()).toBe('Visit someone in prison')
+        expect($('.govuk-service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
       })
   })
 })
@@ -122,7 +122,7 @@ describe('Privacy notice', () => {
 
         expect($('header.govuk-header').length).toBe(1)
         expect($('header .one-login-header').length).toBe(0)
-        expect($('.govuk-header__content').text().trim()).toBe('Visit someone in prison')
+        expect($('.govuk-service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
       })
   })
 })
@@ -143,7 +143,7 @@ describe('Signed out', () => {
 
         expect($('header.govuk-header').length).toBe(1)
         expect($('header .one-login-header').length).toBe(0)
-        expect($('.govuk-header__content').text().trim()).toBe('Visit someone in prison')
+        expect($('.govuk-service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
       })
   })
 })
@@ -201,7 +201,7 @@ describe('Terms and conditions', () => {
 
         expect($('header.govuk-header').length).toBe(1)
         expect($('header .one-login-header').length).toBe(0)
-        expect($('.govuk-header__content').text().trim()).toBe('Visit someone in prison')
+        expect($('.govuk-service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
       })
   })
 })

--- a/server/views/authError.test.ts
+++ b/server/views/authError.test.ts
@@ -13,7 +13,7 @@ describe('Authorisation error page', () => {
 
       expect($('header.govuk-header').length).toBe(1)
       expect($('header .one-login-header').length).toBe(0)
-      expect($('.service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
+      expect($('.govuk-service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
       expect($('h1').text().trim()).toBe('Sorry, there is a problem with the service')
     })
   })

--- a/server/views/authError.test.ts
+++ b/server/views/authError.test.ts
@@ -13,7 +13,7 @@ describe('Authorisation error page', () => {
 
       expect($('header.govuk-header').length).toBe(1)
       expect($('header .one-login-header').length).toBe(0)
-      expect($('.govuk-header__content').text().trim()).toBe('Visit someone in prison')
+      expect($('.service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
       expect($('h1').text().trim()).toBe('Sorry, there is a problem with the service')
     })
   })

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../components/one_login_header/service-header.njk" import govukOneLoginServiceHeader %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% set navigationItems = [
@@ -70,7 +71,11 @@
   }) }}
 {% else %}
   {{ govukHeader({
-    homepageUrl: "/",
+    homepageUrl: "https://www.gov.uk",
+    containerClasses: "govuk-width-container",
+    classes: "govuk-header--full-width-border"
+  }) }}
+  {{ govukServiceNavigation({
     serviceName: applicationName,
     serviceUrl: "/"
   }) }}


### PR DESCRIPTION
We need to implement the new “service navigation” component alongside the new simplified GOV.UK Header component in the public service.

[Service navigation – GOV.UK Design System (design-system.service.gov.uk)](https://design-system.service.gov.uk/components/service-navigation/)

[GOV.UK header – GOV.UK Design System (design-system.service.gov.uk)](https://design-system.service.gov.uk/components/header/)

We also need to move elements currently in the Header component into the new “Service navigation” component. 

GDS will retire the ‘old’ Header in a future break changes version of the Design System.

---
There are some pages in the new public service that we need to update - particularly if they are being viewed by users who are NOT signed in to the service. These are:

* cookies page
* terms and conditions page
* accessibility page
* privacy policy page
