### PR TITLE
VB-5117 Add prisoner details - remove unnecessary escaping

### DIFF
--- a/server/routes/addPrisoner/prisonerDetailsController.ts
+++ b/server/routes/addPrisoner/prisonerDetailsController.ts
@@ -84,8 +84,8 @@ export default class PrisonerDetailsController {
 
   public validate(): ValidationChain[] {
     return [
-      body('firstName', 'Enter a first name').trim().escape().isLength({ min: 1, max: 250 }),
-      body('lastName', 'Enter a last name').trim().escape().isLength({ min: 1, max: 250 }),
+      body('firstName', 'Enter a first name').trim().isLength({ min: 1, max: 250 }),
+      body('lastName', 'Enter a last name').trim().isLength({ min: 1, max: 250 }),
 
       body(['day', 'month', 'year']).trim(),
       // 'prisonerDob' not an actual form field but used to store combined result and any validation errors


### PR DESCRIPTION
Prisoner first/last name being escaped unnecessarily causing it to be double-escaped if user goes back to page (Nunjucks is already escaping it).