### PR TITLE
Fixing incorrect page width

### DIFF
--- a/server/views/pages/bookings/visit.njk
+++ b/server/views/pages/bookings/visit.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
 
       {# Messages #}
       {% for message in messages %}


### PR DESCRIPTION
During testing, we noticed that the "Visit/request booking details" page was incorrectly set to full width. This PR fixes it to 2/3 width in line with the other pages.