### PR TITLE
Fix to header link

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -75,7 +75,7 @@
 {% else %}
   {{ govukHeader({
     rebrand: true,
-    homepageUrl: "https://www.gov.uk" if not hideGOVUKServiceNav
+    homepageUrl: "https://www.gov.uk"
   }) }}
   {% if not hideGOVUKServiceNav %}
     {{ govukServiceNavigation({


### PR DESCRIPTION
Spotted a minor but of extraneous code that was stopping the GOV.UK link working correctly in the header.