### PR TITLE
Tweak dataCache prefix

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -8,6 +8,8 @@ SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
 ENVIRONMENT_NAME=dev
 
+DATA_CACHE_PREFIX=test
+
 ORCHESTRATION_API_URL=http://localhost:9091/orchestration
 PRISON_REGISTER_API_URL=http://localhost:9091/prisonRegister
 

--- a/integration_tests/redis/redisHelpers.ts
+++ b/integration_tests/redis/redisHelpers.ts
@@ -2,7 +2,7 @@
 import logger from '../../logger'
 import { createRedisClient } from '../../server/data/redisClient'
 
-const dataCacheKeyPattern = 'dataCache_*'
+const dataCacheKeyPattern = 'dataCache_test:*'
 const rateLimitKeyPattern = 'rateLimit:*'
 
 const clearDataCache = async () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -43,7 +43,7 @@ export type RateLimitConfig = {
 export default {
   buildNumber: get('BUILD_NUMBER', '1_0_0', requiredInProduction),
   productId: get('PRODUCT_ID', 'UNASSIGNED', requiredInProduction),
-  gitRef: get('GIT_REF', 'git-ref', requiredInProduction),
+  gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   branchName: get('GIT_BRANCH', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   production,
   https: production,
@@ -94,6 +94,9 @@ export default {
       agent: new AgentConfig(Number(get('PRISON_REGISTER_API_TIMEOUT_RESPONSE', 10000))),
     },
   },
+  // include short Git ref in dataCache prefix to invalidate data cache on deploy of new build
+  // DATA_CACHE_PREFIX overrides for integration tests
+  dataCachePrefix: `dataCache_${get('DATA_CACHE_PREFIX', '') || get('GIT_REF', 'local').slice(0, 7)}:`,
   pvbUrl: get('PVB_URL', 'http://localhost:9091/pvb/en/request', requiredInProduction),
   rateLimit: <Record<string, RateLimitConfig>>{
     // Rate limit config for Add a prisoner journey

--- a/server/data/dataCache/redisDataCache.test.ts
+++ b/server/data/dataCache/redisDataCache.test.ts
@@ -18,7 +18,7 @@ describe('redisDataCache', () => {
   const jsonDataAsString = '{"some":"data"}'
 
   beforeEach(() => {
-    dataCache = new DataCache(redisClient as unknown as RedisClient, 'gitRef')
+    dataCache = new DataCache(redisClient as unknown as RedisClient)
   })
 
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('redisDataCache', () => {
 
       await expect(dataCache.get('key')).resolves.toStrictEqual(jsonData)
 
-      expect(redisClient.get).toHaveBeenCalledWith('dataCache_gitRef:key')
+      expect(redisClient.get).toHaveBeenCalledWith('dataCache_local:key')
     })
 
     it('Connects when no connection calling get data', async () => {
@@ -47,7 +47,7 @@ describe('redisDataCache', () => {
     it('Can set data', async () => {
       await dataCache.set('key', jsonData, 10)
 
-      expect(redisClient.set).toHaveBeenCalledWith('dataCache_gitRef:key', jsonDataAsString, { EX: 10 })
+      expect(redisClient.set).toHaveBeenCalledWith('dataCache_local:key', jsonDataAsString, { EX: 10 })
     })
 
     it('Connects when no connection calling set data', async () => {

--- a/server/data/dataCache/redisDataCache.ts
+++ b/server/data/dataCache/redisDataCache.ts
@@ -1,19 +1,10 @@
+import config from '../../config'
 import type { RedisClient } from '../redisClient'
 
 import { DataCache } from './dataCache'
 
 export default class RedisDataCache implements DataCache {
-  private readonly prefix: string
-
-  constructor(
-    private readonly client: RedisClient,
-    private readonly gitRef: string,
-  ) {
-    // include short Git ref in prefix to invalidate data cache on deploy of new build
-    // to avoid errors should data type stored for a key change between builds
-    const shortGitRef = gitRef.slice(0, 7)
-    this.prefix = `dataCache_${shortGitRef}:`
-  }
+  constructor(private readonly client: RedisClient) {}
 
   private async ensureConnected() {
     if (!this.client.isOpen) {
@@ -23,12 +14,12 @@ export default class RedisDataCache implements DataCache {
 
   public async set<DataType>(key: string, data: DataType, durationSeconds: number): Promise<void> {
     await this.ensureConnected()
-    await this.client.set(`${this.prefix}${key}`, JSON.stringify(data), { EX: durationSeconds })
+    await this.client.set(`${config.dataCachePrefix}${key}`, JSON.stringify(data), { EX: durationSeconds })
   }
 
   public async get<DataType>(key: string): Promise<DataType | null> {
     await this.ensureConnected()
-    const result = await this.client.get(`${this.prefix}${key}`)
+    const result = await this.client.get(`${config.dataCachePrefix}${key}`)
     try {
       return typeof result === 'string' ? <DataType>JSON.parse(result) : null
     } catch {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -27,7 +27,7 @@ export const dataAccess = () => {
   if (config.redis.enabled) {
     redisClient = createRedisClient()
   }
-  const dataCache = config.redis.enabled ? new RedisDataCache(redisClient, config.gitRef) : new InMemoryDataCache()
+  const dataCache = config.redis.enabled ? new RedisDataCache(redisClient) : new InMemoryDataCache()
 
   return {
     applicationInfo,


### PR DESCRIPTION
When running locally, `dataCache_` entries in Redis creating during Cypress tests were colliding with those created when running the app for local development.

This change derives `dataCache` in `config.ts` so it can be overridden in `feature.env`.

(This change doesn't affect the app when deployed: it still uses `dataCache_<short-git-ref>:` so that cache is cleared on deploying a new version of the app.)