### PR TITLE
VB-5389 Refresh booker's prisoners when loading home page

### DIFF
--- a/server/middleware/populateCurrentBooker.test.ts
+++ b/server/middleware/populateCurrentBooker.test.ts
@@ -22,7 +22,7 @@ describe('populateCurrentBooker', () => {
   beforeEach(() => {
     jest.resetAllMocks()
 
-    req = { session: {} } as unknown as Request
+    req = { path: '/test', session: {} } as unknown as Request
 
     res = {
       locals: {
@@ -49,6 +49,19 @@ describe('populateCurrentBooker', () => {
     })
     expect(bookerService.getPrisoners).toHaveBeenCalledWith(bookerReference)
     expect(req.session).toStrictEqual(<SessionData>{ booker: { reference: bookerReference, prisoners } })
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should get booker reference and NOT prisoners and add to session if it is not already set - HOME page only', async () => {
+    bookerService.getBookerReference.mockResolvedValue(bookerReference)
+    req = { path: paths.HOME, session: {} } as unknown as Request
+
+    await populateCurrentBooker(bookerService)(req, res, next)
+
+    expect(bookerService.getBookerReference).toHaveBeenCalled()
+    expect(bookerService.getPrisoners).not.toHaveBeenCalled()
+    expect(req.session).toStrictEqual(<SessionData>{ booker: { reference: bookerReference, prisoners: [] } })
     expect(res.redirect).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalled()
   })

--- a/server/middleware/populateCurrentBooker.ts
+++ b/server/middleware/populateCurrentBooker.ts
@@ -19,7 +19,8 @@ export default function populateCurrentBooker(bookerService: BookerService): Req
         }
 
         const reference = await bookerService.getBookerReference(authDetailDto)
-        const prisoners = await bookerService.getPrisoners(reference)
+        // Prisoner details loaded on home page to refresh so don't auto-populate here
+        const prisoners = req.path !== paths.HOME ? await bookerService.getPrisoners(reference) : []
         req.session.booker = { reference, prisoners }
       }
       return next()

--- a/server/routes/homeController.ts
+++ b/server/routes/homeController.ts
@@ -1,14 +1,16 @@
 import type { RequestHandler } from 'express'
 import paths from '../constants/paths'
 import { clearSession } from '../utils/utils'
+import { BookerService } from '../services'
 
 export default class HomeController {
-  public constructor() {}
+  public constructor(private readonly bookerService: BookerService) {}
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const prisoner = req.session.booker.prisoners[0]
-      res.render('pages/home', { prisoner, showOLServiceNav: true })
+      const { booker } = req.session
+      booker.prisoners = await this.bookerService.getPrisoners(booker.reference)
+      res.render('pages/home', { prisoner: booker.prisoners[0], showOLServiceNav: true })
     }
   }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,7 +16,7 @@ export default function routes(services: Services): Router {
 
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  const homeController = new HomeController()
+  const homeController = new HomeController(services.bookerService)
   const accessDeniedController = new AccessDeniedController()
 
   get(paths.HOME, homeController.view())

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -124,9 +124,10 @@ describe('pluralise', () => {
   })
 
   describe('Clear session data', () => {
-    it('should clear booking journey from the session', () => {
+    it('should clear booking and add prisoner journey data from the session', () => {
       const sessionData: Partial<Record<keyof SessionData, string>> = {
         booker: 'BOOKER DATA',
+        addPrisonerJourney: 'ADD PRISONER JOURNEY DATA',
         bookingJourney: 'BOOKING JOURNEY DATA',
         bookingConfirmed: 'BOOKING CONFIRMATION DATA',
       }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -79,7 +79,7 @@ export const isAdult = (dateOfBirth: string, referenceDate: Date = new Date()): 
 }
 
 export const clearSession = (req: Request): void => {
-  ;['bookingJourney', 'bookingConfirmed'].forEach((sessionItem: keyof SessionData) => {
+  ;['addPrisonerJourney', 'bookingJourney', 'bookingConfirmed'].forEach((sessionItem: keyof SessionData) => {
     delete req.session[sessionItem]
   })
 }


### PR DESCRIPTION
* Load booker's prisoners each time home page is loaded to ensure it is up-to-date - i.e. includes newly-added prisoners
* Exclude auto-loading of booker's prisoners in `populateCurrentBooker()` middleware for requests to `/home` to avoid duplicate API calls