### PR TITLE
VB-3571 Simplify and refactor handling of visitor bans

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -24,6 +24,6 @@
   color: govuk-colour("red");
 }
 
-.banned-hint { // using colour from govuk-hint
-  color: govuk-colour("dark-grey"); 
+.secondary-text {
+  color: $govuk-secondary-text-colour
 }

--- a/integration_tests/e2e/visitors.cy.ts
+++ b/integration_tests/e2e/visitors.cy.ts
@@ -38,10 +38,10 @@ context('Visitors page', () => {
 
     const visitorsPage = Page.verifyOnPage(VisitorsPage)
     visitorsPage.prisonerName().contains('John Smith')
-    visitorsPage.visitorName(1).contains('Joan Phillips')
-    visitorsPage.visitorDateOfBirth(1).contains('21 February 1980')
-    visitorsPage.visitorName(2).contains('Keith Richards')
-    visitorsPage.visitorDateOfBirth(2).contains('5 May 1990')
+    visitorsPage.visitorName(0).contains('Joan Phillips')
+    visitorsPage.visitorDateOfBirth(0).contains('21 February 1980')
+    visitorsPage.visitorName(1).contains('Keith Richards')
+    visitorsPage.visitorDateOfBirth(1).contains('5 May 1990')
   })
 
   it('should not show a banned visitor on booking journey Select visitors page', () => {

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -78,6 +78,13 @@ export type CannotBookReason =
 
 export type FlashFormValues = Record<string, unknown>
 
+export type GOVUKTableRow = GOVUKTableRowItem[]
+
+type GOVUKTableRowItem = TextOrHtml & {
+  classes?: string
+  attributes?: { 'data-test': string }
+}
+
 export type MoJAlert = {
   variant: 'information' | 'success' | 'warning' | 'error'
   title: string

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -100,7 +100,6 @@ const visitor9 = TestData.visitor({
   lastName: 'LastName',
   dateOfBirth: '2004-04-01',
   adult: false,
-  eligible: false,
   banExpiryDate: '2025-05-02', // 1 year after currently faked date
 })
 const eligibleVisitors = [visitor1, visitor2, visitor3, visitor4, visitor5, visitor6, visitor7, visitor8]

--- a/server/routes/bookVisit/selectVisitorsController.ts
+++ b/server/routes/bookVisit/selectVisitorsController.ts
@@ -18,13 +18,13 @@ export default class SelectVisitorsController {
 
       if (!bookingJourney.prison) {
         bookingJourney.prison = await this.prisonService.getPrison(bookingJourney.prisoner.prisonId)
-        const visitorsByStatus = await this.bookerService.getVisitorsByEligibility(
+        const visitorsByEligibility = await this.bookerService.getVisitorsByEligibility(
           booker.reference,
           booker.prisoners[0].prisonerNumber,
           bookingJourney.prison.policyNoticeDaysMax,
         )
-        bookingJourney.eligibleVisitors = visitorsByStatus.eligibleVisitors
-        bookingJourney.ineligibleVisitors = visitorsByStatus.ineligibleVisitors
+        bookingJourney.eligibleVisitors = visitorsByEligibility.eligibleVisitors
+        bookingJourney.ineligibleVisitors = visitorsByEligibility.ineligibleVisitors
       }
 
       const isAtLeastOneAdultVisitor = bookingJourney.eligibleVisitors.some(visitor => visitor.adult)

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -315,9 +315,8 @@ export default class TestData {
     firstName = 'Joan',
     lastName = 'Phillips',
     dateOfBirth = '1980-02-21',
-    visitorRestrictions = [],
     adult = true,
-    eligible = true,
+    banned = false,
     banExpiryDate,
   }: Partial<Visitor> = {}): Visitor => ({
     visitorDisplayId,
@@ -325,9 +324,8 @@ export default class TestData {
     lastName,
     firstName,
     dateOfBirth,
-    visitorRestrictions,
     adult,
-    eligible,
+    banned,
     banExpiryDate,
   })
 }

--- a/server/routes/visitors/visitorsController.test.ts
+++ b/server/routes/visitors/visitorsController.test.ts
@@ -54,9 +54,9 @@ describe('Visitors page', () => {
         expect($('h1').text()).toBe('Visitors')
 
         expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-        expect($('[data-test="visitor-name-1"]').text()).toBe('Joan Phillips')
-        expect($('[data-test="visitor-dob-1"]').text()).toBe('21 February 1980')
-        expect($('[data-test="visitor-availability-1"]').text()).toBe('Yes')
+        expect($('[data-test="visitor-name-0"]').text()).toBe('Joan Phillips')
+        expect($('[data-test="visitor-dob-0"]').text()).toBe('21 February 1980')
+        expect($('[data-test="visitor-availability-0"]').text()).toBe('Yes')
         expect($('[data-test=no-visitors]').length).toBe(0)
 
         expect(bookerService.getVisitors).toHaveBeenCalledWith(bookerReference, prisoner.prisonerNumber)

--- a/server/routes/visitors/visitorsController.ts
+++ b/server/routes/visitors/visitorsController.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express'
 import { BookerService } from '../../services'
 import paths from '../../constants/paths'
-import { getVisitorAvailabilityDescription } from './visitorsUtils'
+import { buildVisitorsTableRows } from './visitorsUtils'
 
 export default class VisitorsController {
   public constructor(private readonly bookerService: BookerService) {}
@@ -16,15 +16,13 @@ export default class VisitorsController {
 
       const visitors = booker.prisoners.length
         ? await this.bookerService.getVisitors(booker.reference, booker.prisoners[0].prisonerNumber)
-        : undefined
+        : []
 
-      const newVisitorsArray = visitors.map(visitor => {
-        return { ...visitor, canVisitorBook: getVisitorAvailabilityDescription(visitor.visitorRestrictions) }
-      })
+      const visitorsTableRows = buildVisitorsTableRows(visitors)
 
       return res.render('pages/visitors/visitors', {
         prisoner: booker.prisoners[0],
-        visitors: newVisitorsArray,
+        visitorsTableRows,
         showOLServiceNav: true,
       })
     }

--- a/server/views/pages/bookVisit/selectVisitors.njk
+++ b/server/views/pages/bookVisit/selectVisitors.njk
@@ -48,10 +48,10 @@
             {%- endset %}
 
             {% set visitorHintHtml -%}
-              <p class='banned-hint govuk-!-margin-bottom-0'>
+              <p class='secondary-text govuk-!-margin-bottom-0'>
                 {{- visitor.firstName }} is banned until {{ visitor.banExpiryDate | formatDate }}.
               </p>
-              <p class='banned-hint'>If they are selected as a visitor, the visit must be on or after this date.</p>
+              <p class='secondary-text'>If they are selected as a visitor, the visit must be on or after this date.</p>
             {%- endset %}
 
             {% set visitorList = (visitorList.push({
@@ -93,11 +93,11 @@
                 {{- visitor.firstName }} {{ visitor.lastName }} ({{ visitor.dateOfBirth | displayAge }}) {{ bannedTagHtml -}}
               </p>
               {% if visitor.banExpiryDate %}
-                <p data-test="ban-expiry-{{ loop.index }}" class="banned-hint govuk-!-margin-bottom-0">
+                <p data-test="ban-expiry-{{ loop.index }}" class="secondary-text govuk-!-margin-bottom-0">
                   {{- visitor.firstName }} is banned until {{ visitor.banExpiryDate | formatDate }}.
                 </p>
               {% endif %}
-              <p class="banned-hint">You cannot currently book for this visitor.</p>
+              <p class="secondary-text">You cannot currently book for this visitor.</p>
             {% endfor %}
           {% endif %}
 

--- a/server/views/pages/bookVisit/selectVisitors.njk
+++ b/server/views/pages/bookVisit/selectVisitors.njk
@@ -48,10 +48,10 @@
             {%- endset %}
 
             {% set visitorHintHtml -%}
-              <p class='secondary-text govuk-!-margin-bottom-0'>
+              <p class="secondary-text govuk-!-margin-bottom-0">
                 {{- visitor.firstName }} is banned until {{ visitor.banExpiryDate | formatDate }}.
               </p>
-              <p class='secondary-text'>If they are selected as a visitor, the visit must be on or after this date.</p>
+              <p class="secondary-text">If they are selected as a visitor, the visit must be on or after this date.</p>
             {%- endset %}
 
             {% set visitorList = (visitorList.push({

--- a/server/views/pages/visitors/visitors.njk
+++ b/server/views/pages/visitors/visitors.njk
@@ -15,34 +15,7 @@
         <span data-test="prisoner-name">{{ prisoner | prisonerNameFirstLast }}</span>’s visitors
       </h2>
 
-      {% if visitors | length %}
-
-        {% set displayRows = [] %}
-
-        {% for visitor in visitors %}
-          {% set displayRows = (displayRows.push([
-            {
-              text: visitor.firstName + " " + visitor.lastName,
-              attributes: {
-                "data-test": "visitor-name-" + loop.index
-              }
-            },
-            { 
-              text: visitor.dateOfBirth | formatDate,
-              attributes: {
-                "data-test": "visitor-dob-" + loop.index
-              }
-            },
-            {
-              text: visitor.canVisitorBook.text,
-              classes: visitor.canVisitorBook.class,
-              attributes: {
-                "data-test": "visitor-availability-" + loop.index
-              }
-            }
-          ]), displayRows)%}
-        {% endfor %}
-       
+      {% if visitorsTableRows | length %}
         {{ govukTable({
           firstCellIsHeader: false,
           head: [
@@ -56,9 +29,8 @@
               text: "Can you book a visit for them?"
             }
           ],
-          rows: displayRows
+          rows: visitorsTableRows
         }) }}
-
       {% else %}
         {{ govukWarningText({
           text: "No visitors are currently approved.",


### PR DESCRIPTION
If a visitor has multiple overlapping `BAN` restrictions, the API processes these so only a single `BAN` would be received with the furthest (or indefinite) expiry date. This means code handling visitor `BAN`s can be removed/simplified.

Also:
* simplify some types
* switch to building GOVUK Table rows in utility function to simplify template code