### PR TITLE
VB-4362 Redirect to Cannot book page if prisoner has been transferred/released

### DIFF
--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -98,6 +98,7 @@ context('Booking journey', () => {
     // Start booking journey
     cy.task('stubGetPrison', prison)
     cy.task('stubGetVisitors', { visitors })
+    cy.task('stubValidatePrisonerPass')
     homePage.startBooking()
 
     // Select visitors page - choose visitors
@@ -198,6 +199,7 @@ context('Booking journey', () => {
     // Start booking journey
     cy.task('stubGetPrison', prison)
     cy.task('stubGetVisitors', { visitors })
+    cy.task('stubValidatePrisonerPass')
     homePage.startBooking()
 
     // Select visitors page - choose visitors

--- a/integration_tests/e2e/bookingJourneyDropOuts.cy.ts
+++ b/integration_tests/e2e/bookingJourneyDropOuts.cy.ts
@@ -51,6 +51,7 @@ context('Booking journey - drop-out points', () => {
       // Start booking journey
       cy.task('stubGetPrison', prison)
       cy.task('stubGetVisitors', { visitors })
+      cy.task('stubValidatePrisonerPass')
       homePage.startBooking()
 
       // Select visitors page - choose visitors
@@ -87,6 +88,7 @@ context('Booking journey - drop-out points', () => {
       // Start booking journey
       cy.task('stubGetPrison', prison)
       cy.task('stubGetVisitors', { visitors })
+      cy.task('stubValidatePrisonerPass')
       homePage.startBooking()
 
       // Select visitors page - choose visitors
@@ -137,12 +139,41 @@ context('Booking journey - drop-out points', () => {
       // Start booking journey
       cy.task('stubGetPrison', prison)
       cy.task('stubGetVisitors', { visitors })
+      cy.task('stubValidatePrisonerPass')
       homePage.startBooking()
 
       // Visit cannot be booked page
       const cannotBookPage = Page.verifyOnPage(CannotBookPage)
       cannotBookPage.getPrisonerName().contains('John Smith')
+      cy.contains('has used their allowance of visits')
       cannotBookPage.getBookFromDate().contains(format(in10Days, DateFormats.PRETTY_DATE))
+
+      // Back link back to Home page
+      cannotBookPage.backLink().click()
+      Page.verifyOnPage(HomePage)
+    })
+
+    it('should show drop-out page when prisoner has been released', () => {
+      const prisonerWithoutVOs = TestData.bookerPrisonerInfoDto({ availableVos: 0, nextAvailableVoDate: in10Days })
+
+      cy.task('stubGetBookerReference')
+      cy.task('stubGetPrisoners', { prisoners: [prisonerWithoutVOs] })
+      cy.signIn()
+
+      // Home page - prisoner shown
+      const homePage = Page.verifyOnPage(HomePage)
+
+      // Start booking journey
+      cy.task('stubGetPrison', prison)
+      cy.task('stubGetVisitors', { visitors })
+      cy.task('stubValidatePrisonerFail')
+      homePage.startBooking()
+
+      // Visit cannot be booked page
+      const cannotBookPage = Page.verifyOnPage(CannotBookPage)
+      cannotBookPage.getPrisonerName().contains('John Smith')
+      cannotBookPage.getPrisonName().contains(prison.prisonName)
+      cy.contains('have moved to another prison or been released')
 
       // Back link back to Home page
       cannotBookPage.backLink().click()

--- a/integration_tests/e2e/visitors.cy.ts
+++ b/integration_tests/e2e/visitors.cy.ts
@@ -29,6 +29,7 @@ context('Visitors page', () => {
 
     cy.task('stubGetPrison', prison)
     cy.task('stubGetVisitors', { visitors })
+    cy.task('stubValidatePrisonerPass')
   })
 
   it('should show Visitors page with two visitors (one having a BAN restriction', () => {

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -9,6 +9,7 @@ import {
   BookerPrisonerInfoDto,
   VisitDto,
   VisitorInfoDto,
+  BookerPrisonerValidationException,
 } from '../../server/data/orchestrationApiTypes'
 import { SessionRestriction } from '../../server/data/orchestrationApiClient'
 
@@ -233,6 +234,51 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: prisoners,
+      },
+    }),
+
+  stubValidatePrisonerPass: ({
+    bookerReference = TestData.bookerReference(),
+    prisonerNumber = TestData.bookerPrisonerInfoDto().prisoner.prisonerNumber,
+  }: {
+    bookerReference?: BookerReference
+    prisonerNumber?: string
+  } = {}): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/orchestration/public/booker/${bookerReference.value}/permitted/prisoners/${prisonerNumber}/validate`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    }),
+
+  stubValidatePrisonerFail: ({
+    bookerReference = TestData.bookerReference(),
+    prisonerNumber = TestData.bookerPrisonerInfoDto().prisoner.prisonerNumber,
+    validationError = 'PRISONER_RELEASED',
+  }: {
+    bookerReference?: BookerReference
+    prisonerNumber?: string
+    validationError?: BookerPrisonerValidationException['errorCodes'][number]
+  } = {}): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/orchestration/public/booker/${bookerReference.value}/permitted/prisoners/${prisonerNumber}/validate`,
+      },
+      response: {
+        status: 422,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          status: 422,
+          errorCode: null,
+          userMessage: 'Prisoner validation failed',
+          developerMessage: null,
+          validationErrors: [validationError],
+        },
       },
     }),
 

--- a/integration_tests/pages/bookVisit/cannotBook.ts
+++ b/integration_tests/pages/bookVisit/cannotBook.ts
@@ -3,11 +3,13 @@ import Page, { PageElement } from '../page'
 export default class CannotBookPage extends Page {
   constructor() {
     super('A visit cannot be booked')
-
-    cy.contains('has used their allowance of visits')
   }
 
   getPrisonerName = (): PageElement => cy.get('[data-test="prisoner-name"]')
 
+  // NO_VO_BALANCE
   getBookFromDate = (): PageElement => cy.get('[data-test="book-from-date"]')
+
+  // TRANSFER_OR_RELEASE
+  getPrisonName = (): PageElement => cy.get('[data-test="prison-name"]')
 }

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -60,4 +60,4 @@ export type BookingCancelled = {
   hasMobile: boolean
 }
 
-export type CannotBookReason = 'NO_VO_BALANCE'
+export type CannotBookReason = 'NO_VO_BALANCE' | 'TRANSFER_OR_RELEASE'

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -197,7 +197,8 @@ describe('Check visit details', () => {
               expect(sessionData.bookingJourney.selectedVisitSession).toStrictEqual(visitSession)
             })
         })
-        it('should throw error APPLICATION_INVALID_PRISON_PRISONER_MISMATCH and not set flash message', () => {
+
+        it('should redirect to cannot book page with no flash message for error APPLICATION_INVALID_PRISON_PRISONER_MISMATCH', () => {
           const error: SanitisedError<ApplicationValidationErrorResponse> = {
             name: 'Error',
             status: 422,
@@ -209,12 +210,17 @@ describe('Check visit details', () => {
 
           return request(app)
             .post(paths.BOOK_VISIT.CHECK_DETAILS)
-            .expect(422)
+            .expect(302)
+            .expect('location', paths.BOOK_VISIT.CANNOT_BOOK)
             .expect(() => {
               expect(flashProvider).not.toHaveBeenCalled()
               expect(sessionData.bookingJourney).not.toBe(undefined)
+              expect(sessionData.bookingJourney.cannotBookReason).toBe('TRANSFER_OR_RELEASE')
               expect(sessionData.bookingConfirmed).toBe(undefined)
-              expect(sessionData.bookingJourney.selectedVisitSession).toStrictEqual(visitSession)
+              expect(visitService.bookVisit).toHaveBeenCalledWith({
+                applicationReference: application.reference,
+                actionedBy: bookerReference,
+              })
             })
         })
 

--- a/server/routes/bookVisit/checkVisitDetailsController.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.ts
@@ -51,11 +51,13 @@ export default class CheckVisitDetailsController {
           const validationErrors =
             (error as SanitisedError<ApplicationValidationErrorResponse>)?.data?.validationErrors ?? []
 
-          if (
-            validationErrors.includes('APPLICATION_INVALID_PRISONER_NOT_FOUND') ||
-            validationErrors.includes('APPLICATION_INVALID_PRISON_PRISONER_MISMATCH')
-          ) {
+          if (validationErrors.includes('APPLICATION_INVALID_PRISONER_NOT_FOUND')) {
             return next(error)
+          }
+
+          if (validationErrors.includes('APPLICATION_INVALID_PRISON_PRISONER_MISMATCH')) {
+            bookingJourney.cannotBookReason = 'TRANSFER_OR_RELEASE'
+            return res.redirect(paths.BOOK_VISIT.CANNOT_BOOK)
           }
 
           if (validationErrors.includes('APPLICATION_INVALID_NO_VO_BALANCE')) {

--- a/server/routes/bookVisit/index.ts
+++ b/server/routes/bookVisit/index.ts
@@ -24,7 +24,7 @@ export default function routes(services: Services): Router {
   const postWithValidation = (path: string | string[], validationChain: ValidationChain[], handler: RequestHandler) =>
     router.post(path, ...validationChain, asyncMiddleware(handler))
 
-  const selectPrisonerController = new SelectPrisonerController()
+  const selectPrisonerController = new SelectPrisonerController(services.bookerService)
   const cannotBookController = new CannotBookController()
   const selectVisitorsController = new SelectVisitorsController(
     services.bookerService,

--- a/server/routes/bookVisit/selectPrisonerController.test.ts
+++ b/server/routes/bookVisit/selectPrisonerController.test.ts
@@ -7,10 +7,12 @@ import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import logger from '../../../logger'
 import { Prisoner } from '../../services/bookerService'
+import { createMockBookerService } from '../../services/testutils/mocks'
 
 jest.mock('../../../logger')
 
 let app: Express
+const bookerService = createMockBookerService()
 let sessionData: SessionData
 
 afterEach(() => {
@@ -27,7 +29,7 @@ describe('Select prisoner', () => {
       booker: { reference: bookerReference },
     } as SessionData
 
-    app = appWithAllRoutes({ services: {}, sessionData })
+    app = appWithAllRoutes({ services: { bookerService }, sessionData })
 
     return request(app)
       .post(paths.BOOK_VISIT.SELECT_PRISONER)
@@ -39,13 +41,15 @@ describe('Select prisoner', () => {
   })
 
   it('should clear any exiting bookingJourney session data, populate new data and redirect to select visitors page', () => {
+    bookerService.validatePrisoner.mockResolvedValue(true)
+
     sessionData = {
       booker: { reference: bookerReference, prisoners: [prisoner] },
       bookingJourney: { prisoner: { prisonerNumber: 'OLD JOURNEY DATA' } as Prisoner },
       bookingConfirmed,
     } as SessionData
 
-    app = appWithAllRoutes({ services: {}, sessionData })
+    app = appWithAllRoutes({ services: { bookerService }, sessionData })
 
     return request(app)
       .post(paths.BOOK_VISIT.SELECT_PRISONER)
@@ -70,7 +74,7 @@ describe('Select prisoner', () => {
       booker: { reference: bookerReference, prisoners: [prisoner] },
     } as SessionData
 
-    app = appWithAllRoutes({ services: {}, sessionData })
+    app = appWithAllRoutes({ services: { bookerService }, sessionData })
 
     return request(app)
       .post(paths.BOOK_VISIT.SELECT_PRISONER)
@@ -89,12 +93,14 @@ describe('Select prisoner', () => {
   })
 
   it('should redirect to Visit cannot be booked page if selected prisoner has no VOs', () => {
+    bookerService.validatePrisoner.mockResolvedValue(true)
+
     const prisonerWithNoVos = TestData.prisoner({ availableVos: -1 })
     sessionData = {
       booker: { reference: bookerReference, prisoners: [prisonerWithNoVos] },
     } as SessionData
 
-    app = appWithAllRoutes({ services: {}, sessionData })
+    app = appWithAllRoutes({ services: { bookerService }, sessionData })
 
     return request(app)
       .post(paths.BOOK_VISIT.SELECT_PRISONER)
@@ -110,6 +116,36 @@ describe('Select prisoner', () => {
           bookingJourney: {
             prisoner: prisonerWithNoVos,
             cannotBookReason: 'NO_VO_BALANCE',
+          },
+        } as SessionData)
+      })
+  })
+
+  it('should redirect to Visit cannot be booked page if prisoner fails validation (transfer or release)', () => {
+    bookerService.validatePrisoner.mockResolvedValue(false)
+
+    sessionData = {
+      booker: { reference: bookerReference, prisoners: [prisoner] },
+      bookingJourney: { prisoner },
+      bookingConfirmed,
+    } as SessionData
+
+    app = appWithAllRoutes({ services: { bookerService }, sessionData })
+
+    return request(app)
+      .post(paths.BOOK_VISIT.SELECT_PRISONER)
+      .send({ prisonerDisplayId: prisoner.prisonerDisplayId.toString() })
+      .expect(302)
+      .expect('location', paths.BOOK_VISIT.CANNOT_BOOK)
+      .expect(() => {
+        expect(sessionData).toStrictEqual({
+          booker: {
+            reference: bookerReference,
+            prisoners: [prisoner],
+          },
+          bookingJourney: {
+            prisoner,
+            cannotBookReason: 'TRANSFER_OR_RELEASE',
           },
         } as SessionData)
       })

--- a/server/routes/bookVisit/selectPrisonerController.ts
+++ b/server/routes/bookVisit/selectPrisonerController.ts
@@ -2,15 +2,17 @@ import type { RequestHandler } from 'express'
 import { NotFound } from 'http-errors'
 import paths from '../../constants/paths'
 import { clearSession } from '../../utils/utils'
+import { BookerService } from '../../services'
 
 export default class SelectPrisonerController {
-  public constructor() {}
+  public constructor(private readonly bookerService: BookerService) {}
 
   public selectPrisoner(): RequestHandler {
     return async (req, res) => {
       clearSession(req)
 
-      const prisoner = req.session.booker.prisoners[0]
+      const { booker } = req.session
+      const prisoner = booker.prisoners[0]
 
       const { prisonerDisplayId } = req.body
       if (prisonerDisplayId !== prisoner.prisonerDisplayId) {
@@ -18,6 +20,12 @@ export default class SelectPrisonerController {
       }
 
       req.session.bookingJourney = { prisoner }
+
+      const prisonerIsValid = await this.bookerService.validatePrisoner(booker.reference, prisoner.prisonerNumber)
+      if (!prisonerIsValid) {
+        req.session.bookingJourney.cannotBookReason = 'TRANSFER_OR_RELEASE'
+        return res.redirect(paths.BOOK_VISIT.CANNOT_BOOK)
+      }
 
       if (prisoner.availableVos <= 0) {
         req.session.bookingJourney.cannotBookReason = 'NO_VO_BALANCE'

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -66,6 +66,7 @@ export default class TestData {
     firstName = 'JOHN',
     lastName = 'SMITH',
     prisonId = 'HEI',
+    prisonName = 'Hewell (HMP)',
     availableVos = 2,
     nextAvailableVoDate = '2024-07-01',
   }: Partial<{
@@ -73,10 +74,11 @@ export default class TestData {
     firstName: string
     lastName: string
     prisonId: string
+    prisonName: string
     availableVos: number
     nextAvailableVoDate: string
   }> = {}): BookerPrisonerInfoDto => ({
-    prisoner: { prisonerNumber, firstName, lastName, dateOfBirth: undefined, prisonId },
+    prisoner: { prisonerNumber, firstName, lastName, dateOfBirth: undefined, prisonId, prisonName },
     availableVos,
     nextAvailableVoDate,
   })
@@ -152,6 +154,7 @@ export default class TestData {
     firstName = 'JOHN',
     lastName = 'SMITH',
     prisonId = 'HEI',
+    prisonName = 'Hewell (HMP)',
     availableVos = 2,
     nextAvailableVoDate = '2024-07-01',
   }: Partial<Prisoner> = {}): Prisoner => ({
@@ -160,6 +163,7 @@ export default class TestData {
     firstName,
     lastName,
     prisonId,
+    prisonName,
     availableVos,
     nextAvailableVoDate,
   })

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -58,6 +58,7 @@ describe('Booker service', () => {
         firstName: 'F1',
         lastName: 'L1',
         prisonId: 'P1',
+        prisonName: 'P1 (HMP)',
         availableVos: 1,
         nextAvailableVoDate: '2024-06-01',
       }
@@ -66,6 +67,7 @@ describe('Booker service', () => {
         firstName: 'F2',
         lastName: 'L2',
         prisonId: 'P2',
+        prisonName: 'P2 (HMP)',
         availableVos: 2,
         nextAvailableVoDate: '2024-06-02',
       }

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -10,6 +10,7 @@ export type Prisoner = {
   firstName: string
   lastName: string
   prisonId: string
+  prisonName: string
   availableVos: number
   nextAvailableVoDate: string
 }
@@ -39,15 +40,18 @@ export default class BookerService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
     const prisoners = await orchestrationApiClient.getPrisoners(bookerReference)
-    return prisoners.map(prisoner => {
+
+    return prisoners.map(bookerPrisonerInfo => {
+      const { prisoner, availableVos, nextAvailableVoDate } = bookerPrisonerInfo
       return {
         prisonerDisplayId: randomUUID(),
-        prisonerNumber: prisoner.prisoner.prisonerNumber,
-        firstName: prisoner.prisoner.firstName,
-        lastName: prisoner.prisoner.lastName,
-        prisonId: prisoner.prisoner.prisonId,
-        availableVos: prisoner.availableVos,
-        nextAvailableVoDate: prisoner.nextAvailableVoDate,
+        prisonerNumber: prisoner.prisonerNumber,
+        firstName: prisoner.firstName,
+        lastName: prisoner.lastName,
+        prisonId: prisoner.prisonId,
+        prisonName: prisoner.prisonName,
+        availableVos,
+        nextAvailableVoDate,
       }
     })
   }

--- a/server/views/pages/bookVisit/cannotBook.njk
+++ b/server/views/pages/bookVisit/cannotBook.njk
@@ -4,6 +4,10 @@
 
 {% set backLinkHref = paths.HOME %}
 
+{% set prisonerName -%}
+  <span data-test="prisoner-name">{{ prisoner.firstName | capitalize }} {{ prisoner.lastName | capitalize }}</span>
+{%- endset %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -12,8 +16,7 @@
 
       {% if cannotBookReason == 'NO_VO_BALANCE' %}
         <p>
-          <span data-test="prisoner-name">{{ prisoner.firstName | capitalize }} {{ prisoner.lastName | capitalize }}</span>
-          has used their allowance of visits for this month.
+          {{ prisonerName | safe }} has used their allowance of visits for this month.
         </p>
 
         <p>
@@ -22,6 +25,21 @@
         </p>
       {% endif %}
 
+      {% if cannotBookReason == 'TRANSFER_OR_RELEASE' %}
+        <p>
+          {{ prisonerName | safe }} is no longer at <span data-test="prison-name">{{ prisoner.prisonName }}</span>.
+          They may have moved to another prison or been released.
+        </p>
+
+        <p>
+          If they have moved to another prison,
+          <a href="https://www.gov.uk/government/collections/prisons-in-england-and-wales" target="_blank">find out how to book a visit at their new prison</a>.
+        </p>
+      
+        <p>
+          For help contacting them, you can use the <a href="https://www.gov.uk/find-prisoner" target="_blank">find a prisoner service</a>.
+        </p>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
When starting a booking journey, call the new validate booker/prisoner endpoint and if this fails (because a prisoner has been transferred or released) redirect to the drop-out page.

Also redirect to the same drop-out page if a prisoner transfer/release is caught at the end of a booking journey (via the `APPLICATION_INVALID_PRISON_PRISONER_MISMATCH` code thrown when booking).