### PR TITLE
VB-4362 Refactor cannot book page to handle different scenarios

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -12,6 +12,9 @@ export type BookingJourney = {
   // selected prisoner for this visit
   prisoner: Prisoner
 
+  // may be set during journey to flag why a visit cannot be booked
+  cannotBookReason?: CannotBookReason
+
   // prison for this visit
   prison?: PrisonDto
 
@@ -56,3 +59,5 @@ export type BookingCancelled = {
   hasEmail: boolean
   hasMobile: boolean
 }
+
+export type CannotBookReason = 'NO_VO_BALANCE'

--- a/server/middleware/bookVisitSessionValidator.test.ts
+++ b/server/middleware/bookVisitSessionValidator.test.ts
@@ -83,7 +83,7 @@ describe('bookVisitSessionValidator', () => {
       })
     })
 
-    describe('bookingJourney data:', () => {
+    describe('bookingJourney data', () => {
       describe('no data', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
@@ -100,7 +100,7 @@ describe('bookVisitSessionValidator', () => {
       describe('prisoner', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'redirect' },
@@ -114,7 +114,7 @@ describe('bookVisitSessionValidator', () => {
       describe('...add prison and eligibleVisitors', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'redirect' },
@@ -133,7 +133,7 @@ describe('bookVisitSessionValidator', () => {
       describe('...add selectedVisitors and sessionRestriction', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
@@ -159,7 +159,7 @@ describe('bookVisitSessionValidator', () => {
       describe('...add allVisitSessionIds and allVisitSessions', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
@@ -188,7 +188,7 @@ describe('bookVisitSessionValidator', () => {
       describe('...add selectedVisitSession and applicationReference', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
@@ -221,7 +221,7 @@ describe('bookVisitSessionValidator', () => {
       describe('...add visitorSupport', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
@@ -262,7 +262,7 @@ describe('bookVisitSessionValidator', () => {
       describe('...add mainContact', () => {
         it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_PRISONER, expected: 'next' },
-          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
           { method: 'GET', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'POST', path: paths.BOOK_VISIT.SELECT_VISITORS, expected: 'next' },
           { method: 'GET', path: paths.BOOK_VISIT.CLOSED_VISIT, expected: 'next' },
@@ -294,6 +294,28 @@ describe('bookVisitSessionValidator', () => {
               mainContact,
             },
           })
+          bookVisitSessionValidator()(req, res, next)
+          runAssertions(expected)
+        })
+      })
+    })
+
+    describe('bookingJourney data - cannotBook', () => {
+      describe('cannotBookReason set', () => {
+        it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'next' },
+        ])('$method $path should call $expected', ({ method, path, expected }) => {
+          req = createMockReq({ method, path, bookingJourney: { prisoner, cannotBookReason: 'NO_VO_BALANCE' } })
+          bookVisitSessionValidator()(req, res, next)
+          runAssertions(expected)
+        })
+      })
+
+      describe('cannotBookReason NOT set', () => {
+        it.each(<{ method: Method; path: string; expected: 'next' | 'redirect' }[]>[
+          { method: 'GET', path: paths.BOOK_VISIT.CANNOT_BOOK, expected: 'redirect' },
+        ])('$method $path should call $expected', ({ method, path, expected }) => {
+          req = createMockReq({ method, path, bookingJourney: { prisoner } })
           bookVisitSessionValidator()(req, res, next)
           runAssertions(expected)
         })

--- a/server/middleware/bookVisitSessionValidator.ts
+++ b/server/middleware/bookVisitSessionValidator.ts
@@ -39,8 +39,13 @@ export default function bookVisitSessionValidator(): RequestHandler {
       return bookingConfirmed && !bookingJourney ? next() : logAndRedirect(res, method, requestPath, booker.reference)
     }
 
-    // Select visitors / Cannot book page
-    if (journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.CANNOT_BOOK) && !bookingJourney?.prisoner) {
+    // Cannot book page - requires reason to be set
+    if (requestPath === paths.BOOK_VISIT.CANNOT_BOOK) {
+      return bookingJourney?.cannotBookReason ? next() : logAndRedirect(res, method, requestPath, booker.reference)
+    }
+
+    // Select visitors
+    if (journeyStage >= journeyOrder.indexOf(paths.BOOK_VISIT.SELECT_VISITORS) && !bookingJourney?.prisoner) {
       return logAndRedirect(res, method, requestPath, booker.reference)
     }
 

--- a/server/routes/bookVisit/cannotBookController.test.ts
+++ b/server/routes/bookVisit/cannotBookController.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('A visit cannot be booked (no VOs)', () => {
+describe('A visit cannot be booked', () => {
   describe(`GET ${paths.BOOK_VISIT.CANNOT_BOOK}`, () => {
     beforeEach(() => {
       sessionData = {
@@ -28,14 +28,17 @@ describe('A visit cannot be booked (no VOs)', () => {
           reference: bookerReference,
           prisoners: [prisonerWithoutVOs],
         },
-        bookingJourney: { prisoner: prisonerWithoutVOs },
+        bookingJourney: {
+          prisoner: prisonerWithoutVOs,
+          cannotBookReason: 'NO_VO_BALANCE',
+        },
       } as SessionData
 
       app = appWithAllRoutes({ sessionData })
     })
 
     it('should use the session validation middleware', () => {
-      sessionData.bookingJourney.prisoner = undefined
+      sessionData.bookingJourney.cannotBookReason = undefined
 
       return request(app)
         .get(paths.BOOK_VISIT.CANNOT_BOOK)
@@ -46,7 +49,7 @@ describe('A visit cannot be booked (no VOs)', () => {
         })
     })
 
-    it('should render drop-out page if the selected prisoner has no VOs and clear bookingJourney data', () => {
+    it('should render cannot book page and clear bookingJourney data - NO_VO_BALANCE', () => {
       return request(app)
         .get(paths.BOOK_VISIT.CANNOT_BOOK)
         .expect('Content-Type', /html/)

--- a/server/routes/bookVisit/cannotBookController.ts
+++ b/server/routes/bookVisit/cannotBookController.ts
@@ -6,10 +6,10 @@ export default class CannotBookController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const { prisoner } = req.session.bookingJourney
+      const { prisoner, cannotBookReason } = req.session.bookingJourney
       clearSession(req)
 
-      return res.render('pages/bookVisit/cannotBook', { prisoner })
+      return res.render('pages/bookVisit/cannotBook', { prisoner, cannotBookReason })
     }
   }
 }

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -235,6 +235,7 @@ describe('Check visit details', () => {
             .expect(() => {
               expect(flashProvider).not.toHaveBeenCalled()
               expect(sessionData.bookingJourney).not.toBe(undefined)
+              expect(sessionData.bookingJourney.cannotBookReason).toBe('NO_VO_BALANCE')
               expect(sessionData.bookingConfirmed).toBe(undefined)
               expect(visitService.bookVisit).toHaveBeenCalledWith({
                 applicationReference: application.reference,

--- a/server/routes/bookVisit/checkVisitDetailsController.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.ts
@@ -59,6 +59,7 @@ export default class CheckVisitDetailsController {
           }
 
           if (validationErrors.includes('APPLICATION_INVALID_NO_VO_BALANCE')) {
+            bookingJourney.cannotBookReason = 'NO_VO_BALANCE'
             return res.redirect(paths.BOOK_VISIT.CANNOT_BOOK)
           }
 

--- a/server/routes/bookVisit/selectPrisonerController.test.ts
+++ b/server/routes/bookVisit/selectPrisonerController.test.ts
@@ -109,6 +109,7 @@ describe('Select prisoner', () => {
           },
           bookingJourney: {
             prisoner: prisonerWithNoVos,
+            cannotBookReason: 'NO_VO_BALANCE',
           },
         } as SessionData)
       })

--- a/server/routes/bookVisit/selectPrisonerController.ts
+++ b/server/routes/bookVisit/selectPrisonerController.ts
@@ -20,6 +20,7 @@ export default class SelectPrisonerController {
       req.session.bookingJourney = { prisoner }
 
       if (prisoner.availableVos <= 0) {
+        req.session.bookingJourney.cannotBookReason = 'NO_VO_BALANCE'
         return res.redirect(paths.BOOK_VISIT.CANNOT_BOOK)
       }
 

--- a/server/views/pages/bookVisit/cannotBook.njk
+++ b/server/views/pages/bookVisit/cannotBook.njk
@@ -10,15 +10,17 @@
 
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
-      <p>
-        <span data-test="prisoner-name">{{ prisoner.firstName | capitalize }} {{ prisoner.lastName | capitalize }}</span>
-        has used their allowance of visits for this month.
-      </p>
+      {% if cannotBookReason == 'NO_VO_BALANCE' %}
+        <p>
+          <span data-test="prisoner-name">{{ prisoner.firstName | capitalize }} {{ prisoner.lastName | capitalize }}</span>
+          has used their allowance of visits for this month.
+        </p>
 
-      <p>
-        You can book a visit from
-        <span data-test="book-from-date">{{ prisoner.nextAvailableVoDate | formatDate(dateFormats.PRETTY_DATE) }}</span>.
-      </p>
+        <p>
+          You can book a visit from
+          <span data-test="book-from-date">{{ prisoner.nextAvailableVoDate | formatDate(dateFormats.PRETTY_DATE) }}</span>.
+        </p>
+      {% endif %}
 
     </div>
   </div>


### PR DESCRIPTION
Refactor the 'A visit cannot be booked page' and associated controller/middleware to work with an extensible set of `CannotBookReason` values - initially just `NO_VO_BALANCE` supported.