### PR TITLE
VB-5674 Select prison accessible autocomplete tweaks

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -6,6 +6,16 @@
   @include govuk-typography-common();
 }
 
+.autocomplete__dropdown-arrow-down {
+  z-index: 1;
+}
+
+.autocomplete__option > span {
+  // workaround for accessible autocomplete issue
+  // https://github.com/alphagov/accessible-autocomplete/issues/556
+  @include govuk-visually-hidden();
+}
+
 .govuk-panel.visits-request-confirmation {
   background-color: govuk-colour("blue");
 }

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -61,6 +61,8 @@
   <script nonce="{{ cspNonce }}">
     accessibleAutocomplete.enhanceSelectElement({
       defaultValue: '',
+      confirmOnBlur: false,
+      showAllValues: true,
       selectElement: document.querySelector('#prisonId')
     })
   </script>


### PR DESCRIPTION
* Use `showAllValues` option to give drop-down style behaviour (https://github.com/alphagov/accessible-autocomplete?tab=readme-ov-file#showallvalues-default-false)
  * (`z-index` tweak needed for this to make the drop-down arrow visible)
* Fix [known issue](https://github.com/alphagov/accessible-autocomplete/issues/556) with accessible autocomplete component on iOS where Content Security Policy blocks inline styles that should hide additional text intended for VoiceOver. This means items display suffixed with counts (e.g. "1 of 10")
  * Fixed by applying `govuk-visually-hidden` helper to these elements  