### PR TITLE
VB-5116 Get dynamic list of supported prisons

### DIFF
--- a/integration_tests/e2e/serviceStartPage.cy.ts
+++ b/integration_tests/e2e/serviceStartPage.cy.ts
@@ -13,11 +13,15 @@ context('Service start page', () => {
   describe('Unauthenticated user', () => {
     it('should be able to visit start page and proceed to GOVUK One Login', () => {
       cy.hideCookieBanner()
+      cy.task('stubGetSupportedPrisons')
 
       // Go to service start page
       cy.visit(paths.START)
       const serviceStartPage = Page.verifyOnPage(ServiceStartPage)
       serviceStartPage.oneLoginHeader().should('not.exist')
+
+      // Check supported prisons
+      serviceStartPage.getSupportedPrison(1).contains('Hewell (HMP)')
 
       // Click Start now button and be redirected to GOVUK One Login
       cy.task('stubSignIn')

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -376,6 +376,19 @@ export default {
 
   // orchestration-prisons-config-controller
 
+  stubGetSupportedPrisons: (prisons = [TestData.prisonRegisterPrisonDto()]): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: '/orchestration/config/prisons/user-type/PUBLIC/supported/detailed',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: prisons,
+      },
+    }),
+
   stubGetPrison: (prisonDto: PrisonDto = TestData.prisonDto()): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/serviceStart.ts
+++ b/integration_tests/pages/serviceStart.ts
@@ -1,9 +1,11 @@
-import Page from './page'
+import Page, { PageElement } from './page'
 
 export default class ServiceStartPage extends Page {
   constructor() {
     super('Visit someone in prison')
   }
+
+  getSupportedPrison = (index: number): PageElement => cy.get(`[data-test^="prison-${index}"]`)
 
   startNow = (): void => {
     cy.get('[data-test="start-now"]').click()

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -271,6 +271,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/public/booker/{bookerReference}/permitted/prisoners/register': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Register prisoner to a booker
+     * @description Register prisoner to a booker
+     */
+    post: operations['registerPrisoner']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/visits/{reference}': {
     parameters: {
       query?: never
@@ -819,6 +839,26 @@ export interface paths {
      * @description Get all supported prisons id's
      */
     get: operations['getSupportedPrisons']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/config/prisons/user-type/{type}/supported/detailed': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get supported prisons with detailed prison details by user type
+     * @description Get all supported prisons with detailed prison details by user type
+     */
+    get: operations['getSupportedPrisonDetails']
     put?: never
     post?: never
     delete?: never
@@ -1397,6 +1437,35 @@ export interface components {
       /** @description full name of user who added the exclude date or username if full name is not available. */
       actionedBy: string
     }
+    /** @description Details to register a prisoner to a booker. */
+    RegisterPrisonerForBookerDto: {
+      /**
+       * @description Prisoner Id
+       * @example A1234AA
+       */
+      prisonerId: string
+      /**
+       * @description Prisoner first name
+       * @example James
+       */
+      prisonerFirstName: string
+      /**
+       * @description Prisoner last name
+       * @example Smith
+       */
+      prisonerLastName: string
+      /**
+       * Format: date
+       * @description Prisoner date of birth
+       * @example 1960-01-30
+       */
+      prisonerDateOfBirth: string
+      /**
+       * @description Prison Id
+       * @example MDI
+       */
+      prisonId: string
+    }
     /** @description Event Audit with actioned by user's full name populated */
     EventAuditOrchestrationDto: {
       /**
@@ -1808,6 +1877,11 @@ export interface components {
        * @example 2018-12-01T13:45:00
        */
       endTimestamp: string
+      /**
+       * @description Session Template Reference
+       * @example v9d.7ed.7u
+       */
+      sessionTemplateReference?: string
       /** @description Visit Notes */
       visitNotes?: components['schemas']['VisitNoteDto'][]
       /** @description Contact associated with the visit */
@@ -1917,7 +1991,7 @@ export interface components {
       relationshipDescription?: string
       /** @description List of restrictions associated with the contact */
       restrictions: components['schemas']['RestrictionDto'][]
-      /** @description List of addresses associated with the contact */
+      /** @description Primary address for the contact or the first address if no primary address available, null if address list is empty */
       primaryAddress?: components['schemas']['AddressDto']
     }
     /**
@@ -1932,13 +2006,11 @@ export interface components {
     visitRestrictions: ('OPEN' | 'CLOSED' | 'UNKNOWN')[]
     SessionTimeSlotDto: {
       /**
-       * Format: HH:mm
        * @description The start time of the generated visit session(s)
        * @example 10:30
        */
       startTime: string
       /**
-       * Format: HH:mm
        * @description The end time of the generated visit session(s)
        * @example 11:30
        */
@@ -1987,19 +2059,19 @@ export interface components {
       visitRestriction: 'OPEN' | 'CLOSED' | 'UNKNOWN'
     }
     PageVisitDto: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       first?: boolean
       last?: boolean
       empty?: boolean
@@ -2008,12 +2080,12 @@ export interface components {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
+      unpaged?: boolean
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
       /** Format: int32 */
       pageSize?: number
-      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean
@@ -3910,6 +3982,57 @@ export interface operations {
       }
     }
   }
+  registerPrisoner: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        bookerReference: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RegisterPrisonerForBookerDto']
+      }
+    }
+    responses: {
+      /** @description Registration successful */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Incorrect request to register a prisoner to a booker */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions for this action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner registration failed */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': 'FAILED_REGISTRATION'
+        }
+      }
+    }
+  }
   getVisitsByReference: {
     parameters: {
       query?: never
@@ -5459,6 +5582,50 @@ export interface operations {
         }
       }
       /** @description Incorrect permissions to view session templates */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getSupportedPrisonDetails: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /**
+         * @description type
+         * @example STAFF
+         */
+        type: 'STAFF' | 'PUBLIC' | 'SYSTEM'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Supported prisons returned */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['PrisonRegisterPrisonDto'][]
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to get supported prison details */
       403: {
         headers: {
           [name: string]: unknown

--- a/server/app.ts
+++ b/server/app.ts
@@ -37,7 +37,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setupGovukOneLogin())
   app.use(analyticsConsent())
   app.use(setUpCsrf())
-  app.use(unauthenticatedRoutes())
+  app.use(unauthenticatedRoutes(services))
   app.use(govukOneLogin.authenticationMiddleware())
   app.use(populateCurrentBooker(services.bookerService))
 

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -329,6 +329,21 @@ describe('orchestrationApiClient', () => {
     })
   })
 
+  describe('getSupportedPrisons', () => {
+    it('should get list of supported prisons', async () => {
+      const prisons = [TestData.prisonRegisterPrisonDto()]
+
+      fakeOrchestrationApi
+        .get('/config/prisons/user-type/PUBLIC/supported/detailed')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, prisons)
+
+      const result = await orchestrationApiClient.getSupportedPrisons()
+
+      expect(result).toStrictEqual(prisons)
+    })
+  })
+
   describe('getPrison', () => {
     it('should get a prison by prisonCode', async () => {
       const prison = TestData.prisonDto()

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -15,6 +15,7 @@ import {
   VisitorInfoDto,
   AvailableVisitSessionRestrictionDto,
   CancelVisitOrchestrationDto,
+  PrisonRegisterPrisonDto,
 } from './orchestrationApiTypes'
 
 export type SessionRestriction = AvailableVisitSessionDto['sessionRestriction']
@@ -217,6 +218,10 @@ export default class OrchestrationApiClient {
   }
 
   // orchestration-prisons-config-controller
+
+  async getSupportedPrisons(): Promise<PrisonRegisterPrisonDto[]> {
+    return this.restClient.get({ path: '/config/prisons/user-type/PUBLIC/supported/detailed' })
+  }
 
   async getPrison(prisonCode: string): Promise<PrisonDto> {
     return this.restClient.get({ path: `/config/prisons/prison/${prisonCode}` })

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -30,6 +30,8 @@ export type OrchestrationVisitDto = components['schemas']['OrchestrationVisitDto
 
 export type PrisonDto = components['schemas']['PrisonDto']
 
+export type PrisonRegisterPrisonDto = components['schemas']['PrisonRegisterPrisonDto']
+
 export type VisitDto = components['schemas']['VisitDto']
 
 export type VisitorInfoDto = components['schemas']['VisitorInfoDto']

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -77,7 +77,7 @@ function appSetup(
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
   app.use(analyticsConsent())
-  app.use(unauthenticatedRoutes())
+  app.use(unauthenticatedRoutes(services))
   app.use(routes(services))
   app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -10,6 +10,7 @@ import type {
   VisitDto,
   VisitorInfoDto,
   ConvictedStatus,
+  PrisonRegisterPrisonDto,
 } from '../../data/orchestrationApiTypes'
 import { Prisoner, Visitor } from '../../services/bookerService'
 import { VisitDetails } from '../../services/visitService'
@@ -159,6 +160,13 @@ export default class TestData {
       webAddress,
       clients,
     }) as PrisonDto
+
+  static prisonRegisterPrisonDto = ({
+    prisonId = 'HEI',
+    prisonName = 'Hewell (HMP)',
+    active = true,
+  }: Partial<PrisonRegisterPrisonDto> = {}): PrisonRegisterPrisonDto =>
+    ({ prisonId, prisonName, active }) as PrisonRegisterPrisonDto
 
   static prisoner = ({
     prisonerDisplayId = 'uuidv4-1',

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -23,6 +23,18 @@ describe('Prison service', () => {
     jest.resetAllMocks()
   })
 
+  describe('getSupportedPrisons', () => {
+    it('should return list of supported prisons', async () => {
+      const prisons = [TestData.prisonRegisterPrisonDto()]
+      orchestrationApiClient.getSupportedPrisons.mockResolvedValue(prisons)
+
+      const results = await prisonService.getSupportedPrisons()
+
+      expect(orchestrationApiClient.getSupportedPrisons).toHaveBeenCalled()
+      expect(results).toStrictEqual(prisons)
+    })
+  })
+
   describe('getPrison', () => {
     it('should return prison config for given prison code', async () => {
       const prison = TestData.prisonDto()

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,11 +1,18 @@
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
-import { PrisonDto } from '../data/orchestrationApiTypes'
+import { PrisonDto, PrisonRegisterPrisonDto } from '../data/orchestrationApiTypes'
 
 export default class PrisonService {
   constructor(
     private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
+
+  async getSupportedPrisons(): Promise<PrisonRegisterPrisonDto[]> {
+    const token = await this.hmppsAuthClient.getSystemClientToken()
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+
+    return orchestrationApiClient.getSupportedPrisons()
+  }
 
   async getPrison(prisonCode: string): Promise<PrisonDto> {
     const token = await this.hmppsAuthClient.getSystemClientToken()

--- a/server/views/pages/serviceStart.njk
+++ b/server/views/pages/serviceStart.njk
@@ -9,8 +9,9 @@
 
       <p>This new service can be used to visit one prisoner in:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Drake Hall (HMP & YOI)</li>
-        <li>Foston Hall (HMP & YOI)</li>
+        {% for prison in supportedPrisons %}
+          <li data-test="prison-{{ loop.index }}">{{ prison.prisonName }}</li>
+        {% endfor %}
       </ul>
 
       <p>


### PR DESCRIPTION
Use new endpoint that returns list of supported prison IDs and names for the service. Avoids hard-coding two existing prisons and will be needed for 'Add a prisoner' journey.