### PR TITLE
VB-5888 Fix implementation of error summaries/components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,6 @@
         "@types/passport": "^1.0.17",
         "@types/superagent": "^8.1.9",
         "@types/supertest": "^6.0.3",
-        "@typescript-eslint/eslint-plugin": "^8.41.0",
-        "@typescript-eslint/parser": "^8.41.0",
         "audit-ci": "^7.1.0",
         "axe-core": "^4.10.3",
         "cheerio": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -133,8 +133,6 @@
     "@types/passport": "^1.0.17",
     "@types/superagent": "^8.1.9",
     "@types/supertest": "^6.0.3",
-    "@typescript-eslint/eslint-plugin": "^8.41.0",
-    "@typescript-eslint/parser": "^8.41.0",
     "audit-ci": "^7.1.0",
     "axe-core": "^4.10.3",
     "cheerio": "^1.1.2",

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -11,7 +11,14 @@ export type Booker = {
 export type AddPrisonerJourney = {
   supportedPrisons: PrisonRegisterPrisonDto[]
   selectedPrison?: PrisonRegisterPrisonDto
-  prisonerDetails?: Record<string, string>
+  prisonerDetails?: {
+    firstName: string
+    lastName: string
+    'prisonerDob-day': string
+    'prisonerDob-month': string
+    'prisonerDob-year': string
+    prisonNumber: string
+  }
   result?: boolean
 }
 

--- a/server/routes/addPrisoner/prisonerLocationController.test.ts
+++ b/server/routes/addPrisoner/prisonerLocationController.test.ts
@@ -62,7 +62,7 @@ describe('Prisoner location', () => {
 
     it('should pre-populate prison choice if selected prison set in session', () => {
       const selectedPrison = TestData.prisonRegisterPrisonDto()
-      const prisonerDetails = { some: 'data' }
+      const prisonerDetails = { firstName: 'name' } as AddPrisonerJourney['prisonerDetails']
       sessionData.addPrisonerJourney = {
         supportedPrisons: undefined,
         selectedPrison,
@@ -102,7 +102,7 @@ describe('Prisoner location', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-error-summary a[href="#prisonId-error"]').text()).toBe('Select a prison')
+          expect($('.govuk-error-summary a[href="#prisonId"]').text()).toBe('Select a prison')
           expect($('#prisonId-error').text()).toContain('Select a prison')
         })
     })

--- a/server/routes/bookVisit/additionalSupportController.test.ts
+++ b/server/routes/bookVisit/additionalSupportController.test.ts
@@ -173,9 +173,7 @@ describe('Additional support needs', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-error-summary a[href="#additionalSupport-error"]').text()).toBe(
-            'Enter details of the request',
-          )
+          expect($('.govuk-error-summary a[href="#additionalSupport"]').text()).toBe('Enter details of the request')
           expect($('#additionalSupport-error').text()).toContain('Enter details of the request')
         })
     })

--- a/server/routes/bookVisit/chooseVisitTimeController.test.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.test.ts
@@ -339,7 +339,7 @@ describe('Choose visit time', () => {
       const validationError: FieldValidationError = {
         type: 'field',
         location: 'body',
-        path: 'visitSession',
+        path: `date-${firstSessionDate}`,
         value: [],
         msg: 'No visit time selected',
       }
@@ -352,8 +352,8 @@ describe('Choose visit time', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('title').text()).toMatch(/^Error: Choose the visit time -/)
-          expect($('.govuk-error-summary a[href="#visitSession-error"]').text()).toBe('No visit time selected')
-          expect($('#visitSession-error').text()).toContain('No visit time selected')
+          expect($(`.govuk-error-summary a[href="#date-${firstSessionDate}"]`).text()).toBe('No visit time selected')
+          expect($(`#date-${firstSessionDate}-error`).text()).toContain('No visit time selected')
         })
     })
   })
@@ -491,7 +491,13 @@ describe('Choose visit time', () => {
 
     describe('Validation errors', () => {
       const expectedFlashErrors: FieldValidationError[] = [
-        { type: 'field', location: 'body', path: 'visitSession', value: undefined, msg: 'No visit time selected' },
+        {
+          type: 'field',
+          location: 'body',
+          path: `date-${firstSessionDate}`,
+          value: undefined,
+          msg: 'No visit time selected',
+        },
       ]
 
       it('should set a validation error and redirect to original page when no visit time selected', () => {

--- a/server/routes/bookVisit/chooseVisitTimeController.ts
+++ b/server/routes/bookVisit/chooseVisitTimeController.ts
@@ -68,6 +68,7 @@ export default class ChooseVisitTimeController {
         formValues,
         messages,
         calendar,
+        firstSessionDate,
         selectedDate,
         prisoner,
         bannedVisitors,
@@ -78,17 +79,24 @@ export default class ChooseVisitTimeController {
 
   public submit(): RequestHandler {
     return async (req, res, next) => {
+      const { booker, bookingJourney } = req.session
+
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
-        req.flash('errors', errors.array())
+        // need to update the path in error obj to match ID of first radio input
+        // so ErrorSummary link works correctly
+        const errorsArray = errors.array()
+        if (errorsArray[0].type === 'field') {
+          errorsArray[0].path = `date-${bookingJourney.allVisitSessions[0]?.sessionDate}`
+        }
+
+        req.flash('errors', errorsArray)
         return res.redirect(paths.BOOK_VISIT.CHOOSE_TIME)
       }
       const { visitSession } = matchedData<{ visitSession: string }>(req)
       const visitSessionSplit = visitSession.split('_')
       const selectedSessionDate = visitSessionSplit[0]
       const selectedSessionTemplateReference = visitSessionSplit[1]
-
-      const { booker, bookingJourney } = req.session
 
       const selectedVisitSession = bookingJourney.allVisitSessions.find(
         session =>

--- a/server/routes/bookVisit/contactDetailsController.test.ts
+++ b/server/routes/bookVisit/contactDetailsController.test.ts
@@ -146,8 +146,8 @@ describe('Contact details', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('title').text()).toMatch(/^Error: Contact details -/)
-          expect($('.govuk-error-summary a[href=#mainContactEmail-error]').text()).toBe('Enter a valid email')
-          expect($('.govuk-error-summary a[href=#mainContactPhone-error]').text()).toBe('Enter a phone number')
+          expect($('.govuk-error-summary a[href=#mainContactEmail]').text()).toBe('Enter a valid email')
+          expect($('.govuk-error-summary a[href=#mainContactPhone]').text()).toBe('Enter a phone number')
           expect($('#mainContactEmail-error').text()).toContain('Enter a valid email')
           expect($('#mainContactPhone-error').text()).toContain('Enter a phone number')
         })

--- a/server/routes/bookVisit/mainContactController.test.ts
+++ b/server/routes/bookVisit/mainContactController.test.ts
@@ -153,7 +153,7 @@ describe('Main contact', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('title').text()).toMatch(/^Error: Who is the main contact for this booking\? -/)
-          expect($('.govuk-error-summary a[href=#contact-error]').text()).toBe('No main contact selected')
+          expect($('.govuk-error-summary a[href=#contact]').text()).toBe('No main contact selected')
           expect($('#contact-error').text()).toContain('No main contact selected')
         })
     })

--- a/server/routes/bookVisit/selectVisitorsController.test.ts
+++ b/server/routes/bookVisit/selectVisitorsController.test.ts
@@ -265,7 +265,7 @@ describe('Select visitors', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('title').text()).toMatch(/^Error: Who is going on the visit\? -/)
-          expect($('.govuk-error-summary a[href="#visitorDisplayIds-error"]').text()).toBe('No visitors selected')
+          expect($('.govuk-error-summary a[href="#visitorDisplayIds"]').text()).toBe('No visitors selected')
           expect($('#visitorDisplayIds-error').text()).toContain('No visitors selected')
         })
     })

--- a/server/routes/cookies/cookiesController.test.ts
+++ b/server/routes/cookies/cookiesController.test.ts
@@ -100,7 +100,7 @@ describe('Cookies page', () => {
           expect($('title').text()).toMatch(/^Error: Cookies -/)
           expect($('h1').text()).toBe('Cookies')
 
-          expect($('.govuk-error-summary a[href="#acceptAnalytics-error"]').text()).toBe('No answer selected')
+          expect($('.govuk-error-summary a[href="#acceptAnalytics"]').text()).toBe('No answer selected')
           expect($('#acceptAnalytics-error').text()).toContain('No answer selected')
         })
     })

--- a/server/routes/selectPrison/selectPrisonController.test.ts
+++ b/server/routes/selectPrison/selectPrisonController.test.ts
@@ -77,7 +77,7 @@ describe('Select a prison', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-error-summary a[href="#prisonId-error"]').text()).toBe('No prison selected')
+          expect($('.govuk-error-summary a[href="#prisonId"]').text()).toBe('No prison selected')
           expect($('#prisonId-error').text()).toContain('No prison selected')
         })
     })

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -64,8 +64,8 @@ describe('Nunjucks Filters', () => {
         { msg: 'Field 2 message', path: 'field2' },
       ]
       const expectedResult = [
-        { text: 'Field 1 message', href: '#field1-error' },
-        { text: 'Field 2 message', href: '#field2-error' },
+        { text: 'Field 1 message', href: '#field1' },
+        { text: 'Field 2 message', href: '#field2' },
       ]
 
       const result = njk.getFilter('errorSummaryList')(errors)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -83,7 +83,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
     return Object.keys(errors).map(error => {
       return {
         text: errors[error].msg,
-        href: errors[error].path ? `#${errors[error].path}-error` : undefined,
+        href: errors[error].path ? `#${errors[error].path}` : undefined,
       }
     })
   })

--- a/server/views/pages/addPrisoner/prisonerDetails.njk
+++ b/server/views/pages/addPrisoner/prisonerDetails.njk
@@ -45,9 +45,10 @@
           errorMessage: errors | findError('lastName')
         }) }}
 
-        {% set prisonerDobError = errors | findError('prisonerDob') %}
+        {% set prisonerDobError = errors | findError('prisonerDob-day') %}
         {{ govukDateInput({
           id: "prisonerDob",
+          namePrefix: "prisonerDob",
           fieldset: {
             legend: {
               text: "Date of birth"
@@ -61,19 +62,19 @@
               name: "day",
               classes: "govuk-input--width-2" + (" govuk-input--error" if prisonerDobError),
               autocomplete: "off",
-              value: formValues.day
+              value: formValues['prisonerDob-day']
             },
             {
               name: "month",
               classes: "govuk-input--width-2" + (" govuk-input--error" if prisonerDobError),
               autocomplete: "off",
-              value: formValues.month
+              value: formValues['prisonerDob-month']
             },
             {
               name: "year",
               classes: "govuk-input--width-4" + (" govuk-input--error" if prisonerDobError),
               autocomplete: "off",
-              value: formValues.year
+              value: formValues['prisonerDob-year']
             }
           ],
           errorMessage: prisonerDobError

--- a/server/views/pages/bookVisit/chooseVisitTime.njk
+++ b/server/views/pages/bookVisit/chooseVisitTime.njk
@@ -95,8 +95,7 @@
         {% endfor %}
       </nav>
 
-      {# if errors, add error ID so anchor link from error summary works #}
-      <form action="{{ paths.BOOK_VISIT.CHOOSE_TIME }}" method="POST" novalidate {% if errors | length%}id="visitSession-error"{% endif %} class="disable-button-on-submit">
+      <form action="{{ paths.BOOK_VISIT.CHOOSE_TIME }}" method="POST" novalidate class="disable-button-on-submit">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {# Build radio visit session items from months/dates/sessions data #}
@@ -137,7 +136,7 @@
                   classes: "govuk-visually-hidden"
                 },
                 items: visitSessionItems,
-                errorMessage: errors | findError('visitSession')
+                errorMessage: errors | findError('date-' + firstSessionDate)
               }) }}
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
Fix handling of links in GOV.UK Error Summary components to link correctly to relevant input fields, to match the [guidance](https://design-system.service.gov.uk/components/error-summary/).

Previously, error summary links were linking to a field's error message component rather than the field itself.

(The accessibility audit identified this specifically in relation to a date input, but it turned out to be a more general problem.)