### PR TITLE
VB-5724 Add data caching and prisons service methods

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -412,6 +412,19 @@ export default {
 
   // orchestration-prisons-config-controller
 
+  stubGetSupportedPrisonIds: (prisonIds = TestData.prisonIds()): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: '/orchestration/config/prisons/user-type/PUBLIC/supported',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: prisonIds,
+      },
+    }),
+
   stubGetSupportedPrisons: (prisons = [TestData.prisonRegisterPrisonDto()]): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/prisonRegister.ts
+++ b/integration_tests/mockApis/prisonRegister.ts
@@ -8,7 +8,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        url: '/prisonRegister/prisons/names',
+        url: '/prisonRegister/prisons/names?active=true',
       },
       response: {
         status: 200,

--- a/server/data/dataCache/dataCache.ts
+++ b/server/data/dataCache/dataCache.ts
@@ -1,0 +1,4 @@
+export interface DataCache {
+  set<DataType>(key: string, data: DataType, durationSeconds: number): Promise<void>
+  get<DataType>(key: string): Promise<DataType | null>
+}

--- a/server/data/dataCache/inMemoryDataCache.test.ts
+++ b/server/data/dataCache/inMemoryDataCache.test.ts
@@ -1,0 +1,21 @@
+import DataCache from './inMemoryDataCache'
+
+describe('inMemoryDataCache', () => {
+  let dataCache: DataCache
+
+  const jsonData = { some: 'data' }
+
+  beforeEach(() => {
+    dataCache = new DataCache()
+  })
+
+  it('Can store and retrieve data', async () => {
+    await dataCache.set('key', jsonData, 10)
+    expect(await dataCache.get('key')).toStrictEqual(jsonData)
+  })
+
+  it('Expires data', async () => {
+    await dataCache.set('key', jsonData, -1)
+    expect(await dataCache.get('key')).toBe(null)
+  })
+})

--- a/server/data/dataCache/inMemoryDataCache.ts
+++ b/server/data/dataCache/inMemoryDataCache.ts
@@ -1,0 +1,18 @@
+import { DataCache } from './dataCache'
+
+export default class InMemoryDataCache implements DataCache {
+  map = new Map<string, { data: string; expiry: Date }>()
+
+  public async set<DataType>(key: string, data: DataType, durationSeconds: number): Promise<void> {
+    this.map.set(key, { data: JSON.stringify(data), expiry: new Date(Date.now() + durationSeconds * 1000) })
+    return Promise.resolve()
+  }
+
+  public async get<DataType>(key: string): Promise<DataType | null> {
+    if (!this.map.has(key) || this.map.get(key).expiry.getTime() < Date.now()) {
+      return Promise.resolve(null)
+    }
+    const parsedData: DataType = JSON.parse(this.map.get(key).data)
+    return Promise.resolve(parsedData)
+  }
+}

--- a/server/data/dataCache/redisDataCache.test.ts
+++ b/server/data/dataCache/redisDataCache.test.ts
@@ -1,0 +1,61 @@
+import { RedisClient } from '../redisClient'
+import DataCache from './redisDataCache'
+
+const redisClient = {
+  get: jest.fn(),
+  set: jest.fn(),
+  incr: jest.fn(),
+  expire: jest.fn(),
+  on: jest.fn(),
+  connect: jest.fn(),
+  isOpen: true,
+} as unknown as jest.Mocked<RedisClient>
+
+describe('redisDataCache', () => {
+  let dataCache: DataCache
+
+  const jsonData = { some: 'data' }
+  const jsonDataAsString = '{"some":"data"}'
+
+  beforeEach(() => {
+    dataCache = new DataCache(redisClient as unknown as RedisClient)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('get data', () => {
+    it('Can retrieve data', async () => {
+      redisClient.get.mockResolvedValue(jsonDataAsString)
+
+      await expect(dataCache.get('key')).resolves.toStrictEqual(jsonData)
+
+      expect(redisClient.get).toHaveBeenCalledWith('dataCache:key')
+    })
+
+    it('Connects when no connection calling get data', async () => {
+      ;(redisClient as unknown as Record<string, boolean>).isOpen = false
+
+      await dataCache.get('key')
+
+      expect(redisClient.connect).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('set data', () => {
+    it('Can set data', async () => {
+      await dataCache.set('key', jsonData, 10)
+
+      expect(redisClient.set).toHaveBeenCalledWith('dataCache:key', jsonDataAsString, { EX: 10 })
+    })
+
+    it('Connects when no connection calling set data', async () => {
+      ;(redisClient as unknown as Record<string, boolean>).isOpen = false
+
+      await dataCache.set('key', jsonData, 10)
+
+      expect(redisClient.connect).toHaveBeenCalledWith()
+    })
+  })
+})

--- a/server/data/dataCache/redisDataCache.ts
+++ b/server/data/dataCache/redisDataCache.ts
@@ -1,0 +1,30 @@
+import type { RedisClient } from '../redisClient'
+
+import { DataCache } from './dataCache'
+
+export default class RedisDataCache implements DataCache {
+  private readonly prefix = 'dataCache:'
+
+  constructor(private readonly client: RedisClient) {}
+
+  private async ensureConnected() {
+    if (!this.client.isOpen) {
+      await this.client.connect()
+    }
+  }
+
+  public async set<DataType>(key: string, data: DataType, durationSeconds: number): Promise<void> {
+    await this.ensureConnected()
+    await this.client.set(`${this.prefix}${key}`, JSON.stringify(data), { EX: durationSeconds })
+  }
+
+  public async get<DataType>(key: string): Promise<DataType | null> {
+    await this.ensureConnected()
+    const result = await this.client.get(`${this.prefix}${key}`)
+    try {
+      return typeof result === 'string' ? <DataType>JSON.parse(result) : null
+    } catch {
+      return null
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -14,19 +14,33 @@ import HmppsAuthClient from './hmppsAuthClient'
 import OrchestrationApiClient from './orchestrationApiClient'
 import tokenStoreFactory from './tokenStore/tokenStoreFactory'
 import PrisonRegisterApiClient from './prisonRegisterApiClient'
+import config from '../config'
+import { createRedisClient, RedisClient } from './redisClient'
+import { DataCache } from './dataCache/dataCache'
+import InMemoryDataCache from './dataCache/inMemoryDataCache'
+import RedisDataCache from './dataCache/redisDataCache'
 
 type RestClientBuilder<T> = (token: string) => T
 
-export const dataAccess = () => ({
-  applicationInfo,
-  hmppsAuthClient: new HmppsAuthClient(tokenStoreFactory('systemToken')),
-  orchestrationApiClientBuilder: ((token: string) =>
-    new OrchestrationApiClient(token)) as RestClientBuilder<OrchestrationApiClient>,
-  prisonRegisterApiClientBuilder: ((token: string) =>
-    new PrisonRegisterApiClient(token)) as RestClientBuilder<PrisonRegisterApiClient>,
-  rateLimitStore: tokenStoreFactory('rateLimit'),
-})
+export const dataAccess = () => {
+  let redisClient: RedisClient
+  if (config.redis.enabled) {
+    redisClient = createRedisClient()
+  }
+  const dataCache = config.redis.enabled ? new RedisDataCache(redisClient) : new InMemoryDataCache()
+
+  return {
+    applicationInfo,
+    dataCache,
+    hmppsAuthClient: new HmppsAuthClient(tokenStoreFactory('systemToken')), // TODO refactor to use redis client defined above
+    orchestrationApiClientBuilder: ((token: string) =>
+      new OrchestrationApiClient(token)) as RestClientBuilder<OrchestrationApiClient>,
+    prisonRegisterApiClientBuilder: ((token: string) =>
+      new PrisonRegisterApiClient(token)) as RestClientBuilder<PrisonRegisterApiClient>,
+    rateLimitStore: tokenStoreFactory('rateLimit'),
+  }
+}
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient, type RestClientBuilder }
+export { type DataCache, HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient, type RestClientBuilder }

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -421,6 +421,21 @@ describe('orchestrationApiClient', () => {
     })
   })
 
+  describe('getSupportedPrisonIds', () => {
+    it('should get list of supported prison IDs', async () => {
+      const prisonIds = ['HEI']
+
+      fakeOrchestrationApi
+        .get('/config/prisons/user-type/PUBLIC/supported')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, prisonIds)
+
+      const result = await orchestrationApiClient.getSupportedPrisonIds()
+
+      expect(result).toStrictEqual(prisonIds)
+    })
+  })
+
   describe('getSupportedPrisons', () => {
     it('should get list of supported prisons', async () => {
       const prisons = [TestData.prisonRegisterPrisonDto()]

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -241,6 +241,10 @@ export default class OrchestrationApiClient {
 
   // orchestration-prisons-config-controller
 
+  async getSupportedPrisonIds(): Promise<string[]> {
+    return this.restClient.get({ path: '/config/prisons/user-type/PUBLIC/supported' })
+  }
+
   async getSupportedPrisons(): Promise<PrisonRegisterPrisonDto[]> {
     return this.restClient.get({ path: '/config/prisons/user-type/PUBLIC/supported/detailed' })
   }

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -32,7 +32,8 @@ export type RegisterPrisonerForBookerDto = components['schemas']['RegisterPrison
 
 export type PrisonDto = components['schemas']['PrisonDto']
 
-export type PrisonRegisterPrisonDto = components['schemas']['PrisonRegisterPrisonDto']
+// FIXME Omitting 'active' until it is removed from the API definition
+export type PrisonRegisterPrisonDto = Omit<components['schemas']['PrisonRegisterPrisonDto'], 'active'>
 
 export type VisitDto = components['schemas']['VisitDto']
 

--- a/server/data/prisonRegisterApiClient.test.ts
+++ b/server/data/prisonRegisterApiClient.test.ts
@@ -28,6 +28,7 @@ describe('prisonRegisterApiClient', () => {
 
       fakePrisonRegisterApi
         .get('/prisons/names')
+        .query({ active: true })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, prisonNames)
 

--- a/server/data/prisonRegisterApiClient.ts
+++ b/server/data/prisonRegisterApiClient.ts
@@ -10,6 +10,6 @@ export default class PrisonRegisterApiClient {
   }
 
   async getPrisonNames(): Promise<PrisonNameDto[]> {
-    return this.restClient.get({ path: '/prisons/names' })
+    return this.restClient.get({ path: '/prisons/names', query: new URLSearchParams({ active: 'true' }).toString() })
   }
 }

--- a/server/data/testutils/mocks.ts
+++ b/server/data/testutils/mocks.ts
@@ -17,11 +17,16 @@ jest.mock('../../applicationInfo', () => {
   return jest.fn(() => testAppInfo)
 })
 
-import { HmppsAuthClient, OrchestrationApiClient } from '..'
+import { DataCache, HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient } from '..'
 
 jest.mock('..')
+
+export const createMockDataCache = () => ({ set: jest.fn(), get: jest.fn() }) as jest.Mocked<DataCache>
 
 export const createMockHmppsAuthClient = () => new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
 
 export const createMockOrchestrationApiClient = () =>
   new OrchestrationApiClient(null) as jest.Mocked<OrchestrationApiClient>
+
+export const createMockPrisonRegisterApiClient = () =>
+  new PrisonRegisterApiClient(null) as jest.Mocked<PrisonRegisterApiClient>

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -214,6 +214,8 @@ export default class TestData {
     convictedStatus,
   })
 
+  static prisonIds = (prisonIds = ['DHI', 'FHI', 'HEI']): string[] => prisonIds
+
   static prisonNameDtos = ({
     prisons = [
       { prisonId: 'DHI', prisonName: 'Drake Hall (HMP & YOI)' },

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -185,9 +185,8 @@ export default class TestData {
   static prisonRegisterPrisonDto = ({
     prisonId = 'HEI',
     prisonName = 'Hewell (HMP)',
-    active = true,
   }: Partial<PrisonRegisterPrisonDto> = {}): PrisonRegisterPrisonDto =>
-    ({ prisonId, prisonName, active }) as PrisonRegisterPrisonDto
+    ({ prisonId, prisonName }) as PrisonRegisterPrisonDto
 
   static prisoner = ({
     prisonerDisplayId = 'uuidv4-1',

--- a/server/routes/unauthenticatedRoutes.ts
+++ b/server/routes/unauthenticatedRoutes.ts
@@ -18,6 +18,7 @@ export default function routes({ prisonService }: Services): Router {
       return res.redirect(paths.HOME)
     }
 
+    // TODO does this call need caching?
     const supportedPrisons = await prisonService.getSupportedPrisons()
     return res.render('pages/serviceStart', { supportedPrisons, hideGOVUKServiceNav: true })
   })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -7,7 +7,14 @@ import VisitService from './visitService'
 import VisitSessionsService from './visitSessionsService'
 
 export const services = () => {
-  const { applicationInfo, hmppsAuthClient, orchestrationApiClientBuilder, rateLimitStore } = dataAccess()
+  const {
+    applicationInfo,
+    dataCache,
+    hmppsAuthClient,
+    orchestrationApiClientBuilder,
+    prisonRegisterApiClientBuilder,
+    rateLimitStore,
+  } = dataAccess()
 
   const bookerService = new BookerService(
     orchestrationApiClientBuilder,
@@ -16,7 +23,12 @@ export const services = () => {
     new RateLimitService(rateLimitStore, config.rateLimit.prisoner),
   )
 
-  const prisonService = new PrisonService(orchestrationApiClientBuilder, hmppsAuthClient)
+  const prisonService = new PrisonService(
+    orchestrationApiClientBuilder,
+    prisonRegisterApiClientBuilder,
+    hmppsAuthClient,
+    dataCache,
+  )
 
   const visitService = new VisitService(orchestrationApiClientBuilder, hmppsAuthClient)
 

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,11 +1,36 @@
-import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
+import { DataCache, HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient, RestClientBuilder } from '../data'
 import { PrisonDto, PrisonRegisterPrisonDto } from '../data/orchestrationApiTypes'
+import { PrisonNameDto } from '../data/prisonRegisterApiTypes'
+
+type CacheConfig = { key: string; ttlSecs: number }
 
 export default class PrisonService {
+  private readonly allPrisonNamesCache: CacheConfig = { key: 'prisonNames', ttlSecs: 60 * 60 * 24 } // 24 hour cache
+
+  private readonly supportedPrisonIdsCache: CacheConfig = { key: 'supportedPrisonIds', ttlSecs: 60 * 5 } // 5 min cache
+
   constructor(
     private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
+    private readonly prisonRegisterApiClientFactory: RestClientBuilder<PrisonRegisterApiClient>,
     private readonly hmppsAuthClient: HmppsAuthClient,
+    private readonly dataCache: DataCache,
   ) {}
+
+  async getAllPrisonNames(): Promise<PrisonNameDto[]> {
+    const cachedAllPrisonNames = await this.dataCache.get<PrisonNameDto[]>(this.allPrisonNamesCache.key)
+
+    if (cachedAllPrisonNames) {
+      return cachedAllPrisonNames
+    }
+
+    const token = await this.hmppsAuthClient.getSystemClientToken()
+    const prisonRegisterApiClient = this.prisonRegisterApiClientFactory(token)
+
+    const allPrisonNames = await prisonRegisterApiClient.getPrisonNames()
+
+    await this.dataCache.set(this.allPrisonNamesCache.key, allPrisonNames, this.allPrisonNamesCache.ttlSecs)
+    return allPrisonNames
+  }
 
   async getSupportedPrisons(): Promise<PrisonRegisterPrisonDto[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
@@ -19,5 +44,25 @@ export default class PrisonService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
     return orchestrationApiClient.getPrison(prisonCode)
+  }
+
+  async isSupportedPrison(prisonCode: string): Promise<boolean> {
+    return (await this.getSupportedPrisonIds()).includes(prisonCode)
+  }
+
+  private async getSupportedPrisonIds(): Promise<string[]> {
+    const cachedSupportedPrisonIds = await this.dataCache.get<string[]>(this.supportedPrisonIdsCache.key)
+
+    if (cachedSupportedPrisonIds) {
+      return cachedSupportedPrisonIds
+    }
+
+    const token = await this.hmppsAuthClient.getSystemClientToken()
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+
+    const supportedPrisonIds = await orchestrationApiClient.getSupportedPrisonIds()
+
+    await this.dataCache.set(this.supportedPrisonIdsCache.key, supportedPrisonIds, this.supportedPrisonIdsCache.ttlSecs)
+    return supportedPrisonIds
   }
 }

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -23,7 +23,7 @@ jest.mock('..')
 
 export const createMockBookerService = () => new BookerService(null, null, null, null) as jest.Mocked<BookerService>
 
-export const createMockPrisonService = () => new PrisonService(null, null) as jest.Mocked<PrisonService>
+export const createMockPrisonService = () => new PrisonService(null, null, null, null) as jest.Mocked<PrisonService>
 
 export const createMockRateLimitService = () => new RateLimitService(null, null) as jest.Mocked<RateLimitService>
 


### PR DESCRIPTION
* Add simple cache for JSON data, with Redis and in-memory versions. (Based on similar existing TokenStore implementation)
* Add service methods for getting all prison names and identifying if a prison is supported in the service (to be used on forthcoming select a prison page)

N.B. none of this code is used yet: it's to support upcoming features.