### PR TITLE
VB-4907 Improve handling of authentication errors

### DIFF
--- a/integration_tests/e2e/govukOneLogin.cy.ts
+++ b/integration_tests/e2e/govukOneLogin.cy.ts
@@ -21,7 +21,12 @@ context('Sign in with GOV.UK One Login', () => {
   })
 
   it('Unauthenticated user redirected to GOV.UK One Login - callback URL', () => {
-    cy.visit('/auth/callback')
+    cy.visit(paths.AUTH_CALLBACK)
+    Page.verifyOnPage(GovukOneLoginPage)
+  })
+
+  it('Unauthenticated user redirected to GOV.UK One Login - callback URL with unrecognised/expired parameters', () => {
+    cy.visit(`${paths.AUTH_CALLBACK}?code=INVALID_AUTHORIZATION_CODE&state=INVALID-STATE`)
     Page.verifyOnPage(GovukOneLoginPage)
   })
 

--- a/integration_tests/mockApis/govukOneLogin.ts
+++ b/integration_tests/mockApis/govukOneLogin.ts
@@ -3,6 +3,7 @@ import jwt, { JwtPayload } from 'jsonwebtoken'
 import { Response } from 'superagent'
 import { createPublicKey } from 'crypto'
 import { getMatchingRequests, stubFor } from './wiremock'
+import paths from '../../server/constants/paths'
 
 let idToken: string
 
@@ -41,8 +42,7 @@ const redirect = () =>
         scope: { equalTo: 'openid email phone' },
         client_id: { equalTo: 'clientId' },
         state: { matches: '.*' },
-        redirect_uri: { equalTo: 'http://localhost:3007/auth/callback' },
-        nonce: { matches: '.*' },
+        redirect_uri: { equalTo: `http://localhost:3007${paths.AUTH_CALLBACK}` },
         vtr: { equalTo: '["Cl.Cm"]' },
         ui_locales: { equalTo: 'en' },
       },
@@ -65,7 +65,7 @@ const getSignInUrl = (nonce?: string): Promise<string> =>
     const stateValue = requests[requests.length - 1].queryParams.state.values[0]
     const nonceForToken = nonce || requests[requests.length - 1].queryParams.nonce.values[0]
     // set up /token response while we have access to the nonce
-    return token(nonceForToken).then(() => `/auth/callback?code=AUTHORIZATION_CODE&state=${stateValue}`)
+    return token(nonceForToken).then(() => `${paths.AUTH_CALLBACK}?code=AUTHORIZATION_CODE&state=${stateValue}`)
   })
 
 const createIdToken = (nonce: string) => {
@@ -98,7 +98,7 @@ const token = (nonce: string) => {
       formParameters: {
         grant_type: { equalTo: 'authorization_code' },
         code: { equalTo: 'AUTHORIZATION_CODE' },
-        redirect_uri: { equalTo: 'http://localhost:3007/auth/callback' },
+        redirect_uri: { equalTo: `http://localhost:3007${paths.AUTH_CALLBACK}` },
         client_assertion_type: { equalTo: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' },
         client_assertion: { matches: '.*' },
       },

--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -46,7 +46,7 @@ async function init(): Promise<{ client: Client; idTokenStore: TokenStore }> {
   const client = new issuer.Client(
     {
       client_id: config.apis.govukOneLogin.clientId,
-      redirect_uris: [`${config.domain}/auth/callback`],
+      redirect_uris: [`${config.domain}${paths.AUTH_CALLBACK}`],
       response_types: ['code'],
       token_endpoint_auth_method: 'private_key_jwt',
       token_endpoint_auth_signing_alg: 'RS256',

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -3,6 +3,8 @@ const paths = {
   RETURN_HOME: '/return-home', // used to clear session and redirect to HOME
 
   ACCESS_DENIED: '/access-denied',
+  AUTH_CALLBACK: '/auth/callback',
+  AUTH_ERROR: '/auth-error',
   SIGN_IN: '/sign-in',
   SIGN_OUT: '/sign-out',
   SIGNED_OUT: '/signed-out',


### PR DESCRIPTION
Calls to `passport.authenticate()` in the `/auth/callback` route can fail if, for example, multiple attempts are made with the same parameters (`code, state`), or, if expired ones are used. Evidence in logs of this happening to users, possibly from, e.g. returning to stale browser tabs.

This change adds a callback to handle the response (whether successful or not) for `passport.authenticate()`. This means that errors in the authentication flow can be logged and handled appropriately by redirecting the user to either the sign-in or authentication error page. Previously errors would just trigger the default error handler resulting in an `HTTP 500` response with a default server error page.

(Similar approach to that used in a few other projects, e.g. https://github.com/ministryofjustice/hmpps-prisoner-profile/blob/34bc9a3e5b84011267e9d09c74d21ddd9be501b3/server/middleware/setUpAuthentication.ts#L32)