### PR TITLE
VB-5951 Handle selecting a prison with no digital service

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -42,6 +42,9 @@ iZSejbyqjUjJBAH9GHkPsiA+w1vutdd2PuPKOV05TLmV5ZM06bmLHQjMCGMiWK0G
 
 ORCHESTRATION_API_URL=http://localhost:9091/orchestration
 PRISON_REGISTER_API_URL=http://localhost:9091/prisonRegister
+
+NO_DIGITAL_SERVICE_PRISON_IDS=ACI
+
 PVB_URL=http://localhost:9091/pvb/en/request
 
 ADD_PRISONER_RATE_LIMIT_BOOKER_MAX_REQUESTS=5

--- a/integration_tests/e2e/selectPrison.cy.ts
+++ b/integration_tests/e2e/selectPrison.cy.ts
@@ -21,11 +21,11 @@ context('Select a prison', () => {
 
     // Submit selected prison
     cy.task('stubGetSupportedPrisonIds')
-    cy.task('stubGetPrison')
     selectPrisonPage.continue()
 
     // Visiting selected prison page
     const selectedPrisonPage = Page.verifyOnPage(SelectedPrisonPage, 'Hewell (HMP & YOI)')
+    selectedPrisonPage.noDigitalService().should('not.exist')
 
     // Continue
     cy.task('stubHmppsAuthToken')
@@ -35,6 +35,25 @@ context('Select a prison', () => {
 
     // Visits home page (via GOVUK One Login)
     Page.verifyOnPage(VisitsPage)
+  })
+
+  it('should select a prison with no digital service and see the contact prison directly message', () => {
+    cy.hideCookieBanner()
+
+    // Start at select prison page and type into autocomplete input
+    cy.visit(paths.SELECT_PRISON)
+    const selectPrisonPage = Page.verifyOnPage(SelectPrisonPage)
+    selectPrisonPage.autoCompletePrisonName('Alt', 'Altcourse (HMP & YOI)')
+
+    // Submit selected prison
+    cy.task('stubGetSupportedPrisonIds')
+    selectPrisonPage.continue()
+
+    // Visiting selected prison page
+    const selectedPrisonPage = Page.verifyOnPage(SelectedPrisonPage, 'Altcourse (HMP & YOI)')
+
+    // Message about no digital service should be shown
+    selectedPrisonPage.noDigitalService().should('exist')
   })
 
   it('should select an unsupported prison be redirected to PVB', () => {

--- a/integration_tests/pages/selectPrison/selectedPrison.ts
+++ b/integration_tests/pages/selectPrison/selectedPrison.ts
@@ -1,4 +1,4 @@
-import Page from '../page'
+import Page, { PageElement } from '../page'
 
 export default class SelectedPrisonPage extends Page {
   constructor(private readonly prisonName: string) {
@@ -8,4 +8,6 @@ export default class SelectedPrisonPage extends Page {
   continue = (): void => {
     cy.get('[data-test="continue-button"]').click()
   }
+
+  noDigitalService = (): PageElement => cy.get('[data-test="no-digital-service"]')
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -33,7 +33,7 @@ declare module 'express-session' {
 
     visitCancelled?: VisitCancelled
 
-    selectedPrisonId?: string
+    selectedPrison?: { prisonId: string; hasDigitalService: boolean }
   }
 }
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -132,7 +132,10 @@ export default {
   noDigitalServicePrisonIds: get(
     'NO_DIGITAL_SERVICE_PRISON_IDS',
     'ACI,ASI,BMI,BZI,DAI,DNI,DGI,FYI,FMI,FWI,FBI,FEI,ISI,KVI,MRI,MKI,NLI,OWI,PRI,PYI,PBI,PFI,UPI,RHI,TCI,WYI',
-  ).split(','),
+  )
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean),
 
   pvbUrl: get('PVB_URL', 'https://dev.prisonvisits.prison.service.justice.gov.uk/en/request', requiredInProduction),
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -127,8 +127,17 @@ export default {
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
+
+  // Prisons that do not use this service or PVB
+  noDigitalServicePrisonIds: get(
+    'NO_DIGITAL_SERVICE_PRISON_IDS',
+    'ACI,ASI,BMI,BZI,DAI,DNI,DGI,FYI,FMI,FWI,FBI,FEI,ISI,KVI,MRI,MKI,NLI,OWI,PRI,PYI,PBI,PFI,UPI,RHI,TCI,WYI',
+  ).split(','),
+
   pvbUrl: get('PVB_URL', 'https://dev.prisonvisits.prison.service.justice.gov.uk/en/request', requiredInProduction),
+
   rootPathRedirect: get('ROOT_PATH_REDIRECT', '/visits'), // Where to redirect unauthenticated users to for requests to '/'
+
   maintenance: {
     enabled: get('MAINTENANCE_MODE', 'false') === 'true',
     endDateTime: get('MAINTENANCE_MODE_END_DATE_TIME', ''), // ISO format e.g. YYYY-MM-DDTHH:MM

--- a/server/locales/en/selectPrison.json
+++ b/server/locales/en/selectPrison.json
@@ -11,6 +11,8 @@
     "title": "Visiting {{prisonName}}",
     "howBookingChanged": "How you book visits at this prison has changed.",
     "signInPrompt": "You need to sign in or create a GOV.UK One Login to book a visit online.",
-    "onlyOnePrisoner": "You can only book visits for one prisoner at {{prisonName}} using this service. If you need to visit another prisoner, <a href=\"{{url}}\">contact the prison directly</a>."
+    "onlyOnePrisoner": "You can only book visits for one prisoner at {{prisonName}} using this service. If you need to visit another prisoner, <a href=\"{{url}}\">contact the prison directly</a>.",
+
+    "noDigitalService": "You need to <a href=\"{{url}}\">contact this prison directly</a> to book visits."
   }
 }

--- a/server/routes/selectPrison/selectPrisonController.test.ts
+++ b/server/routes/selectPrison/selectPrisonController.test.ts
@@ -15,6 +15,8 @@ let sessionData: SessionData
 const prisonNames = TestData.prisonNameDtos()
 const prisonService = createMockPrisonService()
 
+jest.replaceProperty(config, 'noDigitalServicePrisonIds', ['ACI'])
+
 beforeEach(() => {
   sessionData = {} as SessionData
 
@@ -35,7 +37,7 @@ describe('Select a prison', () => {
     })
 
     it('should render select prison page with list of prisons and store supported prison in session', () => {
-      sessionData.selectedPrisonId = 'HEI'
+      sessionData.selectedPrison = { prisonId: 'HEI', hasDigitalService: true }
 
       return request(app)
         .get(paths.SELECT_PRISON)
@@ -52,7 +54,7 @@ describe('Select a prison', () => {
           expect($('select#prisonId option[value="HEI"]').text()).toBe('Hewell (HMP & YOI)')
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 
-          expect(sessionData.selectedPrisonId).toBeUndefined()
+          expect(sessionData.selectedPrison).toBeUndefined()
         })
     })
 
@@ -90,7 +92,23 @@ describe('Select a prison', () => {
         .expect('Location', paths.SELECTED_PRISON)
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
-          expect(sessionData.selectedPrisonId).toBe(prisonId)
+          expect(sessionData.selectedPrison).toStrictEqual({ prisonId, hasDigitalService: true })
+          expect(prisonService.isSupportedPrison).toHaveBeenCalledWith(prisonId)
+        })
+    })
+
+    it('should save selected prison to session and redirect to selected prison info page - prison with no online service', () => {
+      const prisonId = 'ACI'
+      prisonService.isSupportedPrison.mockResolvedValue(false)
+
+      return request(app)
+        .post(paths.SELECT_PRISON)
+        .send({ prisonId })
+        .expect(302)
+        .expect('Location', paths.SELECTED_PRISON)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalled()
+          expect(sessionData.selectedPrison).toStrictEqual({ prisonId, hasDigitalService: false })
           expect(prisonService.isSupportedPrison).toHaveBeenCalledWith(prisonId)
         })
     })
@@ -106,7 +124,7 @@ describe('Select a prison', () => {
         .expect('Location', config.pvbUrl)
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
-          expect(sessionData.selectedPrisonId).toBeUndefined()
+          expect(sessionData.selectedPrison).toBeUndefined()
           expect(prisonService.isSupportedPrison).toHaveBeenCalledWith(prisonId)
         })
     })
@@ -127,7 +145,7 @@ describe('Select a prison', () => {
           .expect('Location', paths.SELECT_PRISON)
           .expect(() => {
             expect(flashProvider).toHaveBeenCalledWith('errors', expectedFlashErrors)
-            expect(sessionData.selectedPrisonId).toBeUndefined()
+            expect(sessionData.selectedPrison).toBeUndefined()
           })
       })
     })

--- a/server/routes/selectPrison/selectPrisonController.ts
+++ b/server/routes/selectPrison/selectPrisonController.ts
@@ -9,7 +9,7 @@ export default class SelectPrisonController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      delete req.session.selectedPrisonId
+      delete req.session.selectedPrison
 
       return res.render('pages/selectPrison/selectPrison', {
         errors: req.flash('errors'),
@@ -27,9 +27,10 @@ export default class SelectPrisonController {
 
       const { prisonId } = matchedData<{ prisonId: string }>(req)
       const isSupportedPrison = await this.prisonService.isSupportedPrison(prisonId)
+      const hasDigitalService = !config.noDigitalServicePrisonIds.includes(prisonId)
 
-      if (isSupportedPrison) {
-        req.session.selectedPrisonId = prisonId
+      if (isSupportedPrison || !hasDigitalService) {
+        req.session.selectedPrison = { prisonId, hasDigitalService }
         return res.redirect(paths.SELECTED_PRISON)
       }
 

--- a/server/routes/selectPrison/selectedPrisonController.test.ts
+++ b/server/routes/selectPrison/selectedPrisonController.test.ts
@@ -3,21 +3,15 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { SessionData } from 'express-session'
 import { appWithAllRoutes } from '../testutils/appSetup'
-import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
-import { createMockPrisonService } from '../../services/testutils/mocks'
 
 let app: Express
 let sessionData: SessionData
 
-const prison = TestData.prisonDto()
-const prisonService = createMockPrisonService()
-
 beforeEach(() => {
   sessionData = {} as SessionData
-  prisonService.getPrison.mockResolvedValue(prison)
 
-  app = appWithAllRoutes({ services: { prisonService }, sessionData })
+  app = appWithAllRoutes({ sessionData })
 })
 
 afterEach(() => {
@@ -26,8 +20,8 @@ afterEach(() => {
 
 describe('Visiting selected prison page', () => {
   describe(`GET ${paths.SELECTED_PRISON}`, () => {
-    it('should render visiting selected prison page', () => {
-      sessionData.selectedPrisonId = 'HEI'
+    it('should render visiting selected prison page - prison with digital service', () => {
+      sessionData.selectedPrison = { prisonId: 'HEI', hasDigitalService: true }
 
       return request(app)
         .get(paths.SELECTED_PRISON)
@@ -42,18 +36,31 @@ describe('Visiting selected prison page', () => {
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
           expect($('[data-test="continue-button"]').attr('href')).toBe(paths.SIGN_IN)
 
-          expect(prisonService.getPrison).toHaveBeenCalledWith(sessionData.selectedPrisonId)
+          expect($('[data-test="no-digital-service"]').length).toBe(0)
+        })
+    })
+
+    it('should render visiting selected prison page - prison without digital service', () => {
+      sessionData.selectedPrison = { prisonId: 'ACI', hasDigitalService: false }
+
+      return request(app)
+        .get(paths.SELECTED_PRISON)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('title').text()).toMatch(/^Visiting Altcourse \(HMP & YOI\) -/)
+          expect($('#navigation').length).toBe(0)
+          expect($('[data-test="back-link"]').attr('href')).toBe(paths.SELECT_PRISON)
+          expect($('h1').text().trim()).toBe('Visiting Altcourse (HMP & YOI)')
+
+          expect($('[data-test="no-digital-service"]').length).toBe(1)
+
+          expect($('[data-test="continue-button"]').length).toBe(0)
         })
     })
 
     it('should redirect to select prison page if selected prison not set in session', () => {
-      return request(app)
-        .get(paths.SELECTED_PRISON)
-        .expect(302)
-        .expect('Location', paths.SELECT_PRISON)
-        .expect(() => {
-          expect(prisonService.getPrison).not.toHaveBeenCalled()
-        })
+      return request(app).get(paths.SELECTED_PRISON).expect(302).expect('Location', paths.SELECT_PRISON)
     })
   })
 })

--- a/server/routes/selectPrison/selectedPrisonController.ts
+++ b/server/routes/selectPrison/selectedPrisonController.ts
@@ -1,21 +1,21 @@
 import type { RequestHandler } from 'express'
-import { PrisonService } from '../../services'
 import paths from '../../constants/paths'
 
 export default class SelectedPrisonController {
-  public constructor(private readonly prisonService: PrisonService) {}
+  public constructor() {}
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const { selectedPrisonId } = req.session
-
-      if (!selectedPrisonId) {
+      if (!req.session.selectedPrison) {
         return res.redirect(paths.SELECT_PRISON)
       }
 
-      const { code: prisonId } = await this.prisonService.getPrison(selectedPrisonId)
+      const { prisonId, hasDigitalService } = req.session.selectedPrison
 
-      return res.render('pages/selectPrison/selectedPrison', { prisonId })
+      return res.render('pages/selectPrison/selectedPrison', {
+        prisonId,
+        hasDigitalService,
+      })
     }
   }
 }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -240,6 +240,7 @@ export default class TestData {
 
   static prisonNames = ({
     prisonNames = {
+      ACI: { name: { en: 'Altcourse (HMP & YOI)' } }, // prison with no digital service
       CFI: { name: { en: 'Cardiff (HMP & YOI)', cy: 'Carchar Caerdydd' } },
       DHI: { name: { en: 'Drake Hall (HMP & YOI)' } },
       FHI: { name: { en: 'Foston Hall (HMP & YOI)' } },
@@ -249,6 +250,7 @@ export default class TestData {
 
   static prisonNameDtos = ({
     prisons = [
+      { prisonId: 'ACI', prisonName: 'Altcourse (HMP & YOI)' }, // prison with no digital service
       { prisonId: 'CFI', prisonName: 'Cardiff (HMP & YOI)', prisonNameInWelsh: 'Carchar Caerdydd' },
       { prisonId: 'DHI', prisonName: 'Drake Hall (HMP & YOI)' },
       { prisonId: 'FHI', prisonName: 'Foston Hall (HMP & YOI)' },

--- a/server/routes/unauthenticatedRoutes.ts
+++ b/server/routes/unauthenticatedRoutes.ts
@@ -11,7 +11,7 @@ export default function routes({ prisonService }: Services): Router {
   const router = Router()
 
   const selectPrisonController = new SelectPrisonController(prisonService)
-  const selectedPrisonController = new SelectedPrisonController(prisonService)
+  const selectedPrisonController = new SelectedPrisonController()
 
   // Root path '/' redirect
   router.get(paths.ROOT, async (req, res) => {

--- a/server/views/pages/selectPrison/selectedPrison.njk
+++ b/server/views/pages/selectPrison/selectedPrison.njk
@@ -22,20 +22,28 @@
 
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
-      <p>{{ t("selectPrison:selectedPrison.howBookingChanged") }}</p>
+      {% if hasDigitalService %}
+        <p>{{ t("selectPrison:selectedPrison.howBookingChanged") }}</p>
 
-      <p>{{ t("selectPrison:selectedPrison.signInPrompt") }}</p>
+        <p>{{ t("selectPrison:selectedPrison.signInPrompt") }}</p>
 
-      {{ govukInsetText({
-        html: insetText
-      }) }}
+        {{ govukInsetText({
+          html: insetText
+        }) }}
 
-      {{ govukButton({
-        text: t("common:buttons.continue"),
-        href: paths.SIGN_IN,
-        attributes: { "data-test": "continue-button" },
-        preventDoubleClick: true
-      }) }} 
+        {{ govukButton({
+          text: t("common:buttons.continue"),
+          href: paths.SIGN_IN,
+          attributes: { "data-test": "continue-button" },
+          preventDoubleClick: true
+        }) }}
+      {% else %}
+        <p data-test="no-digital-service">
+          {{ t("selectPrison:selectedPrison.noDigitalService", {
+            url: "https://www.gov.uk/government/collections/prisons-in-england-and-wales"
+          }) | safe -}}
+        </p>
+      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
Add config for the list of prisons that have no digital services (i.e. cannot use this service or PVB).

If one of these prisons is selected, advise users to contact the prison directly rather than allowing sign in to the service or a redirect to PVB.