### PR TITLE
VB-5752 Add PVB Urls to config

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     GOVUK_ONE_LOGIN_HOME_URL: "https://home.integration.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
+    PVB_URL: "https://preprod.prisonvisits.prison.service.justice.gov.uk/en/request"
     GOOGLE_ANALYTICS_ID: "G-SSLMWLQYHQ"
 
   allowlist:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,6 +14,7 @@ generic-service:
     GOVUK_ONE_LOGIN_HOME_URL: "https://home.account.gov.uk"
     ORCHESTRATION_API_URL: "https://hmpps-manage-prison-visits-orchestration.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"
+    PVB_URL: "https://www.prisonvisits.service.gov.uk/en/request"
     GOOGLE_ANALYTICS_ID: "G-JJ1QR21HJ7"
 
 generic-prometheus-alerts:

--- a/server/config.ts
+++ b/server/config.ts
@@ -94,6 +94,7 @@ export default {
       agent: new AgentConfig(Number(get('PRISON_REGISTER_API_TIMEOUT_RESPONSE', 10000))),
     },
   },
+  pvbUrl: get('PVB_URL', 'https://dev.prisonvisits.prison.service.justice.gov.uk/en/request', requiredInProduction),
   rateLimit: <Record<string, RateLimitConfig>>{
     // Rate limit config for Add a prisoner journey
     booker: {


### PR DESCRIPTION
Add new config for `PVB_URL` which will be used for redirecting users to PVB for prisons that are not onboarded to the new service.