### PR TITLE
VB-5699 Handle 'sessionForReview' flag and pass when booking

### DIFF
--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -219,7 +219,7 @@ context('Booking journey', () => {
       visitorIds: [1000, 3000],
       bookerReference,
       // set needs review flag for returned sessions
-      visitSessions: visitSessions.map(visitSession => ({ ...visitSession, isSessionForReview: true })),
+      visitSessions: visitSessions.map(visitSession => ({ ...visitSession, sessionForReview: true })),
     })
     selectVisitorsPage.continue()
     const chooseVisitTimePage = Page.verifyOnPage(ChooseVisitTimePage)

--- a/integration_tests/e2e/bookingJourney.cy.ts
+++ b/integration_tests/e2e/bookingJourney.cy.ts
@@ -79,19 +79,19 @@ context('Booking journey', () => {
     visitors: [{ nomisPersonId: 1000 }, { nomisPersonId: 3000 }],
   })
 
+  const bookerReference = TestData.bookerReference().value
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubHmppsAuthToken')
-  })
 
-  it('should complete the booking journey (OPEN visit) - visit BOOKED (AUTO_APPROVED)', () => {
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners', { prisoners: [prisoner] })
     cy.signIn()
+  })
 
-    const bookerReference = TestData.bookerReference().value
-
+  it('should complete the booking journey (OPEN visit) - visit BOOKED (AUTO_APPROVED)', () => {
     // Home page - prisoner shown
     const homePage = Page.verifyOnPage(HomePage)
     homePage.prisonerName().contains('John Smith')
@@ -193,12 +193,6 @@ context('Booking journey', () => {
   })
 
   it('should complete the booking journey (OPEN visit) - visit BOOKED (REQUESTED)', () => {
-    cy.task('stubGetBookerReference')
-    cy.task('stubGetPrisoners', { prisoners: [prisoner] })
-    cy.signIn()
-
-    const bookerReference = TestData.bookerReference().value
-
     // Home page - prisoner shown
     const homePage = Page.verifyOnPage(HomePage)
     homePage.prisonerName().contains('John Smith')
@@ -224,7 +218,8 @@ context('Booking journey', () => {
       prisonerId: prisoner.prisoner.prisonerNumber,
       visitorIds: [1000, 3000],
       bookerReference,
-      visitSessions,
+      // set needs review flag for returned sessions
+      visitSessions: visitSessions.map(visitSession => ({ ...visitSession, isSessionForReview: true })),
     })
     selectVisitorsPage.continue()
     const chooseVisitTimePage = Page.verifyOnPage(ChooseVisitTimePage)
@@ -273,7 +268,7 @@ context('Booking journey', () => {
     cy.task('stubBookVisit', {
       visit: TestData.visitDto({ visitSubStatus: 'REQUESTED' }),
       bookerReference: TestData.bookerReference().value,
-      isRequestBooking: false, // TODO will be true when VB-5699 implemented
+      isRequestBooking: true,
     })
     checkVisitDetailsPage.submit()
 
@@ -303,12 +298,6 @@ context('Booking journey', () => {
   })
 
   it('should show closed visit interruption card (CLOSED visit)', () => {
-    cy.task('stubGetBookerReference')
-    cy.task('stubGetPrisoners', { prisoners: [prisoner] })
-    cy.signIn()
-
-    const bookerReference = TestData.bookerReference().value
-
     // Home page - prisoner shown
     const homePage = Page.verifyOnPage(HomePage)
     homePage.prisonerName().contains('John Smith')

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -359,7 +359,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        urlPath: '/orchestration/visit-sessions/available',
+        urlPath: '/orchestration/visit-sessions/available/v2',
         queryParameters: {
           prisonId: { equalTo: prisonId },
           prisonerId: { equalTo: prisonerId },

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -548,6 +548,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/visit-sessions/available/v2': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Returns available visit sessions for a specified prisoner and visitors combination for the date range passed in
+     * @description Returns available visit sessions for a specified prisoner and visitors combination for the date range passed in. Used by Visits Public only, not PVB
+     */
+    get: operations['getAvailableVisitSessions_1']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/visit-sessions/available/restriction': {
     parameters: {
       query?: never
@@ -2066,33 +2086,33 @@ export interface components {
       visitRestriction: 'OPEN' | 'CLOSED' | 'UNKNOWN'
     }
     PageVisitDto: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      first?: boolean
-      last?: boolean
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
+      unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      /** Format: int32 */
-      pageSize?: number
-      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean
@@ -2328,6 +2348,12 @@ export interface components {
        * @enum {string}
        */
       sessionRestriction: 'OPEN' | 'CLOSED'
+      /**
+       * @description Does session need review, defaults to false
+       * @example true
+       */
+      isSessionForReview: boolean
+      sessionForReview?: boolean
     }
     /** @description Visit Session restriction type */
     AvailableVisitSessionRestrictionDto: {
@@ -4818,6 +4844,80 @@ export interface operations {
         fromDateOverride?: number
         /** @description maximum override in days for closing session slot booking window, E.g. 28 will set max booking window to today + 28 days */
         toDateOverride?: number
+        /**
+         * @description Username for the user making the request. Used to exclude user's pending applications from session capacity count. Optional, ignored if not passed in.
+         * @example user-1
+         */
+        username?: string
+        /**
+         * @description user type for the session
+         * @example PUBLIC
+         */
+        userType?: 'STAFF' | 'PUBLIC' | 'SYSTEM' | 'PRISONER'
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Visit session information returned */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['AvailableVisitSessionDto'][]
+        }
+      }
+      /** @description Incorrect request to Get visit sessions  */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getAvailableVisitSessions_1: {
+    parameters: {
+      query: {
+        /**
+         * @description Query by NOMIS Prison Identifier
+         * @example MDI
+         */
+        prisonId: string
+        /**
+         * @description Filter results by prisoner id
+         * @example A12345DC
+         */
+        prisonerId: string
+        /**
+         * @description Filter sessions by session restriction - OPEN or CLOSED, if prisoner has CLOSED it will use that
+         * @example CLOSED
+         */
+        sessionRestriction?: 'OPEN' | 'CLOSED'
+        /**
+         * @description List of visitors who require visit sessions
+         * @example 4729510,4729220
+         */
+        visitors?: number[]
+        /**
+         * @description The current application reference to be excluded from capacity count and double booking
+         * @example dfs-wjs-eqr
+         */
+        excludedApplicationReference?: string
         /**
          * @description Username for the user making the request. Used to exclude user's pending applications from session capacity count. Optional, ignored if not passed in.
          * @example user-1

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -2107,12 +2107,12 @@ export interface components {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      unpaged?: boolean
       /** Format: int32 */
       pageSize?: number
-      paged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      paged?: boolean
+      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean
@@ -2352,8 +2352,7 @@ export interface components {
        * @description Does session need review, defaults to false
        * @example true
        */
-      isSessionForReview: boolean
-      sessionForReview?: boolean
+      sessionForReview: boolean
     }
     /** @description Visit Session restriction type */
     AvailableVisitSessionRestrictionDto: {
@@ -4903,11 +4902,6 @@ export interface operations {
          * @example A12345DC
          */
         prisonerId: string
-        /**
-         * @description Filter sessions by session restriction - OPEN or CLOSED, if prisoner has CLOSED it will use that
-         * @example CLOSED
-         */
-        sessionRestriction?: 'OPEN' | 'CLOSED'
         /**
          * @description List of visitors who require visit sessions
          * @example 4729510,4729220

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -327,7 +327,7 @@ describe('orchestrationApiClient', () => {
       const excludedApplicationReference = 'aaa-bbb-ccc'
 
       fakeOrchestrationApi
-        .get('/visit-sessions/available')
+        .get('/visit-sessions/available/v2')
         .query({
           prisonId: prisoner.prisonId,
           prisonerId: prisoner.prisonerNumber,

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -210,7 +210,7 @@ export default class OrchestrationApiClient {
     bookerReference: string
   }): Promise<AvailableVisitSessionDto[]> {
     return this.restClient.get({
-      path: '/visit-sessions/available',
+      path: '/visit-sessions/available/v2',
       query: new URLSearchParams({
         prisonId,
         prisonerId,

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -210,7 +210,7 @@ export default class OrchestrationApiClient {
     bookerReference: string
   }): Promise<AvailableVisitSessionDto[]> {
     return this.restClient.get({
-      path: '/visit-sessions/available/v2',
+      path: config.features.visitRequest ? '/visit-sessions/available/v2' : '/visit-sessions/available',
       query: new URLSearchParams({
         prisonId,
         prisonerId,

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -205,7 +205,7 @@ describe('Check visit details', () => {
 
       beforeEach(() => {
         sessionData.bookingJourney.selectedVisitSession = TestData.availableVisitSessionDto({
-          isSessionForReview: true,
+          sessionForReview: true,
         })
         visitService.bookVisit.mockResolvedValue(visitRequested)
       })

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -204,6 +204,9 @@ describe('Check visit details', () => {
       const visitRequested = TestData.visitDto({ visitSubStatus: 'REQUESTED' })
 
       beforeEach(() => {
+        sessionData.bookingJourney.selectedVisitSession = TestData.availableVisitSessionDto({
+          isSessionForReview: true,
+        })
         visitService.bookVisit.mockResolvedValue(visitRequested)
       })
 
@@ -261,7 +264,7 @@ describe('Check visit details', () => {
             expect(visitService.bookVisit).toHaveBeenCalledWith({
               applicationReference: application.reference,
               actionedBy: bookerReference,
-              isRequestBooking: false, // TODO will be true when VB-5699 implemented
+              isRequestBooking: true,
             })
           })
       })

--- a/server/routes/bookVisit/checkVisitDetailsController.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.ts
@@ -35,7 +35,7 @@ export default class CheckVisitDetailsController {
         const visit = await this.visitService.bookVisit({
           applicationReference: bookingJourney.applicationReference,
           actionedBy: booker.reference,
-          isRequestBooking: false, // TODO to be implemented in VB-5699, where it will come from the selected session
+          isRequestBooking: config.features.visitRequest && bookingJourney.selectedVisitSession.isSessionForReview,
         })
 
         const bookingConfirmed: BookingConfirmed = {

--- a/server/routes/bookVisit/checkVisitDetailsController.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.ts
@@ -35,7 +35,7 @@ export default class CheckVisitDetailsController {
         const visit = await this.visitService.bookVisit({
           applicationReference: bookingJourney.applicationReference,
           actionedBy: booker.reference,
-          isRequestBooking: config.features.visitRequest && bookingJourney.selectedVisitSession.isSessionForReview,
+          isRequestBooking: config.features.visitRequest && bookingJourney.selectedVisitSession.sessionForReview,
         })
 
         const bookingConfirmed: BookingConfirmed = {

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -58,11 +58,13 @@ export default class TestData {
     sessionTemplateReference = 'a',
     sessionTimeSlot = { startTime: '10:00', endTime: '11:30' },
     sessionRestriction = 'OPEN',
+    isSessionForReview = false,
   }: Partial<AvailableVisitSessionDto> = {}): AvailableVisitSessionDto => ({
     sessionDate,
     sessionTemplateReference,
     sessionTimeSlot,
     sessionRestriction,
+    isSessionForReview,
   })
 
   static bookerPrisonerInfoDto = ({

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -58,13 +58,13 @@ export default class TestData {
     sessionTemplateReference = 'a',
     sessionTimeSlot = { startTime: '10:00', endTime: '11:30' },
     sessionRestriction = 'OPEN',
-    isSessionForReview = false,
+    sessionForReview = false,
   }: Partial<AvailableVisitSessionDto> = {}): AvailableVisitSessionDto => ({
     sessionDate,
     sessionTemplateReference,
     sessionTimeSlot,
     sessionRestriction,
-    isSessionForReview,
+    sessionForReview,
   })
 
   static bookerPrisonerInfoDto = ({


### PR DESCRIPTION
**Only** if the `FEATURE_VISIT_REQUEST` flag is enabled (currently just dev & staging):
* Update to use available sessions V2 endpoint
* `sessionForReview` flag for selected visiting session stored in booking journey
* `isRequestBooking` flag passed in Dto when calling `/book` endpoint at end of journey