### PR TITLE
VB-6754, VB-6755 Ask bookers Welsh language comms preference

### DIFF
--- a/assets/scss/components/_language-toggle.scss
+++ b/assets/scss/components/_language-toggle.scss
@@ -6,7 +6,7 @@
   display: inline;
 
   &__list {
-    margin-top: 1em;
+    margin-bottom: govuk-spacing(-2);
     float: right;
     text-align: right;
   }

--- a/server/routes/addVisitor/checkVisitorDetailsController.test.ts
+++ b/server/routes/addVisitor/checkVisitorDetailsController.test.ts
@@ -22,6 +22,7 @@ beforeEach(() => {
         'visitorDob-month': '2',
         'visitorDob-year': '2000',
         visitorDob: '2000-02-01',
+        languagePreference: 'en',
       },
     },
   } as SessionData
@@ -35,7 +36,7 @@ afterEach(() => {
 
 describe('Check visitor request details', () => {
   describe(`GET ${paths.ADD_VISITOR.CHECK}`, () => {
-    it('should render check visitor request page', () => {
+    it('should render check visitor request page (in English - no updates in Welsh row)', () => {
       return request(app)
         .get(paths.ADD_VISITOR.CHECK)
         .expect('Content-Type', /html/)
@@ -50,8 +51,34 @@ describe('Check visitor request details', () => {
           expect($('[data-test=first-name]').text().trim()).toBe('first')
           expect($('[data-test=last-name]').text().trim()).toBe('last')
           expect($('[data-test=date-of-birth]').text().trim()).toBe('1 February 2000')
+          expect($('[data-test=updates-in-welsh]').length).toBe(0)
           expect($('[data-test=submit]').parent('form').attr('action')).toBe(paths.ADD_VISITOR.CHECK)
           expect($('[data-test=submit]').text().trim()).toBe('Accept and send')
+        })
+    })
+
+    it('should render check visitor request page (in Welsh - with updates in Welsh row showing no)', () => {
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.ADD_VISITOR.CHECK)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test=updates-in-welsh]').text().trim()).toBe('No')
+        })
+    })
+
+    it('should render check visitor request page (in Welsh - with updates in Welsh row showing yes)', () => {
+      sessionData.addVisitorJourney!.visitorDetails.languagePreference = 'cy'
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.ADD_VISITOR.CHECK)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test=updates-in-welsh]').text().trim()).toBe('Yes')
         })
     })
 
@@ -88,6 +115,7 @@ describe('Check visitor request details', () => {
                 firstName: 'first',
                 lastName: 'last',
                 dateOfBirth: '2000-02-01',
+                languagePreference: 'en',
               },
             })
           })

--- a/server/routes/addVisitor/visitorDetailsController.test.ts
+++ b/server/routes/addVisitor/visitorDetailsController.test.ts
@@ -30,7 +30,7 @@ describe('Visitor details', () => {
       flashProvider.mockImplementation((key: keyof FlashData) => flashData[key])
     })
 
-    it('should render visitor information page', () => {
+    it('should render visitor information page (in English - without Welsh updates preference checkbox)', () => {
       return request(app)
         .get(paths.ADD_VISITOR.DETAILS)
         .expect('Content-Type', /html/)
@@ -47,7 +47,21 @@ describe('Visitor details', () => {
           expect($('input[name=visitorDob-day]').length).toBe(1)
           expect($('input[name=visitorDob-month]').length).toBe(1)
           expect($('input[name=visitorDob-year]').length).toBe(1)
+          expect($('input[name=languagePreference]').length).toBe(0)
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
+        })
+    })
+
+    it('should render visitor information page (in Welsh - with Welsh updates preference checkbox)', () => {
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.ADD_VISITOR.DETAILS)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=languagePreference]').length).toBe(1)
+          expect($('input[name=languagePreference]').prop('checked')).toBe(true)
         })
     })
 
@@ -121,25 +135,46 @@ describe('Visitor details', () => {
   })
 
   describe(`POST ${paths.ADD_VISITOR.DETAILS}`, () => {
-    const visitorDetails: AddVisitorJourney['visitorDetails'] = {
+    const formData = {
       firstName: 'first',
       lastName: 'last',
       'visitorDob-day': '1',
       'visitorDob-month': '2',
       'visitorDob-year': '2000',
       visitorDob: '2000-02-01',
-      languagePreference: 'en',
-    } as const
+    }
 
-    it('should save visitor information to session and redirect to check request page', () => {
+    it('should save visitor information to session and redirect to check request page (English language)', () => {
+      const expectedVisitorDetails: AddVisitorJourney['visitorDetails'] = {
+        ...formData,
+        languagePreference: 'en',
+      }
       return request(app)
         .post(paths.ADD_VISITOR.DETAILS)
-        .send(visitorDetails)
+        .send(formData)
         .expect(302)
         .expect('Location', paths.ADD_VISITOR.CHECK)
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
-          expect(sessionData.addVisitorJourney!.visitorDetails).toStrictEqual(visitorDetails)
+          expect(sessionData.addVisitorJourney!.visitorDetails).toStrictEqual(expectedVisitorDetails)
+        })
+    })
+
+    it('should save visitor information to session and redirect to check request page (Welsh language with updates in Welsh checked)', () => {
+      const expectedVisitorDetails: AddVisitorJourney['visitorDetails'] = {
+        ...formData,
+        languagePreference: 'cy',
+      }
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .post(paths.ADD_VISITOR.DETAILS)
+        .send({ ...formData, languagePreference: 'cy' })
+        .expect(302)
+        .expect('Location', paths.ADD_VISITOR.CHECK)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalled()
+          expect(sessionData.addVisitorJourney!.visitorDetails).toStrictEqual(expectedVisitorDetails)
         })
     })
 

--- a/server/routes/addVisitor/visitorDetailsController.ts
+++ b/server/routes/addVisitor/visitorDetailsController.ts
@@ -8,9 +8,14 @@ export default class VisitorDetailsController {
     return async (req, res) => {
       const { addVisitorJourney } = req.session
 
-      const formValues = {
+      const formValues: Record<string, string> = {
         ...(addVisitorJourney?.visitorDetails && { ...addVisitorJourney.visitorDetails }),
         ...req.flash('formValues')?.[0],
+      }
+
+      // Default to updates in Welsh on initial form load if user language is Welsh
+      if (req.language === 'cy' && Object.keys(formValues).length === 0) {
+        formValues.languagePreference = 'cy'
       }
 
       return res.render('pages/addVisitor/visitorDetails', {
@@ -38,6 +43,7 @@ export default class VisitorDetailsController {
           'visitorDob-month': string
           'visitorDob-year': string
           visitorDob: string
+          languagePreference?: 'cy'
         }
       >matchedData(req)
 
@@ -49,7 +55,7 @@ export default class VisitorDetailsController {
           'visitorDob-month': data['visitorDob-month'],
           'visitorDob-year': data['visitorDob-year'],
           visitorDob: data.visitorDob,
-          languagePreference: 'en',
+          languagePreference: data.languagePreference ?? 'en',
         },
       }
 
@@ -63,12 +69,15 @@ export default class VisitorDetailsController {
         .trim()
         .isLength({ min: 1, max: 250 })
         .withMessage((_value, { req }) => req.t('validation:firstName')),
+
       body('lastName')
         .trim()
         .isLength({ min: 1, max: 250 })
         .withMessage((_value, { req }) => req.t('validation:lastName')),
 
       ...dateOfBirthValidationChain('visitorDob'),
+
+      body('languagePreference').optional().isIn(['cy']),
     ]
   }
 }

--- a/server/routes/bookVisit/checkVisitDetailsController.test.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
       mainContact: 'User One',
       mainContactPhone: '07712 000 000',
       mainContactEmail: 'user@example.com',
+      languagePreference: 'en',
       visitorSupport: 'Wheelchair access',
     },
   } as SessionData
@@ -79,7 +80,7 @@ describe('Check visit details', () => {
         })
     })
 
-    it('should render check visit details page', () => {
+    it('should render check visit details page (in English - no updates in English/Welsh row)', () => {
       return request(app)
         .get(paths.BOOK_VISIT.CHECK_DETAILS)
         .expect(200)
@@ -101,7 +102,36 @@ describe('Check visit details', () => {
           expect($('[data-test="main-contact-name"]').text()).toBe('User One')
           expect($('[data-test="contact-details-email"]').text()).toBe('user@example.com')
           expect($('[data-test="contact-details-phone"]').text()).toBe('07712 000 000')
+          expect($('[data-test=updates-in-language]').length).toBe(0)
           expect($('[data-test="change-main-contact"]').attr('href')).toBe(paths.BOOK_VISIT.MAIN_CONTACT)
+        })
+    })
+
+    it('should render check visit details page (in Welsh - with updates in Welsh and English)', () => {
+      sessionData.bookVisitJourney!.languagePreference = 'cy'
+
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.BOOK_VISIT.CHECK_DETAILS)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test=updates-in-language]').text()).toBe('Updates in Welsh and English')
+        })
+    })
+
+    it('should render check visit details page (in Welsh - with updates in English only)', () => {
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.BOOK_VISIT.CHECK_DETAILS)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test=updates-in-language]').text()).toBe('Updates in English')
         })
     })
 

--- a/server/routes/bookVisit/checkVisitDetailsController.ts
+++ b/server/routes/bookVisit/checkVisitDetailsController.ts
@@ -15,6 +15,7 @@ export default class CheckVisitDetailsController {
 
       res.render('pages/bookVisit/checkVisitDetails', {
         additionalSupport: bookVisitJourney.visitorSupport,
+        languagePreference: bookVisitJourney.languagePreference,
         mainContactName: getMainContactName(bookVisitJourney.mainContact),
         mainContactPhone: bookVisitJourney.mainContactPhone,
         mainContactEmail: bookVisitJourney.mainContactEmail,

--- a/server/routes/bookVisit/contactDetailsController.test.ts
+++ b/server/routes/bookVisit/contactDetailsController.test.ts
@@ -78,7 +78,7 @@ describe('Contact details', () => {
         })
     })
 
-    it('should render contact details page for selected main contact and all fields empty (in English - without without Welsh updates preference checkbox)', () => {
+    it('should render contact details page for selected main contact and all fields empty (in English - without Welsh updates preference checkbox)', () => {
       return request(app)
         .get(paths.BOOK_VISIT.CONTACT_DETAILS)
         .expect(200)

--- a/server/routes/bookVisit/contactDetailsController.test.ts
+++ b/server/routes/bookVisit/contactDetailsController.test.ts
@@ -78,7 +78,7 @@ describe('Contact details', () => {
         })
     })
 
-    it('should render contact details page for selected main contact and all fields empty', () => {
+    it('should render contact details page for selected main contact and all fields empty (in English - without without Welsh updates preference checkbox)', () => {
       return request(app)
         .get(paths.BOOK_VISIT.CONTACT_DETAILS)
         .expect(200)
@@ -95,6 +95,21 @@ describe('Contact details', () => {
           expect($('input[name=getUpdatesBy]:checked').length).toBe(0)
           expect($('input[name=mainContactEmail]').prop('value')).toBeFalsy()
           expect($('input[name=mainContactPhone]').prop('value')).toBeFalsy()
+          expect($('input[name=languagePreference]').length).toBe(0)
+        })
+    })
+
+    it('should render contact details page (in Welsh - with Welsh updates preference checkbox)', () => {
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.BOOK_VISIT.CONTACT_DETAILS)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=languagePreference]').length).toBe(1)
+          expect($('input[name=languagePreference]').prop('checked')).toBe(true)
         })
     })
 
@@ -111,6 +126,7 @@ describe('Contact details', () => {
           expect($('input[name=getUpdatesBy]:checked').length).toBe(2)
           expect($('input[name=mainContactEmail]').prop('value')).toBe('user@example.com')
           expect($('input[name=mainContactPhone]').prop('value')).toBe('07712 000 000')
+          expect($('input[name=languagePreference]').length).toBe(0)
         })
     })
 
@@ -129,6 +145,30 @@ describe('Contact details', () => {
           expect($('input[name=getUpdatesBy]:checked').length).toBe(1)
           expect($('input[name=mainContactEmail]').prop('value')).toBe('new-email')
           expect($('input[name=mainContactPhone]').prop('value')).toBeFalsy()
+          expect($('input[name=languagePreference]').length).toBe(0)
+        })
+    })
+
+    it('should pre-populate with data in formValues overriding that in session (in Welsh - unchecked updates in Welsh checkbox)', () => {
+      sessionData.bookVisitJourney!.mainContactEmail = 'user@example.com'
+      sessionData.bookVisitJourney!.mainContactPhone = '07712 000 000'
+      sessionData.bookVisitJourney!.languagePreference = 'en'
+      const formValues = { getUpdatesBy: ['email'], mainContactEmail: 'new-email', mainContactPhone: '' }
+      flashData = { formValues: [formValues] }
+
+      app = appWithAllRoutes({ sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(paths.BOOK_VISIT.CONTACT_DETAILS)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('input[name=getUpdatesBy]:checked').length).toBe(1)
+          expect($('input[name=mainContactEmail]').prop('value')).toBe('new-email')
+          expect($('input[name=mainContactPhone]').prop('value')).toBeFalsy()
+          expect($('input[name=languagePreference]').length).toBe(1)
+          expect($('input[name=languagePreference]').prop('checked')).toBe(false)
         })
     })
 
@@ -180,6 +220,35 @@ describe('Contact details', () => {
           expect(flashProvider).not.toHaveBeenCalled()
           expect(sessionData.bookVisitJourney!.mainContactEmail).toBe('user@example.com')
           expect(sessionData.bookVisitJourney!.mainContactPhone).toBe('07712 000 000')
+          expect(sessionData.bookVisitJourney!.languagePreference).toBe('en')
+
+          expect(visitService.changeVisitApplication).toHaveBeenCalledWith({
+            bookVisitJourney: sessionData.bookVisitJourney,
+          })
+        })
+    })
+    it('should save new email and phone number to session, update application and redirect to check visit details page (in Welsh with updates in Welsh checked)', () => {
+      sessionData.bookVisitJourney!.mainContactEmail = 'existing-email'
+      sessionData.bookVisitJourney!.mainContactPhone = 'existing-phone'
+      sessionData.bookVisitJourney!.languagePreference = 'en'
+
+      app = appWithAllRoutes({ services: { visitService }, sessionData, lng: 'cy' })
+
+      return request(app)
+        .post(paths.BOOK_VISIT.CONTACT_DETAILS)
+        .send({
+          getUpdatesBy: ['email', 'phone'],
+          mainContactEmail: 'user@example.com',
+          mainContactPhone: '07712 000 000',
+          languagePreference: 'cy',
+        })
+        .expect(302)
+        .expect('location', paths.BOOK_VISIT.CHECK_DETAILS)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalled()
+          expect(sessionData.bookVisitJourney!.mainContactEmail).toBe('user@example.com')
+          expect(sessionData.bookVisitJourney!.mainContactPhone).toBe('07712 000 000')
+          expect(sessionData.bookVisitJourney!.languagePreference).toBe('cy')
 
           expect(visitService.changeVisitApplication).toHaveBeenCalledWith({
             bookVisitJourney: sessionData.bookVisitJourney,
@@ -204,6 +273,7 @@ describe('Contact details', () => {
           expect(flashProvider).not.toHaveBeenCalled()
           expect(sessionData.bookVisitJourney!.mainContactEmail).toBeUndefined()
           expect(sessionData.bookVisitJourney!.mainContactPhone).toBe('07712 000 000')
+          expect(sessionData.bookVisitJourney!.languagePreference).toBe('en')
 
           expect(visitService.changeVisitApplication).toHaveBeenCalledWith({
             bookVisitJourney: sessionData.bookVisitJourney,
@@ -228,7 +298,7 @@ describe('Contact details', () => {
           expect(flashProvider).not.toHaveBeenCalled()
           expect(sessionData.bookVisitJourney!.mainContactEmail).toBe('user@example.com')
           expect(sessionData.bookVisitJourney!.mainContactPhone).toBeUndefined()
-
+          expect(sessionData.bookVisitJourney!.languagePreference).toBe('en')
           expect(visitService.changeVisitApplication).toHaveBeenCalledWith({
             bookVisitJourney: sessionData.bookVisitJourney,
           })

--- a/server/routes/bookVisit/contactDetailsController.ts
+++ b/server/routes/bookVisit/contactDetailsController.ts
@@ -9,13 +9,21 @@ export default class ContactDetailsController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const { mainContact, mainContactEmail, mainContactPhone } = req.session.bookVisitJourney!
+      const { mainContact, mainContactEmail, mainContactPhone, languagePreference } = req.session.bookVisitJourney!
+
+      const flashFormValues = req.flash('formValues')?.[0] ?? {}
+
+      // Default to updates in Welsh on initial form load if user language is Welsh
+      if (req.language === 'cy' && !languagePreference && Object.keys(flashFormValues).length === 0) {
+        flashFormValues.languagePreference = 'cy'
+      }
 
       const formValues = {
         mainContactEmail,
         mainContactPhone,
         getUpdatesBy: [...(mainContactEmail ? ['email'] : []), ...(mainContactPhone ? ['phone'] : [])],
-        ...req.flash('formValues')?.[0],
+        languagePreference,
+        ...flashFormValues,
       }
 
       res.render('pages/bookVisit/contactDetails', {
@@ -36,15 +44,16 @@ export default class ContactDetailsController {
       }
 
       const bookVisitJourney = req.session.bookVisitJourney!
-      const { getUpdatesBy, mainContactEmail, mainContactPhone } = matchedData<{
+      const { getUpdatesBy, mainContactEmail, mainContactPhone, languagePreference } = matchedData<{
         getUpdatesBy: string[]
         mainContactEmail?: string
         mainContactPhone?: string
+        languagePreference?: 'cy'
       }>(req)
 
       bookVisitJourney.mainContactEmail = getUpdatesBy.includes('email') ? mainContactEmail : undefined
       bookVisitJourney.mainContactPhone = getUpdatesBy.includes('phone') ? mainContactPhone : undefined
-      bookVisitJourney.languagePreference = 'en'
+      bookVisitJourney.languagePreference = languagePreference ?? 'en'
 
       await this.visitService.changeVisitApplication({ bookVisitJourney })
 
@@ -60,16 +69,20 @@ export default class ContactDetailsController {
         .withMessage((_value, { req }) => req.t('validation:contactMethodRequired'))
         .isIn(['email', 'phone'])
         .withMessage((_value, { req }) => req.t('validation:contactMethodRequired')),
+
       body('mainContactEmail')
         .if(body('getUpdatesBy').custom((value: string[]) => value.includes('email')))
         .trim()
         .isEmail()
         .withMessage((_value, { req }) => req.t('validation:emailInvalid')),
+
       body('mainContactPhone')
         .if(body('getUpdatesBy').custom((value: string[]) => value.includes('phone')))
         .trim()
         .matches(/^(?:0|\+?44)(?:\d\s?){9,10}$/)
         .withMessage((_value, { req }) => req.t('validation:phoneInvalid')),
+
+      body('languagePreference').optional().isIn(['cy']),
     ]
   }
 }

--- a/server/routes/visits/visitDetailsController.test.ts
+++ b/server/routes/visits/visitDetailsController.test.ts
@@ -45,7 +45,7 @@ describe('View a single visit', () => {
       jest.useRealTimers()
     })
 
-    it('should render the visit details page', () => {
+    it('should render the visit details page (in English with no Welsh/English preference)', () => {
       sessionData.bookedVisits = { type: 'future', visits: [visitDetails] }
 
       return request(app)
@@ -67,6 +67,7 @@ describe('View a single visit', () => {
           expect($('[data-test="main-contact-email"]').text()).toBe('visitor@example.com')
           expect($('[data-test="main-contact-number"]').text()).toBe('07712 000 000')
           expect($('[data-test="main-contact-no-details"]').length).toBe(0)
+          expect($('[data-test="main-contact-updates-language"]').length).toBe(0)
 
           expect($('[data-test="contact-prison"]').text()).toContain(prison.prisonName)
           expect($('[data-test="contact-prison"]').text()).toContain(prison.phoneNumber)
@@ -81,6 +82,35 @@ describe('View a single visit', () => {
           expect($('[data-test="cancel-visit"]').attr('href')).toBe(`${paths.VISITS.CANCEL_VISIT}/${visitDisplayId}`)
 
           expect(prisonService.getPrison).toHaveBeenCalledWith(visitDetails.prisonId)
+        })
+    })
+
+    it('should render the visit details page (in Welsh with English and Welsh updates preference)', () => {
+      visitDetails.visitContact!.languagePreference = 'cy'
+      sessionData.bookedVisits = { type: 'future', visits: [visitDetails] }
+
+      app = appWithAllRoutes({ services: { prisonService }, sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(`${paths.VISITS.DETAILS}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="main-contact-updates-language"]').text()).toBe('Updates in Welsh and English')
+        })
+    })
+
+    it('should render the visit details page (in Welsh with English only updates preference)', () => {
+      sessionData.bookedVisits = { type: 'future', visits: [visitDetails] }
+
+      app = appWithAllRoutes({ services: { prisonService }, sessionData, lng: 'cy' })
+
+      return request(app)
+        .get(`${paths.VISITS.DETAILS}/${visitDetails.visitDisplayId}`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="main-contact-updates-language"]').text()).toBe('Updates in English')
         })
     })
 

--- a/server/views/pages/addVisitor/checkVisitorDetails.njk
+++ b/server/views/pages/addVisitor/checkVisitorDetails.njk
@@ -30,6 +30,7 @@
         </div>
       </div>
 
+       {# Only render last item if the language is Welsh #}
       {{ govukSummaryList({
         rows: [
           {
@@ -60,7 +61,18 @@
                 (visitorDetails.visitorDob | formatDate(dateFormats.DISPLAY_DATE, language)) +
                 "</span>"
             }
-          }
+          },
+          ({
+            key: {
+              text: t("common:labels.updatesInWelsh")
+            },
+            value: {
+              html:
+                '<span data-test="updates-in-welsh">' +
+                (t("common:labels.yes") if visitorDetails.languagePreference == 'cy' else t("common:labels.no")) +
+                "</span>"
+            }
+          } if language == 'cy')
         ]
       }) }}
 

--- a/server/views/pages/addVisitor/visitorDetails.njk
+++ b/server/views/pages/addVisitor/visitorDetails.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "components/dateOfBirthInput.njk" import dateOfBirthInput with context %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = t("addVisitor:visitorDetails.title") %}
 
@@ -46,11 +47,31 @@
 
         {{ dateOfBirthInput('visitorDob', formValues, errors) }}
 
+        {# Only render if the language is Welsh #}
+        {{ govukCheckboxes({
+          name: "languagePreference",
+          fieldset: {
+            legend: {
+              text: t("common:labels.welshLanguage")
+            }
+          },
+          items: [
+            {
+              value: "cy",
+              text: t("addVisitor:visitorDetails.updatesInWelsh"),
+              hint: {
+                text: t("common:hints.alsoInEnglish")
+              },
+              checked: formValues.languagePreference === "cy"
+            }
+          ]
+        }) if language == 'cy' }}
+
         {{ govukButton({
           text: t("common:buttons.continue"),
           attributes: { "data-test": "continue-button" },
           preventDoubleClick: true
-        }) }} 
+        }) }}
       </form>
     </div>
   </div>

--- a/server/views/pages/bookVisit/checkVisitDetails.njk
+++ b/server/views/pages/bookVisit/checkVisitDetails.njk
@@ -125,9 +125,16 @@
             },
             value: {
               html: '<p><span data-test="contact-details-email">' + mainContactEmail | escape + "</span></p>" +
-                    '<p><span data-test="contact-details-phone">' + mainContactPhone | escape + "</span></p>"
-                      if mainContactEmail or mainContactPhone else
-                    '<p><span data-test="no-contact-details">' + t("common:labels.noContactDetails") + '</span>'
+                    (
+                      '<p><span data-test="contact-details-phone">' + mainContactPhone | escape + "</span></p>"
+                        if mainContactEmail or mainContactPhone else
+                      '<p><span data-test="no-contact-details">' + t("common:labels.noContactDetails") + '</span></p>'
+                    ) +
+                    ((
+                      '<p><span data-test="updates-in-language">' +
+                        (t("common:labels.updatesInWelshAndEnglish") if languagePreference == 'cy' else t("common:labels.updatesInEnglish")) +
+                      '</span></p>'
+                    ) if language == 'cy')
             },
             actions: {
               items: [

--- a/server/views/pages/bookVisit/checkVisitDetails.njk
+++ b/server/views/pages/bookVisit/checkVisitDetails.njk
@@ -124,17 +124,14 @@
               text: t("common:labels.contactDetails")
             },
             value: {
-              html: '<p><span data-test="contact-details-email">' + mainContactEmail | escape + "</span></p>" +
-                    (
-                      '<p><span data-test="contact-details-phone">' + mainContactPhone | escape + "</span></p>"
-                        if mainContactEmail or mainContactPhone else
-                      '<p><span data-test="no-contact-details">' + t("common:labels.noContactDetails") + '</span></p>'
-                    ) +
-                    ((
-                      '<p><span data-test="updates-in-language">' +
-                        (t("common:labels.updatesInWelshAndEnglish") if languagePreference == 'cy' else t("common:labels.updatesInEnglish")) +
-                      '</span></p>'
-                    ) if language == 'cy')
+              html:
+              (('<p><span data-test="contact-details-email">' + mainContactEmail | escape + "</span></p>") if mainContactEmail) +
+
+              (('<p><span data-test="contact-details-phone">' + mainContactPhone | escape + "</span></p>") if mainContactPhone) +
+
+              (('<p><span data-test="no-contact-details">' + t("common:labels.noContactDetails") + '</span></p>') if not mainContactEmail and not mainContactPhone) +
+
+              (('<p><span data-test="updates-in-language">' + (t("common:labels.updatesInWelshAndEnglish") if languagePreference == 'cy' else t("common:labels.updatesInEnglish")) + '</span></p>') if language == 'cy')
             },
             actions: {
               items: [

--- a/server/views/pages/bookVisit/contactDetails.njk
+++ b/server/views/pages/bookVisit/contactDetails.njk
@@ -37,7 +37,7 @@
           errorMessage: errors | findError('mainContactEmail')
         }) }}
         {% endset -%}
-  
+
         {% set phoneHtml %}
         <p class="govuk-hint">
           {{ t("bookVisit:contactDetails.ukMobileHint") }}
@@ -87,11 +87,31 @@
 
         }) }}
 
+        {# Only render if the language is Welsh #}
+        {{ govukCheckboxes({
+          name: "languagePreference",
+          fieldset: {
+            legend: {
+              text: t("common:labels.welshLanguage")
+            }
+          },
+          items: [
+            {
+              value: "cy",
+              text: t("bookVisit:contactDetails.updatesInWelsh"),
+              hint: {
+                text: t("common:hints.alsoInEnglish")
+              },
+              checked: formValues.languagePreference === "cy"
+            }
+          ]
+        }) if language == 'cy' }}
+
         {{ govukButton({
           text: t("common:buttons.continue"),
           attributes: { "data-test": "continue-button" },
           preventDoubleClick: true
-        }) }} 
+        }) }}
       </form>
     </div>
   </div>

--- a/server/views/pages/visits/visit.njk
+++ b/server/views/pages/visits/visit.njk
@@ -70,6 +70,11 @@
             {{- t("common:labels.noContactDetails") -}}
           </li>
         {% endif %}
+        {% if language == 'cy' %}
+          <li data-test="main-contact-updates-language">
+            {{- t("common:labels.updatesInWelshAndEnglish") if visit.visitContact.languagePreference == 'cy' else t("common:labels.updatesInEnglish") -}}
+          </li>
+        {% endif %}
       </ul>
 
       {% if showCancelButton %}


### PR DESCRIPTION
Add checkbox for user to choose to get updates in both Welsh and English. This shows on the  **Welsh version only** of the service and has been added to the:
* Visitor request details page
* Contact details page (visit booking journey)

The stored preference is also displayed on individual visit details pages.