### PR TITLE
Removed reference to cancelling

### DIFF
--- a/server/views/partials/howToChangeBooking.njk
+++ b/server/views/partials/howToChangeBooking.njk
@@ -3,14 +3,14 @@
 
 {% if prison.phoneNumber %}
   <p>
-    To update or cancel your booking, call
+    To update your booking, call
     <span data-test="prison-name">{{ prison.prisonName }}</span>
     on <span data-test="prison-phone-number">{{ prison.phoneNumber }}</span>
     between 9am and 5pm, Monday to Friday.
   </p>
 {% else %}
   <p data-test="no-prison-phone-number">
-    To update or cancel your booking,
+    To update your booking,
     <a href="{{ prison.webAddress }}" target="_blank">contact {{ prison.prisonName }} directly</a>.
   </p>
 {% endif %}


### PR DESCRIPTION
Cancellations can now be done in the service so no need to refer bookers to other journeys to cancel a visit.