### PR TITLE
VB-5674, VB-5760 Select prison and selected prison page, with autocomplete

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -12,6 +12,8 @@ $path: "/assets/images/";
 // GOV.UK One Login components
 @import './components/service-header-no-imports';
 
+@import 'dist/accessible-autocomplete.min';
+
 @import './components/visits-spacing';
-@import './components/visitsCalendar.scss';
+@import './components/visitsCalendar';
 @import './local';

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -2,6 +2,10 @@
   min-height: 300px;
 }
 
+.autocomplete__wrapper {
+  @include govuk-typography-common();
+}
+
 .govuk-panel.visits-request-confirmation {
   background-color: govuk-colour("blue");
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import hmppsAuth from './integration_tests/mockApis/hmppsAuth'
 import govukOneLogin from './integration_tests/mockApis/govukOneLogin'
+import pvb from './integration_tests/mockApis/pvb'
 import redisHelpers from './integration_tests/redis/redisHelpers'
 import orchestrationService from './integration_tests/mockApis/orchestration'
 import prisonRegister from './integration_tests/mockApis/prisonRegister'
@@ -20,12 +21,13 @@ export default defineConfig({
   e2e: {
     setupNodeEvents(on) {
       on('task', {
-        reset: resetStubs,
+        reset: () => Promise.all([redisHelpers.clearDataCache(), resetStubs()]),
         ...hmppsAuth,
         ...govukOneLogin,
         ...redisHelpers,
         ...orchestrationService,
         ...prisonRegister,
+        ...pvb,
 
         // Log message to console
         log: (message: string) => {

--- a/integration_tests/e2e/selectPrison.cy.ts
+++ b/integration_tests/e2e/selectPrison.cy.ts
@@ -1,0 +1,54 @@
+import paths from '../../server/constants/paths'
+import GovukOneLoginPage from '../pages/govukOneLogin'
+import Page from '../pages/page'
+import SelectedPrisonPage from '../pages/selectPrison/selectedPrison'
+import SelectPrisonPage from '../pages/selectPrison/selectPrison'
+
+context('Select a prison', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
+    cy.task('stubSignIn')
+  })
+
+  it('should select a supported prison and go to GOVUK One Login', () => {
+    cy.hideCookieBanner()
+
+    // Start at select prison page and type into autocomplete input
+    cy.visit(paths.SELECT_PRISON)
+    const selectPrisonPage = Page.verifyOnPage(SelectPrisonPage)
+    selectPrisonPage.autoCompletePrisonName('Hew', 'Hewell (HMP)')
+
+    // Submit selected prison
+    cy.task('stubGetSupportedPrisonIds')
+    cy.task('stubGetPrison')
+    selectPrisonPage.continue()
+
+    // Visiting selected prison page
+    const selectedPrisonPage = Page.verifyOnPage(SelectedPrisonPage, 'Hewell (HMP)')
+
+    // Continue
+    selectedPrisonPage.continue()
+
+    // Redirected to GOV.UK One Login Page
+    Page.verifyOnPage(GovukOneLoginPage)
+  })
+
+  it('should select an unsupported prison be redirected to PVB', () => {
+    cy.hideCookieBanner()
+
+    // Start at select prison page and type into autocomplete input
+    cy.visit(paths.SELECT_PRISON)
+    const selectPrisonPage = Page.verifyOnPage(SelectPrisonPage)
+    selectPrisonPage.autoCompletePrisonName('Hew', 'Hewell (HMP)')
+
+    // Submit selected prison
+    cy.task('stubGetSupportedPrisonIds', []) // none supported
+    cy.task('stubPvbRequestPage')
+    selectPrisonPage.continue()
+
+    // Redirected to PVB request page
+    cy.contains('PVB request page')
+  })
+})

--- a/integration_tests/mockApis/pvb.ts
+++ b/integration_tests/mockApis/pvb.ts
@@ -1,0 +1,20 @@
+import { SuperAgentRequest } from 'superagent'
+import { stubFor } from './wiremock'
+
+export default {
+  stubPvbRequestPage: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath: '/pvb/en/request',
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html',
+        },
+        body: '<html><body><h1>PVB request page</h1></body></html>',
+      },
+    })
+  },
+}

--- a/integration_tests/pages/selectPrison/selectPrison.ts
+++ b/integration_tests/pages/selectPrison/selectPrison.ts
@@ -1,0 +1,20 @@
+import Page from '../page'
+
+export default class SelectPrisonPage extends Page {
+  constructor() {
+    super('Which prison are you visiting?')
+  }
+
+  autoCompletePrisonName = (startChars: string, expectedMatch: string): void => {
+    // enter initial characters to autocomplete input
+    cy.get('#prisonId').type(startChars)
+    // keypresses to choose match that should be found
+    cy.get('#prisonId').type('{downArrow}{enter}')
+    // check match
+    cy.get('#prisonId').should('have.value', expectedMatch)
+  }
+
+  continue = (): void => {
+    cy.get('[data-test="continue-button"]').click()
+  }
+}

--- a/integration_tests/pages/selectPrison/selectedPrison.ts
+++ b/integration_tests/pages/selectPrison/selectedPrison.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class SelectedPrisonPage extends Page {
+  constructor(private readonly prisonName: string) {
+    super(`Visiting ${prisonName}`)
+  }
+
+  continue = (): void => {
+    cy.get('[data-test="continue-button"]').click()
+  }
+}

--- a/integration_tests/redis/redisHelpers.ts
+++ b/integration_tests/redis/redisHelpers.ts
@@ -2,7 +2,7 @@
 import logger from '../../logger'
 import { createRedisClient } from '../../server/data/redisClient'
 
-const dataCacheKeyPattern = 'dataCache:*'
+const dataCacheKeyPattern = 'dataCache_*'
 const rateLimitKeyPattern = 'rateLimit:*'
 
 const clearDataCache = async () => {

--- a/integration_tests/redis/redisHelpers.ts
+++ b/integration_tests/redis/redisHelpers.ts
@@ -2,21 +2,32 @@
 import logger from '../../logger'
 import { createRedisClient } from '../../server/data/redisClient'
 
+const dataCacheKeyPattern = 'dataCache:*'
 const rateLimitKeyPattern = 'rateLimit:*'
 
+const clearDataCache = async () => {
+  await clearCache(dataCacheKeyPattern)
+  logger.info('Data cache cleared')
+  return null
+}
+
 const clearRateLimits = async () => {
+  await clearCache(rateLimitKeyPattern)
+  logger.info('Rate limits cleared')
+  return null
+}
+
+const clearCache = async (keyPattern: string) => {
   const client = createRedisClient()
   await client.connect()
 
-  const keys = await client.keys(rateLimitKeyPattern)
+  const keys = await client.keys(keyPattern)
 
   if (keys.length > 0) {
     await client.del(keys)
-    logger.info('Rate limits cleared')
   }
 
   await client.quit()
-  return Promise.resolve(null)
 }
 
 const waitUntilRateLimitsExpire = async () => {
@@ -47,4 +58,4 @@ const waitUntilRateLimitsExpire = async () => {
   return null
 }
 
-export default { clearRateLimits, waitUntilRateLimitsExpire }
+export default { clearDataCache, clearRateLimits, waitUntilRateLimitsExpire }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/frontend": "^5.1.4",
+        "accessible-autocomplete": "^3.0.1",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^2.9.7",
         "bunyan": "^1.8.15",
@@ -3529,6 +3530,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz",
+      "integrity": "sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "husky",
     "copy-views": "cp -R server/views dist/server/",
-    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
+    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice/frontend --load-path=node_modules/accessible-autocomplete --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
     "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^5.1.4",
+    "accessible-autocomplete": "^3.0.1",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^2.9.7",
     "bunyan": "^1.8.15",

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -31,6 +31,8 @@ declare module 'express-session' {
     }
 
     bookingCancelled?: BookingCancelled
+
+    selectedPrisonId?: string
   }
 }
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -94,7 +94,7 @@ export default {
       agent: new AgentConfig(Number(get('PRISON_REGISTER_API_TIMEOUT_RESPONSE', 10000))),
     },
   },
-  pvbUrl: get('PVB_URL', 'https://dev.prisonvisits.prison.service.justice.gov.uk/en/request', requiredInProduction),
+  pvbUrl: get('PVB_URL', 'http://localhost:9091/pvb/en/request', requiredInProduction),
   rateLimit: <Record<string, RateLimitConfig>>{
     // Rate limit config for Add a prisoner journey
     booker: {

--- a/server/config.ts
+++ b/server/config.ts
@@ -43,7 +43,7 @@ export type RateLimitConfig = {
 export default {
   buildNumber: get('BUILD_NUMBER', '1_0_0', requiredInProduction),
   productId: get('PRODUCT_ID', 'UNASSIGNED', requiredInProduction),
-  gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
+  gitRef: get('GIT_REF', 'git-ref', requiredInProduction),
   branchName: get('GIT_BRANCH', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   production,
   https: production,

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -4,6 +4,7 @@ const paths = {
   RETURN_HOME: '/return-home', // used to clear session and redirect to HOME
 
   SELECT_PRISON: '/select-prison',
+  SELECTED_PRISON: '/visiting-selected-prison',
 
   AUTH_CALLBACK: '/auth/callback',
   AUTH_ERROR: '/auth-error',

--- a/server/data/dataCache/redisDataCache.test.ts
+++ b/server/data/dataCache/redisDataCache.test.ts
@@ -18,7 +18,7 @@ describe('redisDataCache', () => {
   const jsonDataAsString = '{"some":"data"}'
 
   beforeEach(() => {
-    dataCache = new DataCache(redisClient as unknown as RedisClient)
+    dataCache = new DataCache(redisClient as unknown as RedisClient, 'gitRef')
   })
 
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('redisDataCache', () => {
 
       await expect(dataCache.get('key')).resolves.toStrictEqual(jsonData)
 
-      expect(redisClient.get).toHaveBeenCalledWith('dataCache:key')
+      expect(redisClient.get).toHaveBeenCalledWith('dataCache_gitRef:key')
     })
 
     it('Connects when no connection calling get data', async () => {
@@ -47,7 +47,7 @@ describe('redisDataCache', () => {
     it('Can set data', async () => {
       await dataCache.set('key', jsonData, 10)
 
-      expect(redisClient.set).toHaveBeenCalledWith('dataCache:key', jsonDataAsString, { EX: 10 })
+      expect(redisClient.set).toHaveBeenCalledWith('dataCache_gitRef:key', jsonDataAsString, { EX: 10 })
     })
 
     it('Connects when no connection calling set data', async () => {

--- a/server/data/dataCache/redisDataCache.ts
+++ b/server/data/dataCache/redisDataCache.ts
@@ -3,9 +3,17 @@ import type { RedisClient } from '../redisClient'
 import { DataCache } from './dataCache'
 
 export default class RedisDataCache implements DataCache {
-  private readonly prefix = 'dataCache:'
+  private readonly prefix: string
 
-  constructor(private readonly client: RedisClient) {}
+  constructor(
+    private readonly client: RedisClient,
+    private readonly gitRef: string,
+  ) {
+    // include short Git ref in prefix to invalidate data cache on deploy of new build
+    // to avoid errors should data type stored for a key change between builds
+    const shortGitRef = gitRef.slice(0, 7)
+    this.prefix = `dataCache_${shortGitRef}:`
+  }
 
   private async ensureConnected() {
     if (!this.client.isOpen) {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -27,7 +27,7 @@ export const dataAccess = () => {
   if (config.redis.enabled) {
     redisClient = createRedisClient()
   }
-  const dataCache = config.redis.enabled ? new RedisDataCache(redisClient) : new InMemoryDataCache()
+  const dataCache = config.redis.enabled ? new RedisDataCache(redisClient, config.gitRef) : new InMemoryDataCache()
 
   return {
     applicationInfo,

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -12,6 +12,7 @@ import {
   CreateApplicationDto,
   VisitDto,
 } from './orchestrationApiTypes'
+import { disableFeatureForTest, enableFeatureForTest } from './testutils/mockFeatureFlags'
 
 describe('orchestrationApiClient', () => {
   let fakeOrchestrationApi: nock.Scope
@@ -331,10 +332,7 @@ describe('orchestrationApiClient', () => {
 
     describe('Feature flag FEATURE_VISIT_REQUEST enabled - use v2 API', () => {
       it('should get available visit sessions for prison / prisoner / visitors', async () => {
-        jest.replaceProperty(config, 'features', {
-          ...config.features,
-          visitRequest: true,
-        })
+        enableFeatureForTest('visitRequest')
 
         orchestrationApiClient = new OrchestrationApiClient(token)
         fakeOrchestrationApi
@@ -364,10 +362,7 @@ describe('orchestrationApiClient', () => {
 
     describe('Feature flag FEATURE_VISIT_REQUEST disabled - use original API', () => {
       it('should get available visit sessions for prison / prisoner / visitors', async () => {
-        jest.replaceProperty(config, 'features', {
-          ...config.features,
-          visitRequest: false,
-        })
+        disableFeatureForTest('visitRequest')
 
         orchestrationApiClient = new OrchestrationApiClient(token)
         fakeOrchestrationApi

--- a/server/data/testutils/mockFeatureFlags.ts
+++ b/server/data/testutils/mockFeatureFlags.ts
@@ -1,0 +1,17 @@
+import config from '../../config'
+
+type FeatureNames = keyof typeof config.features
+
+export const enableFeatureForTest = (feature: FeatureNames) => {
+  jest.replaceProperty(config, 'features', {
+    ...config.features,
+    [feature]: true,
+  })
+}
+
+export const disableFeatureForTest = (feature: FeatureNames) => {
+  jest.replaceProperty(config, 'features', {
+    ...config.features,
+    [feature]: false,
+  })
+}

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -19,6 +19,7 @@ export default function setUpStaticResources(): Router {
     '/assets/js',
     '/node_modules/govuk-frontend/dist/govuk/assets',
     '/node_modules/govuk-frontend/dist',
+    '/node_modules/accessible-autocomplete/dist',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -41,6 +41,7 @@ export default function setUpWebSecurity(): Router {
             "'self'",
             config.apis.govukOneLogin.url,
             config.apis.govukOneLogin.url.replace('oidc', 'signin'),
+            config.pvbUrl,
           ],
           upgradeInsecureRequests: process.env.NODE_ENV === 'development' ? null : [],
         },

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -12,7 +12,7 @@ import logger from '../../../logger'
 import { ApplicationValidationErrorResponse } from '../../data/orchestrationApiTypes'
 import { SanitisedError } from '../../sanitisedError'
 import { SessionRestriction } from '../../data/orchestrationApiClient'
-import config from '../../config'
+import { disableFeatureForTest, enableFeatureForTest } from '../../data/testutils/mockFeatureFlags'
 
 jest.mock('../../../logger')
 
@@ -131,10 +131,7 @@ describe('Check visit details', () => {
 
   describe(`POST ${paths.BOOK_VISIT.CHECK_DETAILS}`, () => {
     beforeEach(() => {
-      jest.replaceProperty(config, 'features', {
-        ...config.features,
-        visitRequest: true,
-      })
+      enableFeatureForTest('visitRequest')
 
       app = appWithAllRoutes({ services: { visitService }, sessionData })
     })
@@ -212,10 +209,7 @@ describe('Check visit details', () => {
 
       describe('Feature flag', () => {
         it('should ignore visitSubStatus and handle as a BOOKED visit when FEATURE_VISIT_REQUEST disabled', () => {
-          jest.replaceProperty(config, 'features', {
-            ...config.features,
-            visitRequest: false,
-          })
+          disableFeatureForTest('visitRequest')
 
           app = appWithAllRoutes({ services: { visitService }, sessionData })
 

--- a/server/routes/selectPrison/selectPrisonController.test.ts
+++ b/server/routes/selectPrison/selectPrisonController.test.ts
@@ -1,0 +1,140 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { SessionData } from 'express-session'
+import { FieldValidationError } from 'express-validator'
+import { FlashData, appWithAllRoutes, flashProvider } from '../testutils/appSetup'
+import TestData from '../testutils/testData'
+import paths from '../../constants/paths'
+import { createMockPrisonService } from '../../services/testutils/mocks'
+import { enableFeatureForTest } from '../../data/testutils/mockFeatureFlags'
+import config from '../../config'
+
+let app: Express
+let sessionData: SessionData
+
+const prisonNames = TestData.prisonNameDtos()
+const prisonService = createMockPrisonService()
+
+beforeEach(() => {
+  enableFeatureForTest('visitRequest')
+
+  sessionData = {} as SessionData
+  prisonService.getAllPrisonNames.mockResolvedValue(prisonNames)
+
+  app = appWithAllRoutes({ services: { prisonService }, sessionData })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Select a prison', () => {
+  describe(`GET ${paths.SELECT_PRISON}`, () => {
+    let flashData: FlashData
+
+    beforeEach(() => {
+      flashData = {}
+      flashProvider.mockImplementation((key: keyof FlashData) => flashData[key])
+    })
+
+    it('should render select prison page with list of prisons and store supported prison in session', () => {
+      sessionData.selectedPrisonId = 'HEI'
+
+      return request(app)
+        .get(paths.SELECT_PRISON)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Which prison are you visiting\? -/)
+          expect($('#service-header__nav').length).toBe(0)
+          expect($('[data-test="back-link"]').attr('href')).toBe('https://www.gov.uk/prison-visits')
+          expect($('h1').text().trim()).toBe('Which prison are you visiting?')
+
+          expect($('form[method=POST]').attr('action')).toBe(paths.SELECT_PRISON)
+          expect($('select#prisonId option').length).toBe(prisonNames.length + 1) // all prisons and default empty option
+          expect($('select#prisonId option[value="HEI"]').text()).toBe('Hewell (HMP)')
+          expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
+
+          expect(sessionData.selectedPrisonId).toBeUndefined()
+          expect(prisonService.getAllPrisonNames).toHaveBeenCalled()
+        })
+    })
+
+    it('should render validation errors', () => {
+      const validationError: FieldValidationError = {
+        type: 'field',
+        location: 'body',
+        path: 'prisonId',
+        value: [],
+        msg: 'No prison selected',
+      }
+
+      flashData = { errors: [validationError] }
+
+      return request(app)
+        .get(paths.SELECT_PRISON)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('.govuk-error-summary a[href="#prisonId-error"]').text()).toBe('No prison selected')
+          expect($('#prisonId-error').text()).toContain('No prison selected')
+        })
+    })
+  })
+
+  describe(`POST ${paths.SELECT_PRISON}`, () => {
+    it('should save selected prison to session and redirect to selected prison info page - supported prison', () => {
+      const prisonId = 'HEI'
+      prisonService.isSupportedPrison.mockResolvedValue(true)
+
+      return request(app)
+        .post(paths.SELECT_PRISON)
+        .send({ prisonId })
+        .expect(302)
+        .expect('Location', paths.SELECTED_PRISON)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalled()
+          expect(sessionData.selectedPrisonId).toBe(prisonId)
+          expect(prisonService.isSupportedPrison).toHaveBeenCalledWith(prisonId)
+        })
+    })
+
+    it('should not save selected prison to session and should redirect to PVB - unsupported prison', () => {
+      const prisonId = 'HEI'
+      prisonService.isSupportedPrison.mockResolvedValue(false)
+
+      return request(app)
+        .post(paths.SELECT_PRISON)
+        .send({ prisonId })
+        .expect(302)
+        .expect('Location', config.pvbUrl)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalled()
+          expect(sessionData.selectedPrisonId).toBeUndefined()
+          expect(prisonService.isSupportedPrison).toHaveBeenCalledWith(prisonId)
+        })
+    })
+
+    describe('Validation errors', () => {
+      let expectedFlashErrors: FieldValidationError[]
+
+      beforeEach(() => {
+        expectedFlashErrors = [
+          { type: 'field', location: 'body', path: 'prisonId', value: undefined, msg: 'No prison selected' },
+        ]
+      })
+
+      it('should set a validation error and redirect to original page when no prison selected', () => {
+        return request(app)
+          .post(paths.SELECT_PRISON)
+          .expect(302)
+          .expect('Location', paths.SELECT_PRISON)
+          .expect(() => {
+            expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
+            expect(sessionData.selectedPrisonId).toBeUndefined()
+          })
+      })
+    })
+  })
+})

--- a/server/routes/selectPrison/selectPrisonController.ts
+++ b/server/routes/selectPrison/selectPrisonController.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from 'express'
+import { body, matchedData, ValidationChain, validationResult } from 'express-validator'
+import { PrisonService } from '../../services'
+import paths from '../../constants/paths'
+import config from '../../config'
+
+export default class SelectPrisonController {
+  public constructor(private readonly prisonService: PrisonService) {}
+
+  public view(): RequestHandler {
+    return async (req, res) => {
+      delete req.session.selectedPrisonId
+
+      const prisons = await this.prisonService.getAllPrisonNames()
+
+      return res.render('pages/selectPrison/selectPrison', {
+        errors: req.flash('errors'),
+        prisons,
+      })
+    }
+  }
+
+  public submit(): RequestHandler {
+    return async (req, res) => {
+      const errors = validationResult(req)
+      if (!errors.isEmpty()) {
+        req.flash('errors', errors.array())
+        return res.redirect(paths.SELECT_PRISON)
+      }
+
+      const { prisonId } = matchedData<{ prisonId: string }>(req)
+      const isSupportedPrison = await this.prisonService.isSupportedPrison(prisonId)
+
+      if (isSupportedPrison) {
+        req.session.selectedPrisonId = prisonId
+        return res.redirect(paths.SELECTED_PRISON)
+      }
+
+      return res.redirect(config.pvbUrl)
+    }
+  }
+
+  public validate(): ValidationChain[] {
+    return [body('prisonId').isLength({ min: 3, max: 3 }).withMessage('No prison selected')]
+  }
+}

--- a/server/routes/selectPrison/selectedPrisonController.test.ts
+++ b/server/routes/selectPrison/selectedPrisonController.test.ts
@@ -1,0 +1,62 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { SessionData } from 'express-session'
+import { appWithAllRoutes } from '../testutils/appSetup'
+import TestData from '../testutils/testData'
+import paths from '../../constants/paths'
+import { createMockPrisonService } from '../../services/testutils/mocks'
+import { enableFeatureForTest } from '../../data/testutils/mockFeatureFlags'
+
+let app: Express
+let sessionData: SessionData
+
+const prison = TestData.prisonDto()
+const prisonService = createMockPrisonService()
+
+beforeEach(() => {
+  enableFeatureForTest('visitRequest')
+
+  sessionData = {} as SessionData
+  prisonService.getPrison.mockResolvedValue(prison)
+
+  app = appWithAllRoutes({ services: { prisonService }, sessionData })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Visiting selected prison page', () => {
+  describe(`GET ${paths.SELECTED_PRISON}`, () => {
+    it('should render visiting selected prison page', () => {
+      sessionData.selectedPrisonId = 'HEI'
+
+      return request(app)
+        .get(paths.SELECTED_PRISON)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Visiting Hewell \(HMP\) -/)
+          expect($('#service-header__nav').length).toBe(0)
+          expect($('[data-test="back-link"]').attr('href')).toBe(paths.SELECT_PRISON)
+          expect($('h1').text().trim()).toBe('Visiting Hewell (HMP)')
+
+          expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
+          expect($('[data-test="continue-button"]').attr('href')).toBe(paths.SIGN_IN)
+
+          expect(prisonService.getPrison).toHaveBeenCalledWith(sessionData.selectedPrisonId)
+        })
+    })
+
+    it('should redirect to select prison page if selected prison not set in session', () => {
+      return request(app)
+        .get(paths.SELECTED_PRISON)
+        .expect(302)
+        .expect('Location', paths.SELECT_PRISON)
+        .expect(() => {
+          expect(prisonService.getPrison).not.toHaveBeenCalled()
+        })
+    })
+  })
+})

--- a/server/routes/selectPrison/selectedPrisonController.ts
+++ b/server/routes/selectPrison/selectedPrisonController.ts
@@ -1,0 +1,21 @@
+import type { RequestHandler } from 'express'
+import { PrisonService } from '../../services'
+import paths from '../../constants/paths'
+
+export default class SelectedPrisonController {
+  public constructor(private readonly prisonService: PrisonService) {}
+
+  public view(): RequestHandler {
+    return async (req, res) => {
+      const { selectedPrisonId } = req.session
+
+      if (!selectedPrisonId) {
+        return res.redirect(paths.SELECT_PRISON)
+      }
+
+      const { prisonName } = await this.prisonService.getPrison(selectedPrisonId)
+
+      return res.render('pages/selectPrison/selectedPrison', { prisonName })
+    }
+  }
+}

--- a/server/routes/unauthenticatedRoutes.ts
+++ b/server/routes/unauthenticatedRoutes.ts
@@ -4,14 +4,26 @@ import paths from '../constants/paths'
 import config from '../config'
 import CookiesController from './cookies/cookiesController'
 import staticPagesRoutes from './staticPages'
+import SelectPrisonController from './selectPrison/selectPrisonController'
+import SelectedPrisonController from './selectPrison/selectedPrisonController'
 
 export default function routes({ prisonService }: Services): Router {
   const router = Router()
 
-  // Legacy service (PVB) redirect
-  router.get(paths.SELECT_PRISON, (req, res) => {
-    return res.redirect(config.pvbUrl)
-  })
+  if (config.features.visitRequest) {
+    const selectPrisonController = new SelectPrisonController(prisonService)
+    const selectedPrisonController = new SelectedPrisonController(prisonService)
+
+    router.get(paths.SELECT_PRISON, selectPrisonController.view())
+    router.post(paths.SELECT_PRISON, selectPrisonController.validate(), selectPrisonController.submit())
+
+    router.get(paths.SELECTED_PRISON, selectedPrisonController.view())
+  } else {
+    // Legacy service (PVB) redirect
+    router.get(paths.SELECT_PRISON, (req, res) => {
+      return res.redirect(config.pvbUrl)
+    })
+  }
 
   // Service start page
   router.get(paths.START, async (req, res) => {

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -58,7 +58,7 @@ describe('Prison service', () => {
       expect(await prisonService.getAllPrisonNames()).toStrictEqual(prisonNames)
 
       expect(dataCache.get).toHaveBeenCalledWith('prisonNames')
-      expect(dataCache.set).toHaveBeenCalledWith('prisonNames', prisonNames, 86400) // 24 hours
+      expect(dataCache.set).toHaveBeenCalledWith('prisonNames', prisonNames, 3600) // 1 hour
       expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalled()
     })
   })
@@ -122,7 +122,7 @@ describe('Prison service', () => {
       expect(await prisonService.isSupportedPrison('XYZ')).toBe(false)
 
       expect(dataCache.get).toHaveBeenCalledWith('supportedPrisonIds')
-      expect(dataCache.set).toHaveBeenCalledWith('supportedPrisonIds', prisonIds, 300)
+      expect(dataCache.set).toHaveBeenCalledWith('supportedPrisonIds', prisonIds, 300) // 5 mins
       expect(orchestrationApiClient.getSupportedPrisonIds).toHaveBeenCalled()
     })
   })

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -58,7 +58,7 @@ describe('Prison service', () => {
       expect(await prisonService.getAllPrisonNames()).toStrictEqual(prisonNames)
 
       expect(dataCache.get).toHaveBeenCalledWith('prisonNames')
-      expect(dataCache.set).toHaveBeenCalledWith('prisonNames', prisonNames, 3600) // 1 hour
+      expect(dataCache.set).toHaveBeenCalledWith('prisonNames', prisonNames, 86400) // 24 hours
       expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalled()
     })
   })

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -5,7 +5,7 @@ import { PrisonNameDto } from '../data/prisonRegisterApiTypes'
 type CacheConfig = { key: string; ttlSecs: number }
 
 export default class PrisonService {
-  private readonly allPrisonNamesCache: CacheConfig = { key: 'prisonNames', ttlSecs: 60 * 60 } // 1 hour cache
+  private readonly allPrisonNamesCache: CacheConfig = { key: 'prisonNames', ttlSecs: 60 * 60 * 24 } // 24 hour cache
 
   private readonly supportedPrisonIdsCache: CacheConfig = { key: 'supportedPrisonIds', ttlSecs: 60 * 5 } // 5 min cache
 

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -5,7 +5,7 @@ import { PrisonNameDto } from '../data/prisonRegisterApiTypes'
 type CacheConfig = { key: string; ttlSecs: number }
 
 export default class PrisonService {
-  private readonly allPrisonNamesCache: CacheConfig = { key: 'prisonNames', ttlSecs: 60 * 60 * 24 } // 24 hour cache
+  private readonly allPrisonNamesCache: CacheConfig = { key: 'prisonNames', ttlSecs: 60 * 60 } // 1 hour cache
 
   private readonly supportedPrisonIdsCache: CacheConfig = { key: 'supportedPrisonIds', ttlSecs: 60 * 5 } // 5 min cache
 

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -1,0 +1,65 @@
+{% extends "partials/layout.njk" %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = "Which prison are you visiting?" %}
+
+{% set backLinkHref = "https://www.gov.uk/prison-visits" %}
+
+{% set prisonSelectItems = [{ value: "", text: "Select a prison" }] %}
+{% for prison in prisons %}
+  {% set prisonSelectItems = (prisonSelectItems.push({
+    value: prison.prisonId,
+    text: prison.prisonName
+  }), prisonSelectItems) %}
+{% endfor %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+      <form action="{{ paths.SELECT_PRISON }}" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        {{ govukSelect({
+          name: "prisonId",
+          label: {
+            text: "Select a prison",
+            classes: "govuk-visually-hidden"
+          },
+          hint: {
+            text: "For example, Cardiff (HMP)"
+          },
+          items: prisonSelectItems,
+          errorMessage: errors | findError('prisonId')
+        }) }}
+
+        {{ govukButton({
+          text: "Continue",
+          attributes: { "data-test": "continue-button" },
+          preventDoubleClick: true
+        }) }} 
+
+      </form>
+
+      <h2 class="govuk-heading-m">What if I don’t know the prisoner’s location?</h2>
+      <p>
+        You can <a href="https://www.gov.uk/find-prisoner">apply to find the prisoner’s location</a>.
+      </p>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/assets/accessible-autocomplete.min.js"></script>
+  <script nonce="{{ cspNonce }}">
+    accessibleAutocomplete.enhanceSelectElement({
+      defaultValue: '',
+      selectElement: document.querySelector('#prisonId')
+    })
+  </script>
+{% endblock %}

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -19,6 +19,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      {% include "partials/errorSummary.njk" %}
+
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
       <form action="{{ paths.SELECT_PRISON }}" method="POST" novalidate>

--- a/server/views/pages/selectPrison/selectedPrison.njk
+++ b/server/views/pages/selectPrison/selectedPrison.njk
@@ -1,0 +1,40 @@
+{% extends "partials/layout.njk" %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = "Visiting " + prisonName %}
+
+{% set backLinkHref = paths.SELECT_PRISON %}
+
+{% set insetText -%}
+  You can only book visits for one prisoner at
+  <span data-test="prison-name">{{ prisonName }}</span>
+  using this service. If you need to visit another prisoner,
+  <a href="https://www.gov.uk/government/collections/prisons-in-england-and-wales">contact the prison directly</a>.
+{%- endset %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+      <p>How you book visits at this prison has changed.</p>
+
+      <p>You need to sign in or create a GOV.UK One Login to book a visit online.</p>
+
+      {{ govukInsetText({
+        html: insetText
+      }) }}
+
+      {{ govukButton({
+        text: "Continue",
+        href: paths.SIGN_IN,
+        attributes: { "data-test": "continue-button" },
+        preventDoubleClick: true
+      }) }} 
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
* Add pages for 'Select prison' journey
  * for supported prisons a user is sent to a prison info page and then logs in to the service
  * for unsupported prisons the user is redirected to PVB
* Integration tests for these journeys
* Added helper methods for mocking feature flags in tests

N.B. This journey is only enabled in dev and staging currently because of the `FEATURE_VISIT_REQUEST` flag. 