### PR TITLE
VB-5963 Add service maintenance page

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,58 @@ This application has several changes to core files inherited from the HMPPS Type
 * client and server public/private key pairs (in `./integration_tests/testKeys/`) for integration testing
 * a new NPM task (`oidc-wiremock`) and customisations to `start-feature` and `watch-node-feature` that ensure the OIDC Discovery Endpoint mock and a private key is available before the application starts
 
+
+## Maintenance page
+The application has a maintenance page with a service unavailable message. It can also optionally show a date when the service will be available again. The maintenance page is served for all requests except the 'health check' ones (`/health, /info, /ping`).
+
+This behaviour is controlled by two environment variables. Default values are in Helm config:
+```
+  MAINTENANCE_MODE: "false"
+  # Optional maintenance end date (in ISO format, YYYY-MM-DDTHH:MM)
+  MAINTENANCE_MODE_END_DATE_TIME: ""
+```
+
+To see the current state of these variables, use this command:
+```
+# example is for 'dev' namespace; replace with 'prod' as appropriate
+
+kubectl -n visit-someone-in-prison-frontend-svc-dev set env deployment/hmpps-book-a-prison-visit-ui --list
+```
+
+Maintenance mode can be turned on by either:
+* changing the values for an environment (e.g. prod) in Helm config, committing and deploying
+* manually changing the values for an environment and restarting the pods
+
+
+### Manually enabling maintenance mode
+To turn on maintenance mode, use one of these commands (depending on whether an end date and time should be shown):
+```
+# examples are for 'dev' namespace; replace with 'prod' as appropriate
+
+# Enable maintenance with no end date and time displayed
+kubectl -n visit-someone-in-prison-frontend-svc-dev set env deployment/hmpps-book-a-prison-visit-ui MAINTENANCE_MODE=true
+
+# Enable maintenance page that includes an end date and time
+kubectl -n visit-someone-in-prison-frontend-svc-dev set env deployment/hmpps-book-a-prison-visit-ui MAINTENANCE_MODE=true MAINTENANCE_MODE_END_DATE_TIME=2025-10-01T14:00
+```
+
+This will update the environment variables and restart the pods. To see the status of pods, use:
+```
+kubectl -n visit-someone-in-prison-backend-svc-dev get pods
+```
+Once these are restarted, the maintenance page will be active.
+
+
+### Manually disabling maintenance mode
+To turn off maintenance mode, run this command:
+```
+# example is for 'dev' namespace; replace with 'prod' as appropriate
+
+kubectl -n visit-someone-in-prison-frontend-svc-dev set env deployment/hmpps-book-a-prison-visit-ui MAINTENANCE_MODE=false
+```
+This will update the environment variables and restart the pods. Once these are restarted, the maintenance page will be turned off.
+
+
+---
+
 This project is tested with BrowserStack

--- a/helm_deploy/hmpps-book-a-prison-visit-ui/values.yaml
+++ b/helm_deploy/hmpps-book-a-prison-visit-ui/values.yaml
@@ -56,6 +56,9 @@ generic-service:
     REDIS_ENABLED: "true"
     REDIS_TLS_ENABLED: "true"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
+    MAINTENANCE_MODE: "false"
+    # Optional maintenance end date (in ISO format, YYYY-MM-DDTHH:MM)
+    MAINTENANCE_MODE_END_DATE_TIME: ""
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/server/app.ts
+++ b/server/app.ts
@@ -14,6 +14,7 @@ import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
 
+import maintenancePageRoute from './routes/maintenancePageRoute'
 import authenticatedRoutes from './routes/authenticatedRoutes'
 import unauthenticatedRoutes from './routes/unauthenticatedRoutes'
 
@@ -34,6 +35,9 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpWebRequestParsing())
   app.use(setUpStaticResources())
   nunjucksSetup(app, services.applicationInfo)
+
+  app.use(maintenancePageRoute())
+
   app.use(setupGovukOneLogin())
   app.use(analyticsConsent())
   app.use(setUpCsrf())

--- a/server/config.ts
+++ b/server/config.ts
@@ -117,4 +117,8 @@ export default {
   features: {},
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
+  maintenance: {
+    enabled: get('MAINTENANCE_MODE', 'false') === 'true',
+    endDateTime: get('MAINTENANCE_MODE_END_DATE_TIME', ''), // ISO format e.g. YYYY-MM-DDTHH:MM
+  },
 }

--- a/server/routes/cookies/cookiesController.test.ts
+++ b/server/routes/cookies/cookiesController.test.ts
@@ -114,7 +114,7 @@ describe('Cookies page', () => {
     const analyticsNoValue = encodeURIComponent(JSON.stringify({ acceptAnalytics: 'no' }))
 
     beforeEach(() => {
-      jest.useFakeTimers({ now: new Date(fakeDate) })
+      jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })
       app = appWithAllRoutes({})
     })
 

--- a/server/routes/maintenancePageRoute.test.ts
+++ b/server/routes/maintenancePageRoute.test.ts
@@ -1,0 +1,69 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes } from './testutils/appSetup'
+import config from '../config'
+
+let app: Express
+
+describe('Maintenance page', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should render maintenance page when enabled (no end date set)', () => {
+    jest.replaceProperty(config, 'maintenance', {
+      enabled: true,
+      endDateTime: '',
+    })
+    app = appWithAllRoutes({})
+
+    return request(app)
+      .get('/any-path')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('title').text()).toMatch(/^Sorry, the service is unavailable -/)
+        expect($('[data-test="back-link"]').length).toBe(0)
+        expect($('[data-test="maintenance-message"]').text()).toBe('You will be able to use the service later.')
+        expect($('.govuk-footer__inline-list a').length).toBe(0)
+      })
+  })
+
+  it('should render maintenance page when enabled (end date set)', () => {
+    jest.replaceProperty(config, 'maintenance', {
+      enabled: true,
+      endDateTime: '2025-10-01T13:30',
+    })
+    app = appWithAllRoutes({})
+
+    return request(app)
+      .get('/any-other-path')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('title').text()).toMatch(/^Sorry, the service is unavailable -/)
+        expect($('[data-test="back-link"]').length).toBe(0)
+        expect($('[data-test="maintenance-message"]').text()).toBe(
+          'You will be able to use the service from 1:30pm on Wednesday 1 October 2025.',
+        )
+        expect($('.govuk-footer__inline-list a').length).toBe(0)
+      })
+  })
+
+  it('should render maintenance page for POST routes', () => {
+    jest.replaceProperty(config, 'maintenance', {
+      enabled: true,
+      endDateTime: '',
+    })
+    app = appWithAllRoutes({})
+
+    return request(app)
+      .post('/form-submission-path')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('title').text()).toMatch(/^Sorry, the service is unavailable -/)
+      })
+  })
+})

--- a/server/routes/maintenancePageRoute.ts
+++ b/server/routes/maintenancePageRoute.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express'
+import { format, parseISO } from 'date-fns'
+import config from '../config'
+import { DateFormats } from '../constants/dateFormats'
+
+export default function maintenancePage(): Router {
+  const router = Router()
+  const { enabled, endDateTime } = config.maintenance
+
+  if (enabled) {
+    router.use((req, res) => {
+      let maintenanceMessage: string
+      try {
+        const parsedEndDateTime = parseISO(endDateTime)
+        const timeFormat = parsedEndDateTime.getMinutes() === 0 ? 'haaa' : 'h:mmaaa' // 2pm instead of 2:00pm
+        const endTime = format(parsedEndDateTime, timeFormat)
+        const endDate = format(parsedEndDateTime, DateFormats.PRETTY_DATE)
+
+        maintenanceMessage = `You will be able to use the service from ${endTime} on ${endDate}.`
+      } catch {
+        maintenanceMessage = 'You will be able to use the service later.'
+      }
+
+      // don't load analytics or display cookie banner
+      res.locals.analyticsEnabled = false
+
+      return res.render('pages/maintenancePage', { maintenanceMessage, hideFooterLinks: true })
+    })
+  }
+
+  return router
+}

--- a/server/routes/staticPages/staticPages.test.ts
+++ b/server/routes/staticPages/staticPages.test.ts
@@ -34,6 +34,11 @@ describe('Static content pages - authenticated users', () => {
         expect($('.govuk-service-navigation__link').eq(0).text().trim()).toBe('Home')
         expect($('.govuk-service-navigation__link').eq(1).text().trim()).toBe('Bookings')
         expect($('.govuk-service-navigation__link').eq(2).text().trim()).toBe('Visitors')
+
+        expect($('.govuk-footer__inline-list a').eq(0).text().trim()).toBe('Accessibility')
+        expect($('.govuk-footer__inline-list a').eq(1).text().trim()).toBe('Cookies')
+        expect($('.govuk-footer__inline-list a').eq(2).text().trim()).toBe('Privacy')
+        expect($('.govuk-footer__inline-list a').eq(3).text().trim()).toBe('Terms and conditions')
       })
   })
 })
@@ -55,6 +60,11 @@ describe('Static content pages - unauthenticated users', () => {
         expect($('header.govuk-header').length).toBe(1)
         expect($('header .rebranded-one-login-header').length).toBe(0)
         expect($('.govuk-service-navigation__service-name').text().trim()).toBe('Visit someone in prison')
+
+        expect($('.govuk-footer__inline-list a').eq(0).text().trim()).toBe('Accessibility')
+        expect($('.govuk-footer__inline-list a').eq(1).text().trim()).toBe('Cookies')
+        expect($('.govuk-footer__inline-list a').eq(2).text().trim()).toBe('Privacy')
+        expect($('.govuk-footer__inline-list a').eq(3).text().trim()).toBe('Terms and conditions')
       })
   })
 })

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -19,6 +19,7 @@ import { NotFound } from 'http-errors'
 import type { Session, SessionData } from 'express-session'
 import { ValidationError } from 'express-validator'
 
+import maintenancePageRoute from '../maintenancePageRoute'
 import authenticatedRoutes from '../authenticatedRoutes'
 import unauthenticatedRoutes from '../unauthenticatedRoutes'
 import nunjucksSetup from '../../utils/nunjucksSetup'
@@ -74,6 +75,7 @@ function appSetup(
   })
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
+  app.use(maintenancePageRoute())
   app.use(analyticsConsent())
   app.use(unauthenticatedRoutes(services))
   app.use(authenticatedRoutes(services))

--- a/server/views/pages/maintenancePage.njk
+++ b/server/views/pages/maintenancePage.njk
@@ -1,0 +1,24 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = "Sorry, the service is unavailable" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+      <p data-test="maintenance-message">{{ maintenanceMessage }}</p>
+
+      <p>
+        We have not saved your answers. When the service is available you will need to
+        <a href="http://www.gov.uk/prison-visits">start again</a>.
+      </p>
+
+      <p>
+        <a href="https://www.gov.uk/government/collections/prisons-in-england-and-wales">Or you can contact the prison directly</a>.
+      </p>
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -109,27 +109,29 @@
 {% endblock %}
 
 {% block footer %}
+  {% set footerLinks = [
+    {
+      href: paths.ACCESSIBILITY,
+      text: "Accessibility"
+    },
+    {
+      href: paths.COOKIES,
+      text: "Cookies"
+    },
+    {
+      href: paths.PRIVACY,
+      text: "Privacy"
+    },
+    {
+      href: paths.TERMS,
+      text: "Terms and conditions"
+    }
+  ] %}
+
   {{ govukFooter({
     rebrand: true,
     meta: {
-      items: [
-        {
-          href: paths.ACCESSIBILITY,
-          text: "Accessibility"
-        },
-        {
-          href: paths.COOKIES,
-          text: "Cookies"
-        },
-        {
-          href: paths.PRIVACY,
-          text: "Privacy"
-        },
-        {
-          href: paths.TERMS,
-          text: "Terms and conditions"
-        }
-      ]
+      items: [] if hideFooterLinks else footerLinks
     }
   }) }}
 {% endblock %}


### PR DESCRIPTION
Add maintenance page with service unavailable page (with optional end date and time).

Maintenance page is controlled by environment variables that can be set via Helm config or edited manually via `kubectl` (documented in the `README`).