### PR TITLE
Fix following openid-client update

### DIFF
--- a/server/authentication/govukOneLogin.ts
+++ b/server/authentication/govukOneLogin.ts
@@ -71,6 +71,9 @@ async function init(): Promise<{ client: Client; idTokenStore: TokenStore }> {
         ui_locales: 'en',
       },
       usePKCE: false,
+      extras: {
+        clientAssertionPayload: { aud: issuer.metadata.token_endpoint },
+      },
     },
     verify,
   )


### PR DESCRIPTION
`opened-client` version `5.7.1` (https://github.com/panva/openid-client/releases/tag/v5.7.1) broke One Login integration because it no longer sent the expected `aud` value in the JWT assertion.

This fix makes sure the expected value (as documented [here](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#create-a-jwt)) is present.