### PR TITLE
VB-6579 Handle English/Welsh prison names

### DIFF
--- a/integration_tests/e2e/addPrisoner.cy.ts
+++ b/integration_tests/e2e/addPrisoner.cy.ts
@@ -11,6 +11,7 @@ context('Add a prisoner', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
 
     cy.task('stubGetSupportedPrisons')
     cy.task('stubGetBookerReference')

--- a/integration_tests/e2e/addVisitor.cy.ts
+++ b/integration_tests/e2e/addVisitor.cy.ts
@@ -15,6 +15,7 @@ context('Add a visitor', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
 
     cy.task('stubGetSupportedPrisons')
     cy.task('stubGetBookerReference')

--- a/integration_tests/e2e/bookVisitJourney.cy.ts
+++ b/integration_tests/e2e/bookVisitJourney.cy.ts
@@ -101,6 +101,7 @@ context('Book visit journey', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
 
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners', { prisoners: [prisoner] })

--- a/integration_tests/e2e/bookVisitJourneyDropOuts.cy.ts
+++ b/integration_tests/e2e/bookVisitJourneyDropOuts.cy.ts
@@ -43,6 +43,7 @@ context('Book visit journey - drop-out points', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
   })
 
   describe('Book visit journey - drop-out points', () => {

--- a/integration_tests/e2e/cancelVisitJourney.cy.ts
+++ b/integration_tests/e2e/cancelVisitJourney.cy.ts
@@ -18,6 +18,7 @@ context('Cancel visit journey', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrison')
     cy.task('stubGetPrisoners', { prisoners: [prisoner] })

--- a/integration_tests/e2e/cookieConsent.cy.ts
+++ b/integration_tests/e2e/cookieConsent.cy.ts
@@ -9,6 +9,7 @@ context('Cookie consent and analytics', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners', { prisoners: [TestData.bookerPrisonerInfoDto()] })
     cy.task('stubGetFuturePublicVisits', {

--- a/integration_tests/e2e/govukOneLogin.cy.ts
+++ b/integration_tests/e2e/govukOneLogin.cy.ts
@@ -13,6 +13,7 @@ context('GOV.UK One Login', () => {
     cy.task('reset')
 
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners')
   })

--- a/integration_tests/e2e/staticContentPages.cy.ts
+++ b/integration_tests/e2e/staticContentPages.cy.ts
@@ -7,6 +7,11 @@ import PrivacyNoticePage from '../pages/staticPages/privacyNotice'
 import TermsAndConditionsPage from '../pages/staticPages/termsAndConditions'
 
 context('Static content pages', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubPrisonNames')
+  })
+
   describe('Unauthenticated user', () => {
     it('should be able to access static content pages', () => {
       cy.hideCookieBanner()
@@ -28,7 +33,6 @@ context('Static content pages', () => {
   describe('Authenticated user', () => {
     const bookerReference = TestData.bookerReference().value
     it('should be able to navigate to static content pages from Visits home page using footer links', () => {
-      cy.task('reset')
       cy.task('stubHmppsAuthToken')
 
       cy.task('stubGetBookerReference')

--- a/integration_tests/e2e/visitors.cy.ts
+++ b/integration_tests/e2e/visitors.cy.ts
@@ -38,6 +38,7 @@ context('Visitors page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrisoners', { prisoners: [prisoner] })
     cy.task('stubGetFuturePublicVisits', {

--- a/integration_tests/e2e/visits.cy.ts
+++ b/integration_tests/e2e/visits.cy.ts
@@ -30,6 +30,7 @@ context('Visits home page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubHmppsAuthToken')
+    cy.task('stubPrisonNames')
     cy.task('stubGetBookerReference')
     cy.task('stubGetPrison')
     cy.task('stubGetPrisoners', { prisoners: [prisoner] })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -10,6 +10,7 @@ import {
   MoJAlert,
   BookedVisits,
 } from '../bapv'
+import { PrisonNames } from '../../services/prisonService'
 
 export default {}
 
@@ -67,6 +68,8 @@ export declare global {
     interface Locals {
       user?: Express.User
       analyticsEnabled?: boolean
+
+      prisonNames?: PrisonNames
     }
   }
 }

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -2120,11 +2120,6 @@ export interface components {
     /** @description An address */
     AddressDto: {
       /**
-       * @description Address Type
-       * @example BUS
-       */
-      addressType?: string
-      /**
        * @description Flat
        * @example 3B
        */
@@ -2179,40 +2174,6 @@ export interface components {
        * @example false
        */
       noFixedAddress: boolean
-      /**
-       * Format: date
-       * @description Date Added
-       * @example 2000-10-31
-       */
-      startDate?: string
-      /**
-       * Format: date
-       * @description Date ended
-       * @example 2000-10-31
-       */
-      endDate?: string
-      /** @description The phone number associated with the address */
-      phones: components['schemas']['TelephoneDto'][]
-      /** @description The address usages/types */
-      addressUsages: components['schemas']['AddressUsageDto'][]
-    }
-    /** @description An Offender's address usage */
-    AddressUsageDto: {
-      /**
-       * @description The address usages
-       * @example HDC
-       */
-      addressUsage?: string
-      /**
-       * @description The address usages description
-       * @example HDC Address
-       */
-      addressUsageDescription?: string
-      /**
-       * @description Active Flag
-       * @example true
-       */
-      activeFlag?: boolean
     }
     /** @description AlertDto returned from orchestration, made of fields from AlertResponseDto from Alerts API call */
     AlertDto: {
@@ -2371,6 +2332,11 @@ export interface components {
        * @example Moorland HMP
        */
       prisonName: string
+      /**
+       * @description Name of the prison in Welsh
+       * @example Carchar Brynbuga
+       */
+      prisonNameInWelsh?: string
     }
     PrisonerDetailsDto: {
       /**
@@ -2456,24 +2422,6 @@ export interface components {
        * @example This is a comment text
        */
       comment?: string
-    }
-    /** @description Telephone Details */
-    TelephoneDto: {
-      /**
-       * @description Telephone number
-       * @example 0114 2345678
-       */
-      number: string
-      /**
-       * @description Telephone type
-       * @example TEL
-       */
-      type: string
-      /**
-       * @description Telephone extension number
-       * @example 123
-       */
-      ext?: string
     }
     VisitBookingDetailsDto: {
       /**
@@ -2782,10 +2730,10 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      /** Format: int32 */
-      pageNumber?: number
       paged?: boolean
       unpaged?: boolean
+      /** Format: int32 */
+      pageNumber?: number
     }
     SortObject: {
       empty?: boolean
@@ -2972,6 +2920,8 @@ export interface components {
        * @example 2000-01-31
        */
       dateOfBirth?: string
+      /** @description Approved Visitor Flag */
+      approvedVisitor: boolean
       /**
        * Format: date
        * @description Date when visitor was last approved for a visit (approved / auto-approved)
@@ -3399,6 +3349,11 @@ export interface components {
        * @example MDI
        */
       prisonName: string
+      /**
+       * @description Name of the prison in Welsh
+       * @example Carchar Brynbuga
+       */
+      prisonNameInWelsh?: string
     }
     /** @description Visit */
     OrchestrationVisitDto: {
@@ -4037,6 +3992,11 @@ export interface components {
        * @example HMP Hewell
        */
       prisonName: string
+      /**
+       * @description Name of the prison in Welsh
+       * @example Carchar Brynbuga
+       */
+      prisonNameInWelsh?: string
       /**
        * @description is prison active
        * @example true

--- a/server/@types/prison-register-api.d.ts
+++ b/server/@types/prison-register-api.d.ts
@@ -307,7 +307,7 @@ export interface components {
       /** @description Set of types for this prison */
       prisonTypes: ('HMP' | 'YOI' | 'IRC' | 'STC' | 'YCS')[]
       /** @description Set of categories for this prison */
-      categories: ('A' | 'B' | 'C' | 'D')[]
+      categories: ('A' | 'B' | 'C' | 'D' | 'OPEN' | 'CLOSED')[]
     }
     AddressDto: {
       /**
@@ -402,7 +402,7 @@ export interface components {
       /** @description List of types for this prison */
       types: components['schemas']['PrisonTypeDto'][]
       /** @description List of the categories for this prison */
-      categories: ('A' | 'B' | 'C' | 'D')[]
+      categories: ('A' | 'B' | 'C' | 'D' | 'OPEN' | 'CLOSED')[]
       /** @description List of address for this prison */
       addresses: components['schemas']['AddressDto'][]
       /** @description List of operators for this prison */
@@ -528,7 +528,7 @@ export interface components {
       /** @description List of addresses for this prison */
       addresses: components['schemas']['UpdateAddressDto'][]
       /** @description Set of categories for this prison */
-      categories: ('A' | 'B' | 'C' | 'D')[]
+      categories: ('A' | 'B' | 'C' | 'D' | 'OPEN' | 'CLOSED')[]
     }
     /** @description Full name of prison with id */
     PrisonNameDto: {
@@ -542,6 +542,11 @@ export interface components {
        * @example Moorland HMP
        */
       prisonName: string
+      /**
+       * @description Name of the prison in Welsh
+       * @example Carchar Brynbuga
+       */
+      prisonNameInWelsh?: string
     }
   }
   responses: never

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import unauthenticatedRoutes from './routes/unauthenticatedRoutes'
 import type { Services } from './services'
 import populateCurrentBooker from './middleware/populateCurrentBooker'
 import analyticsConsent from './middleware/analyticsConsent'
+import populatePrisonNames from './middleware/populatePrisonNames'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -46,6 +47,7 @@ export default function createApp(services: Services): express.Application {
   app.use(analyticsConsent())
   app.use(setUpCsrf())
 
+  app.use(populatePrisonNames(services.prisonService))
   app.use(unauthenticatedRoutes(services))
 
   app.use(authenticationMiddleware())

--- a/server/constants/locales.ts
+++ b/server/constants/locales.ts
@@ -5,6 +5,8 @@ export const LOCALE = {
   CY: 'cy',
 } as const
 
+export type Locale = (typeof LOCALE)[keyof typeof LOCALE] // 'en' | 'cy'
+
 export const SUPPORTED_LOCALES = config.features.welshLanguageEnabled
   ? ([LOCALE.EN, LOCALE.CY] as const)
   : ([LOCALE.EN] as const)

--- a/server/middleware/populatePrisonNames.test.ts
+++ b/server/middleware/populatePrisonNames.test.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express'
+import populatePrisonNames from './populatePrisonNames'
+import { createMockPrisonService } from '../services/testutils/mocks'
+import TestData from '../routes/testutils/testData'
+
+describe('populatePrisonNames', () => {
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  const prisonService = createMockPrisonService()
+  const prisonNames = TestData.prisonNames()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    req = { path: '/test', session: {} } as Request
+    res = { locals: {} } as Response
+  })
+
+  it('should populate res.locals.prisonNames with prison names from the PrisonService', async () => {
+    prisonService.getAllPrisonNames.mockResolvedValue(prisonNames)
+
+    await populatePrisonNames(prisonService)(req, res, next)
+
+    expect(prisonService.getAllPrisonNames).toHaveBeenCalled()
+    expect(res.locals.prisonNames).toStrictEqual(prisonNames)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/populatePrisonNames.ts
+++ b/server/middleware/populatePrisonNames.ts
@@ -1,0 +1,9 @@
+import { RequestHandler } from 'express'
+import { PrisonService } from '../services'
+
+export default function populatePrisonNames(prisonService: PrisonService): RequestHandler {
+  return async (req, res, next) => {
+    res.locals.prisonNames = await prisonService.getAllPrisonNames()
+    return next()
+  }
+}

--- a/server/routes/selectPrison/selectPrisonController.test.ts
+++ b/server/routes/selectPrison/selectPrisonController.test.ts
@@ -17,7 +17,6 @@ const prisonService = createMockPrisonService()
 
 beforeEach(() => {
   sessionData = {} as SessionData
-  prisonService.getAllPrisonNames.mockResolvedValue(prisonNames)
 
   app = appWithAllRoutes({ services: { prisonService }, sessionData })
 })
@@ -54,7 +53,6 @@ describe('Select a prison', () => {
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 
           expect(sessionData.selectedPrisonId).toBeUndefined()
-          expect(prisonService.getAllPrisonNames).toHaveBeenCalled()
         })
     })
 

--- a/server/routes/selectPrison/selectPrisonController.ts
+++ b/server/routes/selectPrison/selectPrisonController.ts
@@ -11,11 +11,8 @@ export default class SelectPrisonController {
     return async (req, res) => {
       delete req.session.selectedPrisonId
 
-      const prisons = await this.prisonService.getAllPrisonNames()
-
       return res.render('pages/selectPrison/selectPrison', {
         errors: req.flash('errors'),
-        prisons,
       })
     }
   }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -78,6 +78,8 @@ function appSetup(
     res.locals = {
       ...res.locals,
       ...(req.user && { user: { ...req.user } }),
+
+      prisonNames: TestData.prisonNames(), // emulate populatePrisonNames()
     }
     next()
   })

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -251,10 +251,10 @@ export default class TestData {
 
   static prisonNames = ({
     prisonNames = {
-      CFI: { prisonName: 'Cardiff (HMP & YOI)', prisonNameInWelsh: 'Carchar Caerdydd' },
-      DHI: { prisonName: 'Drake Hall (HMP & YOI)' },
-      FHI: { prisonName: 'Foston Hall (HMP & YOI)' },
-      HEI: { prisonName: 'Hewell (HMP & YOI)' },
+      CFI: { name: { en: 'Cardiff (HMP & YOI)', cy: 'Carchar Caerdydd' } },
+      DHI: { name: { en: 'Drake Hall (HMP & YOI)' } },
+      FHI: { name: { en: 'Foston Hall (HMP & YOI)' } },
+      HEI: { name: { en: 'Hewell (HMP & YOI)' } },
     },
   }: Partial<{ prisonNames: PrisonNames }> = {}): PrisonNames => prisonNames
 

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -250,6 +250,7 @@ export default class TestData {
 
   static prisonNameDtos = ({
     prisons = [
+      { prisonId: 'CFI', prisonName: 'Cardiff (HMP & YOI)', prisonNameInWelsh: 'Carchar Caerdydd' },
       { prisonId: 'DHI', prisonName: 'Drake Hall (HMP & YOI)' },
       { prisonId: 'FHI', prisonName: 'Foston Hall (HMP & YOI)' },
       { prisonId: 'HEI', prisonName: 'Hewell (HMP & YOI)' },

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../data/orchestrationApiTypes'
 import { PrisonNameDto } from '../../data/prisonRegisterApiTypes'
 import { Prisoner, Visitor } from '../../services/bookerService'
+import { PrisonNames } from '../../services/prisonService'
 import { VisitDetails } from '../../services/visitService'
 
 export default class TestData {
@@ -247,6 +248,15 @@ export default class TestData {
   })
 
   static prisonIds = (prisonIds = ['DHI', 'FHI', 'HEI']): string[] => prisonIds
+
+  static prisonNames = ({
+    prisonNames = {
+      CFI: { prisonName: 'Cardiff (HMP & YOI)', prisonNameInWelsh: 'Carchar Caerdydd' },
+      DHI: { prisonName: 'Drake Hall (HMP & YOI)' },
+      FHI: { prisonName: 'Foston Hall (HMP & YOI)' },
+      HEI: { prisonName: 'Hewell (HMP & YOI)' },
+    },
+  }: Partial<{ prisonNames: PrisonNames }> = {}): PrisonNames => prisonNames
 
   static prisonNameDtos = ({
     prisons = [

--- a/server/routes/unauthenticatedRoutes.test.ts
+++ b/server/routes/unauthenticatedRoutes.test.ts
@@ -3,11 +3,9 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes } from './testutils/appSetup'
 import paths from '../constants/paths'
-import { createMockPrisonService } from '../services/testutils/mocks'
 import config from '../config'
 
 let app: Express
-const prisonService = createMockPrisonService()
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -28,9 +26,7 @@ describe('/ - root path redirect', () => {
 describe('/select-prison', () => {
   // Full tests for this route in ./server/routes/selectPrison
   it('should render select prison page', () => {
-    prisonService.getAllPrisonNames.mockResolvedValue([])
-
-    app = appWithAllRoutes({ services: { prisonService } })
+    app = appWithAllRoutes({})
     return request(app)
       .get(paths.SELECT_PRISON)
       .expect('Content-Type', /html/)

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -39,26 +39,27 @@ describe('Prison service', () => {
   })
 
   describe('getAllPrisonNames', () => {
+    const prisonNames = TestData.prisonNames() // Prison names key/value object used in the app
+    const prisonNameDtos = TestData.prisonNameDtos() // PrisonNameDto array from the API
+
     it('should return all prison names if cache hit', async () => {
-      const prisonNames = TestData.prisonNameDtos()
       dataCache.get.mockResolvedValue(prisonNames)
 
       expect(await prisonService.getAllPrisonNames()).toStrictEqual(prisonNames)
 
-      expect(dataCache.get).toHaveBeenCalledWith('prisonNames')
+      expect(dataCache.get).toHaveBeenCalledWith('allPrisonNames')
       expect(dataCache.set).not.toHaveBeenCalled()
       expect(prisonRegisterApiClient.getPrisonNames).not.toHaveBeenCalled()
     })
 
     it('should return all prison names and save to cache if a cache miss', async () => {
-      const prisonNames = TestData.prisonNameDtos()
       dataCache.get.mockResolvedValue(null)
-      prisonRegisterApiClient.getPrisonNames.mockResolvedValue(prisonNames)
+      prisonRegisterApiClient.getPrisonNames.mockResolvedValue(prisonNameDtos)
 
       expect(await prisonService.getAllPrisonNames()).toStrictEqual(prisonNames)
 
-      expect(dataCache.get).toHaveBeenCalledWith('prisonNames')
-      expect(dataCache.set).toHaveBeenCalledWith('prisonNames', prisonNames, 86400) // 24 hours
+      expect(dataCache.get).toHaveBeenCalledWith('allPrisonNames')
+      expect(dataCache.set).toHaveBeenCalledWith('allPrisonNames', prisonNames, 86400) // 24 hours
       expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalled()
     })
   })

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,11 +1,12 @@
 import { DataCache, HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient, RestClientBuilder } from '../data'
 import { PrisonDto, PrisonRegisterPrisonDto } from '../data/orchestrationApiTypes'
-import { PrisonNameDto } from '../data/prisonRegisterApiTypes'
 
 type CacheConfig = { key: string; ttlSecs: number }
 
+export type PrisonNames = Record<string, { prisonName: string; prisonNameInWelsh?: string }>
+
 export default class PrisonService {
-  private readonly allPrisonNamesCache: CacheConfig = { key: 'prisonNames', ttlSecs: 60 * 60 * 24 } // 24 hour cache
+  private readonly allPrisonNamesCache: CacheConfig = { key: 'allPrisonNames', ttlSecs: 60 * 60 * 24 } // 24 hour cache
 
   private readonly supportedPrisonIdsCache: CacheConfig = { key: 'supportedPrisonIds', ttlSecs: 60 * 5 } // 5 min cache
 
@@ -18,8 +19,8 @@ export default class PrisonService {
     private readonly dataCache: DataCache,
   ) {}
 
-  async getAllPrisonNames(): Promise<PrisonNameDto[]> {
-    const cachedAllPrisonNames = await this.dataCache.get<PrisonNameDto[]>(this.allPrisonNamesCache.key)
+  async getAllPrisonNames(): Promise<PrisonNames> {
+    const cachedAllPrisonNames = await this.dataCache.get<PrisonNames>(this.allPrisonNamesCache.key)
 
     if (cachedAllPrisonNames) {
       return cachedAllPrisonNames
@@ -28,7 +29,15 @@ export default class PrisonService {
     const token = await this.hmppsAuthClient.getSystemClientToken()
     const prisonRegisterApiClient = this.prisonRegisterApiClientFactory(token)
 
-    const allPrisonNames = await prisonRegisterApiClient.getPrisonNames()
+    const allPrisonNameDtos = await prisonRegisterApiClient.getPrisonNames()
+
+    const allPrisonNames: PrisonNames = allPrisonNameDtos.reduce((acc, prison) => {
+      acc[prison.prisonId] = {
+        prisonName: prison.prisonName,
+        ...(prison.prisonNameInWelsh && { prisonNameInWelsh: prison.prisonNameInWelsh }),
+      }
+      return acc
+    }, {} as PrisonNames)
 
     await this.dataCache.set(this.allPrisonNamesCache.key, allPrisonNames, this.allPrisonNamesCache.ttlSecs)
     return allPrisonNames

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -3,7 +3,7 @@ import { PrisonDto, PrisonRegisterPrisonDto } from '../data/orchestrationApiType
 
 type CacheConfig = { key: string; ttlSecs: number }
 
-export type PrisonNames = Record<string, { prisonName: string; prisonNameInWelsh?: string }>
+export type PrisonNames = Record<string, { name: { en: string; cy?: string } }>
 
 export default class PrisonService {
   private readonly allPrisonNamesCache: CacheConfig = { key: 'allPrisonNames', ttlSecs: 60 * 60 * 24 } // 24 hour cache
@@ -33,8 +33,10 @@ export default class PrisonService {
 
     const allPrisonNames: PrisonNames = allPrisonNameDtos.reduce((acc, prison) => {
       acc[prison.prisonId] = {
-        prisonName: prison.prisonName,
-        ...(prison.prisonNameInWelsh && { prisonNameInWelsh: prison.prisonNameInWelsh }),
+        name: {
+          en: prison.prisonName,
+          ...(prison.prisonNameInWelsh && { cy: prison.prisonNameInWelsh }),
+        },
       }
       return acc
     }, {} as PrisonNames)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -10,6 +10,7 @@ import {
   formatTime,
   formatTimeDuration,
   formatTimeFromDateTime,
+  getPrisonName,
   initialiseName,
 } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
@@ -113,6 +114,8 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('formatTimeDuration', formatTimeDuration)
 
   njkEnv.addFilter('initialiseName', initialiseName)
+
+  njkEnv.addFilter('getPrisonName', getPrisonName)
 
   njkEnv.addGlobal('govukRebrand', true)
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -8,12 +8,15 @@ import {
   formatTimeDuration,
   formatTimeFromDateTime,
   getMainContactName,
+  getPrisonName,
   initialiseName,
   isAdult,
   isMobilePhoneNumber,
 } from './utils'
 import TestData from '../routes/testutils/testData'
 import { Visitor } from '../services/bookerService'
+import { PrisonNames } from '../services/prisonService'
+import { Locale } from '../constants/locales'
 
 describe('convert to title case', () => {
   it.each([
@@ -148,5 +151,21 @@ describe('isMobilePhoneNumber', () => {
     ['undefined number', undefined, false],
   ])('%s - %s - %s', (_: string, number: string | undefined, expected: boolean) => {
     expect(isMobilePhoneNumber(number)).toBe(expected)
+  })
+})
+
+describe('getPrisonName', () => {
+  const prisonNames: PrisonNames = {
+    A: { name: { en: 'Prison A' } },
+    B: { name: { en: 'Prison B', cy: 'Carchar B' } },
+  }
+
+  it.each([
+    ['returns English name when language is English', 'A', prisonNames, 'en', 'Prison A'],
+    ['returns Welsh name when language is Welsh', 'B', prisonNames, 'cy', 'Carchar B'],
+    ['falls back to English name if Welsh name not available', 'A', prisonNames, 'cy', 'Prison A'],
+    ['returns prison ID if prison is not found', 'C', prisonNames, 'en', 'C'],
+  ] as const)('%s', (_: string, prisonId: string, names: PrisonNames, lng: Locale, expected: string) => {
+    expect(getPrisonName(prisonId, names, lng)).toBe(expected)
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -3,6 +3,8 @@ import { differenceInYears, format, formatDuration, intervalToDuration, parse, p
 // eslint-disable-next-line import/no-named-as-default
 import parsePhoneNumber from 'libphonenumber-js/mobile'
 import type { Visitor } from '../services/bookerService'
+import { PrisonNames } from '../services/prisonService'
+import { Locale } from '../constants/locales'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -86,4 +88,14 @@ export const getMainContactName = (mainContact: Visitor | string = ''): string =
 
 export const isMobilePhoneNumber = (phoneNumber: string | undefined): boolean => {
   return parsePhoneNumber(phoneNumber ?? '', 'GB')?.getType() === 'MOBILE'
+}
+
+export const getPrisonName = (prisonId: string, prisonNames: PrisonNames, lng: Locale): string => {
+  const prison = prisonNames[prisonId]
+
+  if (!prison) {
+    return prisonId
+  }
+
+  return prison.name?.[lng] ?? prison.name.en
 }

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -10,7 +10,7 @@
 {% for prisonId, prison in prisonNames %}
   {% set prisonSelectItems = (prisonSelectItems.push({
     value: prisonId,
-    text: prison.name.en
+    text: prisonId | getPrisonName(prisonNames, language)
   }), prisonSelectItems) %}
 {% endfor %}
 

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -7,15 +7,14 @@
 {% set backLinkHref = paths.GOVUK_START_PAGE  %}
 
 {% set prisonSelectItems = [{ value: "", text: t("selectPrison:selectPrison.selectLabel") }] %}
-{% for prison in prisons %}
+{% for prisonId, prison in prisonNames %}
   {% set prisonSelectItems = (prisonSelectItems.push({
-    value: prison.prisonId,
+    value: prisonId,
     text: prison.prisonName
   }), prisonSelectItems) %}
 {% endfor %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -10,7 +10,7 @@
 {% for prisonId, prison in prisonNames %}
   {% set prisonSelectItems = (prisonSelectItems.push({
     value: prisonId,
-    text: prison.prisonName
+    text: prison.name.en
   }), prisonSelectItems) %}
 {% endfor %}
 


### PR DESCRIPTION
Some prisons in the Prison Register have a `prisonNameInWelsh` property which should be used if the user's language is set to Welsh.

Changes in this PR:
* update prison register API client and type definitions to include `prisonNameInWelsh` property
* refactor the data structure used to cache all prison names in Redis to be easier to look up via prisonId as a key
* add a middleware (`populatePrisonNames`) to ensure the prison name cache is available in `res.locals` (and consequently in Nunjucks)
* add a utility function and Nunjucks filter (`getPrisonName`) to get appropriate prison name given prison ID and user language

Some instances of prison names in code/templates are updated to use the new helpers. The rest will be moved over in a follow-on PR.