### PR TITLE
VB-6811 Simplify translations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -186,7 +186,11 @@ async addVisitorRequest(...): Promise<...> {
 | **Feature Testing Setup** | `docker-compose -f docker-compose-test.yml up` (WireMock, Redis, OIDC simulator) |
 | **Feature Tests (dev mode)** | `npm run start-feature:dev` + `npm run int-test` in another terminal |
 | **Lint** | `npm run lint` (ESLint, zero warnings policy) |
+| **Lint Fix** | `npm run lint-fix` (ESLint, auto-fix issues) |
 | **Type Check** | `npm run typecheck` (tsc for server + integration_tests) |
+
+# After making code changes, always run `npm run lint-fix` then `npm run lint`
+# to auto-fix formatting and confirm zero warnings before considering a task done.
 
 ## Session & Journey Objects
 
@@ -277,4 +281,3 @@ Use `express-validator` body() chains. For complex validation (e.g., date of bir
 - **Assets:** SCSS files auto-compile to CSS, views auto-copy during dev mode.
 - **i18n Development:** Missing translation keys throw errors in development (see `server/middleware/setUpI18n.ts`). Always add keys to English locale before referencing in code/templates. Locale files are auto-copied to `dist/` during build.
 - **i18n for Agents:** When adding new UI copy, always add to locale JSON files first, then reference via `t()` in templates/code. Use [server/locales/TRANSLATOR_CONTEXT.md](server/locales/TRANSLATOR_CONTEXT.md) for namespace guidance.
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,8 @@ The app uses i18next with English (en) and Welsh (cy) support. Configuration is 
 - **In Templates:** Use `t("namespace:key", { var: value })` syntax. Example: `t("bookVisit:checkVisitDetails.prisoner")`
 - **In Code:** Use `req.t("namespace:key")` in controllers for validation messages or view data
 - **Plurals:** Handled via `_one` and `_other` key suffixes; pass `{count: n}` to resolve correct form
-- **Nested References:** Locale values can contain `$t(namespace:key)` to reference other translations
+- **Nested References:** Avoid nested `$t(...)` inside locale values. Prefer plain strings with interpolation placeholders and plural suffix keys.
+- **Links in Translations:** Use `<link>...</link>` tokens in locale strings, then render with `| renderLinkTag(url) | safe` in templates.
 - **Language Detection:** Via query parameter (`?lng=cy`) or cookie; falls back to English
 - **Files:** Locales stored in `server/locales/{en,cy}/{namespace}.json` (11 namespaces: common, errors, validation, addPrisoner, addVisitor, bookVisit, selectPrison, shared, visitors, visits, staticPages)
 - **Documentation:** See [server/locales/README.md](server/locales/README.md) for setup details, [server/locales/TRANSLATOR_CONTEXT.md](server/locales/TRANSLATOR_CONTEXT.md) for translator guidance

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "watch-node-feature": "nodemon --env-file=feature.env --watch dist/ $NODE_DEBUG_OPTION dist/server.js | bunyan -o short",
     "start-feature:dev": "concurrently -k -p \"[{name}]\" -n \"Views,Locales,TypeScript,Node,Sass\" -c \"yellow.bold,magenta.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-views\" \"npm run watch-locales\" \"npm run watch-ts\" \"npm run watch-node-feature\" \"npm run watch-sass\"",
     "lint": "eslint . --cache --max-warnings 0",
+    "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest",
     "test:ci": "jest --runInBand",

--- a/server/locales/README.md
+++ b/server/locales/README.md
@@ -40,15 +40,19 @@ res.render('template', {
   prisonName: prisonLocation
 }) }}</p>
 
-{# Nested translation reference (for reusable strings) #}
-<p>{{ t("bookVisit:checkVisitDetails.visitors") }}</p>
-where that key value contains: "$t(common:plurals.visitor, {\"count\": {{count}} })"
+{# Translation containing link token, rendered with filter #}
+<p>{{ t("common:postBooking.feedback") | renderLinkTag("https://example.test") | safe }}</p>
 
 {# Using translation in conditionals #}
 {% if not email %}
   <p>{{ t("common:labels.noContactDetails") }}</p>
 {% endif %}
 ```
+
+Guidance:
+- Avoid nested translation calls (`$t(...)`) inside locale values.
+- Use interpolation placeholders (for example `{{count}}`) and plural suffix keys (`_one`, `_other`, etc.).
+- Use `<link>...</link>` tokens in locale strings and render links in templates with `renderLinkTag`.
 
 **Key Format Convention:**
 - `namespace:path.to.key` - namespaces and keys are required
@@ -65,6 +69,7 @@ Several utilities work alongside i18n for localization:
 | `formatTime` | Format time with locale | `visit.time \| formatTime(language)` |
 | `displayAge` | Translate age phrases | `visitor.dob \| displayAge(t)` (uses `common:plurals.ageYears/ageMonths`) |
 | `getPrisonName` | Lookup prison name | `prisoner.prisonId \| getPrisonName(prisonNames, language)` |
+| `renderLinkTag` | Replaces a `<link>...</link>` token with a safe anchor element | `t("common:postBooking.feedback") \| renderLinkTag(url) \| safe` |
 
 These utilities are registered in [server/utils/nunjucksSetup.ts](../utils/nunjucksSetup.ts).
 

--- a/server/locales/TRANSLATOR_CONTEXT.md
+++ b/server/locales/TRANSLATOR_CONTEXT.md
@@ -43,7 +43,6 @@ Example: `{{prisonName}}` must stay unchanged in translated text.
 
 - Keys ending in `title` are page-level headings (usually H1).
 - Keys ending in `Heading` are section headings within a page.
-- Strings may contain inline HTML (for example `<a href="{{url}}">...</a>`). Keep HTML tags and attributes intact.
 - Strings may contain nested translation references (for example `$t(common:plurals.visitor, {"count": {{count}} })`). Do not alter key names inside `$t(...)`.
 - Some short labels intentionally repeat across screens (for example "Visitors", "Date and time").
 

--- a/server/locales/TRANSLATOR_CONTEXT.md
+++ b/server/locales/TRANSLATOR_CONTEXT.md
@@ -34,7 +34,6 @@ Use i18next interpolation style with no spaces inside braces, for example `{{pri
 | `startTime` / `endTime` | Visit start/end time strings | `common`, `visits` |
 | `count` | Pluralization count | `common.plurals`, `bookVisit`, `validation` |
 | `age` / `adultAgeYears` | Age threshold/count context | `validation`, `bookVisit` |
-| `count` + `adultAgeYears` | Visit capacity values and age thresholds | `bookVisit.selectVisitors`, `validation` |
 | `phoneNumber` | Prison contact phone number | `shared` |
 | `visitReference` | Booking/request reference | `shared` |
 | `visitorName` / `prisonerName` | Display names in confirmation/status copy | `addVisitor`, `visits` |
@@ -44,12 +43,13 @@ Use i18next interpolation style with no spaces inside braces, for example `{{pri
 - Keys ending in `title` are page-level headings (usually H1).
 - Keys ending in `Heading` are section headings within a page.
 - Locale values should not contain nested translation references (for example `$t(...)`). Use plain text with placeholders and plural suffix keys (`_one`, `_other`, etc.) instead.
+- For links, use a `<link>...</link>` token in locale values. Templates render this with the `renderLinkTag` filter.
 - Some short labels intentionally repeat across screens (for example "Visitors", "Date and time").
 
 ## 4) Quick QA Checklist Before Submitting Translations
 
 - JSON remains valid.
 - Placeholder names are unchanged.
-- HTML tags are preserved and balanced.
+- Link tokens (`<link>...</link>`) are preserved and balanced.
 - Apostrophes/quotes are valid JSON-escaped where needed.
 - Tone remains plain, service-style GOV.UK English equivalent in target language.

--- a/server/locales/TRANSLATOR_CONTEXT.md
+++ b/server/locales/TRANSLATOR_CONTEXT.md
@@ -21,8 +21,8 @@ Use it with English source files in `server/locales/en`.
 
 ## 2) Interpolation Variables (Do Not Translate Variable Names)
 
-Keep placeholders exactly as written, including braces and spacing style.
-Example: `{{prisonName}}` must stay unchanged in translated text.
+Keep placeholders exactly as written.
+Use i18next interpolation style with no spaces inside braces, for example `{{prisonName}}`.
 
 | Variable | Meaning | Typical namespaces |
 |---|---|---|
@@ -34,7 +34,7 @@ Example: `{{prisonName}}` must stay unchanged in translated text.
 | `startTime` / `endTime` | Visit start/end time strings | `common`, `visits` |
 | `count` | Pluralization count | `common.plurals`, `bookVisit`, `validation` |
 | `age` / `adultAgeYears` | Age threshold/count context | `validation`, `bookVisit` |
-| `maxVisitors` / `maxAdultVisitors` / `maxChildVisitors` | Visit capacity values | `bookVisit.selectVisitors` |
+| `count` + `adultAgeYears` | Visit capacity values and age thresholds | `bookVisit.selectVisitors`, `validation` |
 | `phoneNumber` | Prison contact phone number | `shared` |
 | `visitReference` | Booking/request reference | `shared` |
 | `visitorName` / `prisonerName` | Display names in confirmation/status copy | `addVisitor`, `visits` |
@@ -43,7 +43,7 @@ Example: `{{prisonName}}` must stay unchanged in translated text.
 
 - Keys ending in `title` are page-level headings (usually H1).
 - Keys ending in `Heading` are section headings within a page.
-- Strings may contain nested translation references (for example `$t(common:plurals.visitor, {"count": {{count}} })`). Do not alter key names inside `$t(...)`.
+- Locale values should not contain nested translation references (for example `$t(...)`). Use plain text with placeholders and plural suffix keys (`_one`, `_other`, etc.) instead.
 - Some short labels intentionally repeat across screens (for example "Visitors", "Date and time").
 
 ## 4) Quick QA Checklist Before Submitting Translations

--- a/server/locales/en/addPrisoner.json
+++ b/server/locales/en/addPrisoner.json
@@ -1,7 +1,7 @@
 {
   "prisonerLocation": {
     "title": "Where is the prisoner you want to visit?",
-    "findPrisonerLink": "If you do not know, you can <a href=\"{{url}}\">apply to find the prisoner’s location</a>."
+    "findPrisonerLink": "If you do not know, you can <link>apply to find the prisoner’s location</link>."
   },
 
   "prisonerDetails": {
@@ -24,7 +24,7 @@
     "reason": "This could be because:",
     "reasonIncorrect": "the prisoner details are incorrect",
     "reasonNotAtPrison": "they are not located at this prison",
-    "checkDetails": "You can <a href=\"{{url}}\">check the details you submitted by going back to the previous page</a>.",
-    "contact": "If the prisoner details cannot be matched, you will need contact the prisoner to get the correct information before you book a visit."
+    "checkDetails": "You can <link>check the details you submitted by going back to the previous page</link>.",
+    "contact": "If the prisoner details cannot be matched, you will need to contact the prisoner to get the correct information before you book a visit."
   }
 }

--- a/server/locales/en/addVisitor.json
+++ b/server/locales/en/addVisitor.json
@@ -2,58 +2,50 @@
   "actions": {
     "viewLinkedAndRequestedVisitors": "View linked and requested visitors"
   },
-
   "addVisitorStart": {
     "title": "Providing visitor information",
     "identityRequirement": "All visitors to prisons in England and Wales, other than accompanied children under the age of 16, are required to prove their identity before entry.",
-    "acceptableId": "The visitor information you provide must match the <a href=\"{{url}}\">acceptable forms of ID</a> that the visitor will show when they visit someone in prison.",
+    "acceptableId": "The visitor information you provide must match the <link>acceptable forms of ID</link> that the visitor will show when they visit someone in prison.",
     "visitorList": "Visitors must also be on the prisoner’s visitor list. It can take several weeks for new visitors to get added to the prisoner’s visitor list.",
     "incorrectInfoRejected": "Requests with incorrect visitor information will be rejected."
   },
-
   "visitorDetails": {
     "title": "Visitor information",
     "updatesInWelsh": "Tick for updates about this request to be sent in Welsh"
   },
-
   "checkVisitorDetails": {
     "title": "Check your request",
     "description": "Your answers need to match the information on the prisoner’s visitor list.",
     "visitorInformationHeading": "Visitor information",
     "changeVisitorInformation": "visitor information",
     "confirmInformation": "By submitting this request you confirm that, to the best of your knowledge, the details you are providing are correct. Visitors must be on the prisoner’s visitor list.",
-    "acceptableId": "Make sure the visitor information you provide matches the <a href=\"{{url}}\">acceptable forms of ID</a> that the visitor will use when they visit someone in prison."
+    "acceptableId": "Make sure the visitor information you provide matches the <link>acceptable forms of ID</link> that the visitor will use when they visit someone in prison."
   },
-
   "visitorApproved": {
     "title": "Visitor linked",
     "visitorLinked": "{{visitorName}} has been linked to your account",
     "approvedMessage": "{{visitorName}} will appear as a visitor when you book visits for {{prisonerName}}."
   },
-
   "visitorRequested": {
     "title": "Request submitted",
     "requestReview": "We will review your request and reply within 5 working days",
     "approvedOrRejected": "You will get an email to say if your request has been approved or rejected.",
-    "statusOnVisitorsPage": "You can also view the status of your requests on <a href=\"{{url}}\">the visitors page</a>."
+    "statusOnVisitorsPage": "You can also view the status of your requests on <link>the visitors page</link>."
   },
-
   "visitorRequestFailAlreadyLinked": {
     "title": "Visitor already linked",
     "visitorAlreadyLinked": "You have previously linked {{visitorName}} to your account.",
     "noNeedToSubmit": "You do not need to submit a new request for this visitor."
   },
-
   "visitorRequestFailAlreadyRequested": {
     "title": "Visitor already requested",
     "visitorAlreadyRequested": "You have previously submitted a request for {{visitorName}}.",
     "waitingToBeReviewed": "It is waiting to be reviewed by the prison."
   },
-
   "visitorRequestFailTooManyRequests": {
     "title": "Visitor request cannot be submitted",
     "limitReached": "You have reached the limit for visitor requests.",
     "cannotMakeAnotherRequest": "You cannot make another request until one of your requests is reviewed. You will get an email to say if your request has been approved or rejected.",
-    "viewLinkedAndRequestedVisitors": "You can <a href=\"{{url}}\">view your linked and requested visitors</a>."
+    "viewLinkedAndRequestedVisitors": "You can <link>view your linked and requested visitors</link>."
   }
 }

--- a/server/locales/en/bookVisit.json
+++ b/server/locales/en/bookVisit.json
@@ -6,16 +6,16 @@
     "bookFromDate": "You can book a visit from {{date}}.",
 
     "transferOrRelease": "{{name}} is no longer at {{prisonName}}. They may have moved to another prison or been released.",
-    "findHowToBook": "If they have moved to another prison, <a href=\"{{url}}\">find out how to book a visit at their new prison</a>.",
-    "findPrisoner": "For help contacting them, you can <a href=\"{{url}}\">apply to find a prisoner’s location</a>.",
+    "findHowToBook": "If they have moved to another prison, <link>find out how to book a visit at their new prison</link>.",
+    "findPrisoner": "For help contacting them, you can <link>apply to find a prisoner’s location</link>.",
 
     "unsupportedPrison": "{{name}} is at {{prisonName}}. This prison is not currently supported by this service.",
-    "bookAtThisPrison": "Find out <a href=\"{{url}}\">how to book a visit at this prison</a>.",
+    "bookAtThisPrison": "Find out <link>how to book a visit at this prison</link>.",
 
     "noEligibleAdultVisitor": "One person on a visit must be 18 years old or older. None of your adult visitors can be selected. This may be because of a new restriction or a ban.",
     "addNewVisitorHeading": "Add a new visitor",
     "addNewVisitorDescription": "The person you want to book a visit for must be on the prisoner’s visitor list.",
-    "addNewVisitorRequest": "To make a request to book a visit for someone new, <a href=\"{{url}}\">complete the form</a>. We will respond within 5 working days."
+    "addNewVisitorRequest": "To make a request to book a visit for someone new, <link>complete the form</link>. We will respond within 5 working days."
   },
 
   "selectVisitors": {
@@ -76,7 +76,7 @@
 
     "noAvailableTimes": "There are currently no available visit times for {{name}}.",
     "tryLater": "Try again later to see if new visit times have become available.",
-    "contactPrison": "If you believe the prisoner should have available visit times, you can <a href=\"{{ url }}\">contact the prison directly</a>."
+    "contactPrison": "If you believe the prisoner should have available visit times, you can <link>contact the prison directly</link>."
   },
 
   "additionalSupport": {
@@ -139,6 +139,6 @@
     "responseByText": "A text message with the prison’s decision will be sent to the main contact.",
     "responseByEmail": "An email with the prison’s decision will be sent to the main contact.",
     "responseByEmailAndText": "An email and a text message with the prison’s decision will be sent to the main contact.",
-    "upcomingVisitsStatus": "<a href=\"{{url}}\">Your visits page</a> also shows the status of upcoming visits."
+    "upcomingVisitsStatus": "<link>Your visits page</link> also shows the status of upcoming visits."
   }
 }

--- a/server/locales/en/bookVisit.json
+++ b/server/locales/en/bookVisit.json
@@ -22,9 +22,12 @@
     "title": "Who is going on the visit?",
 
     "visitorLimits": {
-      "maxVisitors": "Up to $t(common:plurals.person, {\"count\": {{maxVisitors}} }) can visit someone at {{prisonName}}. This includes:",
-      "maxAdults": "$t(common:plurals.person, {\"count\": {{maxAdultVisitors}} }) $t(common:plurals.ageYears, {\"count\": {{adultAgeYears}} }) or older",
-      "maxChildren": "$t(common:plurals.person, {\"count\": {{maxChildVisitors}} }) under $t(common:plurals.ageYears, {\"count\": {{adultAgeYears}} })",
+      "maxVisitors_one": "Up to {{count}} person can visit someone at {{prisonName}}. This includes:",
+      "maxVisitors_other": "Up to {{count}} people can visit someone at {{prisonName}}. This includes:",
+      "maxAdults_one": "{{count}} person {{adultAgeYears}} years old or older",
+      "maxAdults_other": "{{count}} people {{adultAgeYears}} years old or older",
+      "maxChildren_one": "{{count}} person under {{adultAgeYears}} years old",
+      "maxChildren_other": "{{count}} people under {{adultAgeYears}} years old",
       "atLeastOneAdult": "At least one visitor must be 18 years or older."
     },
 
@@ -62,7 +65,9 @@
     "reservationTime": "Select one visit time. It will be reserved for 10 minutes.",
     "prisonerVisitTimes": "Only times that {{name}} can attend are shown.",
 
-    "availableTimesForDate": "{{date}} - $t(common:plurals.visitTime, {\"count\": {{count}} }) available",
+    "availableTimesForDate_zero": "{{date}} - no visit times available",
+    "availableTimesForDate_one": "{{date}} - {{count}} visit time available",
+    "availableTimesForDate_other": "{{date}} - {{count}} visit times available",
 
     "onlyAfterDate": "Only visit times on or after this date are shown.",
 

--- a/server/locales/en/common.json
+++ b/server/locales/en/common.json
@@ -8,7 +8,7 @@
 
   "phase": {
     "beta": "Beta",
-    "feedback": "This is a new service – your <a href=\"https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/\" target=\"_blank\">feedback (opens in a new tab)</a> will help us to improve it."
+    "feedback": "This is a new service – your <link>feedback (opens in a new tab)</link> will help us to improve it."
   },
 
   "links": {
@@ -32,7 +32,7 @@
     "viewButton": "View cookies",
     "acceptedAnalytics": "You’ve accepted analytics cookies.",
     "rejectedAnalytics": "You’ve rejected analytics cookies.",
-    "changeSettings": "You can <a href=\"{{url}}\">change your cookie settings</a> at any time.",
+    "changeSettings": "You can <link>change your cookie settings</link> at any time.",
     "hideCookieMessage": "Hide cookie message"
   },
 
@@ -53,8 +53,8 @@
 
   "postBooking": {
     "whatHappensNext": "What happens next",
-    "checkVisitDetails": "When signed in to GOV.UK One Login, you can <a href=\"{{url}}\">check the details of your visits</a>.",
-    "feedback": "You can help us to improve this service by giving <a href=\"{{url}}\">feedback</a>."
+    "checkVisitDetails": "When signed in to GOV.UK One Login, you can <link>check the details of your visits</link>.",
+    "feedback": "You can help us to improve this service by giving <link>feedback</link>."
   },
 
   "days": {

--- a/server/locales/en/common.json
+++ b/server/locales/en/common.json
@@ -24,7 +24,7 @@
   },
 
   "cookieBanner": {
-    "cookiesOn": "Cookies on $t(common:applicationName)",
+    "cookiesOn": "Cookies on {{serviceName}}",
     "essential": "We use some essential cookies to make this service work.",
     "analytics": "We’d also like to use analytics cookies so we can understand how you use the service and make improvements.",
     "acceptButton": "Accept analytics cookies",

--- a/server/locales/en/errors.json
+++ b/server/locales/en/errors.json
@@ -5,11 +5,11 @@
 
   "authError": {
     "title": "Sorry, there is a problem with the service",
-    "tryAgain": "Try again later by <a href=\"{{url}}\">signing into the service using GOV.UK One Login</a>."
+    "tryAgain": "Try again later by <link>signing into the service using GOV.UK One Login</link>."
   },
   "error": {
     "message": "Sorry, there is a problem with the service.",
     "logged": "The error has been logged.",
-    "tryReload": "You can try reloading the page or <a href=\"{{url}}\">start again</a>."
+    "tryReload": "You can try reloading the page or <link>start again</link>."
   }
 }

--- a/server/locales/en/selectPrison.json
+++ b/server/locales/en/selectPrison.json
@@ -4,15 +4,15 @@
     "selectLabel": "Select a prison",
     "selectHint": "For example, Cardiff (HMP)",
     "unknownLocationHeading": "What if I don’t know the prisoner’s location?",
-    "findPrisonerLink": "You can <a href=\"{{url}}\">apply to find the prisoner’s location</a>."
+    "findPrisonerLink": "You can <link>apply to find the prisoner’s location</link>."
   },
 
   "selectedPrison": {
     "title": "Visiting {{prisonName}}",
     "howBookingChanged": "How you book visits at this prison has changed.",
     "signInPrompt": "You need to sign in or create a GOV.UK One Login to book a visit online.",
-    "onlyOnePrisoner": "You can only book visits for one prisoner at {{prisonName}} using this service. If you need to visit another prisoner, <a href=\"{{url}}\">contact the prison directly</a>.",
+    "onlyOnePrisoner": "You can only book visits for one prisoner at {{prisonName}} using this service. If you need to visit another prisoner, <link>contact the prison directly</link>.",
 
-    "noDigitalService": "You need to <a href=\"{{url}}\">contact this prison directly</a> to book visits."
+    "noDigitalService": "You need to <link>contact this prison directly</link> to book visits."
   }
 }

--- a/server/locales/en/shared.json
+++ b/server/locales/en/shared.json
@@ -3,18 +3,18 @@
     "title": "How to change your visit",
 
     "contactPrisonPhone": "To update your visit, call {{prisonName}} on {{phoneNumber}}.",
-    "contactPrisonWebsite": "To update your visit, <a href=\"{{url}}\">contact {{prisonName}} directly</a>.",
+    "contactPrisonWebsite": "To update your visit, <link>contact {{prisonName}} directly</link>.",
 
     "visitReference": "You will need the visit reference to make changes. Your visit reference is {{ visitReference }}.",
 
-    "cancelVisit": "Or you can cancel your visit from <a href=\"{{url}}\">the visits page</a>."
+    "cancelVisit": "Or you can cancel your visit from <link>the visits page</link>."
   },
 
   "howToUpdateRequest": {
     "title": "How to update your request",
 
     "contactPrisonPhone": "To update your request, call {{prisonName}} on {{phoneNumber}}.",
-    "contactPrisonWebsite": "To update your request, <a href=\"{{url}}\">contact {{prisonName}} directly</a>.",
+    "contactPrisonWebsite": "To update your request, <link>contact {{prisonName}} directly</link>.",
 
     "visitReference": "You will need the visit reference to make changes. Your request reference is {{ visitReference }}."
   },
@@ -22,15 +22,15 @@
   "visitingInfo": {
     "title": "Prepare for visiting {{prisonName}}",
 
-    "acceptableId": "All visitors over 16 years old must show <a href=\"{{url}}\">acceptable forms of ID to enter the prison</a>.",
+    "acceptableId": "All visitors over 16 years old must show <link>acceptable forms of ID to enter the prison</link>.",
     "arriveEarly": "Visitors should arrive 45 minutes before the visit starts.",
-    "moreVisitsInfo": "You can read more about <a href=\"{{url}}\">visits at {{prisonName}}</a>. This includes information on getting to the prison and visiting facilities.",
+    "moreVisitsInfo": "You can read more about <link>visits at {{prisonName}}</link>. This includes information on getting to the prison and visiting facilities.",
 
     "expectationsHeading": "What to expect when visiting a prison",
     "search1": "Visitors will be searched before entering the prison visiting room.",
     "search2": "Prison staff may check visitors’ pockets, pat them down and ask them to go through a metal detector. Dogs may also be used to detect illegal substances.",
 
     "helpWithCostHeading": "Help with the cost of prison visits",
-    "helpWithCostDetails": "You may be able to <a href=\"{{url}}\">get help with the cost of prison visits</a> if you’re getting certain benefits or have a health certificate."
+    "helpWithCostDetails": "You may be able to <link>get help with the cost of prison visits</link> if you’re getting certain benefits or have a health certificate."
   }
 }

--- a/server/locales/en/shared.json
+++ b/server/locales/en/shared.json
@@ -5,7 +5,7 @@
     "contactPrisonPhone": "To update your visit, call {{prisonName}} on {{phoneNumber}}.",
     "contactPrisonWebsite": "To update your visit, <link>contact {{prisonName}} directly</link>.",
 
-    "visitReference": "You will need the visit reference to make changes. Your visit reference is {{ visitReference }}.",
+    "visitReference": "You will need the visit reference to make changes. Your visit reference is {{visitReference}}.",
 
     "cancelVisit": "Or you can cancel your visit from <link>the visits page</link>."
   },
@@ -16,7 +16,7 @@
     "contactPrisonPhone": "To update your request, call {{prisonName}} on {{phoneNumber}}.",
     "contactPrisonWebsite": "To update your request, <link>contact {{prisonName}} directly</link>.",
 
-    "visitReference": "You will need the visit reference to make changes. Your request reference is {{ visitReference }}."
+    "visitReference": "You will need the visit reference to make changes. Your request reference is {{visitReference}}."
   },
 
   "visitingInfo": {

--- a/server/locales/en/staticPages.json
+++ b/server/locales/en/staticPages.json
@@ -4,11 +4,11 @@
     "applies": "This accessibility statement applies to https://prison-visits.service.justice.gov.uk.",
     "runBy": "This website is run by HM Prison and Probation Service (HMPPS).",
     "wantManyPeople": "We want as many people as possible to be able to use this website. We will make improvements to accessibility as we find issues.",
-    "abilityNet": "<a href=\"{{url}}\">AbilityNet</a> has advice on making your device easier to use if you have a disability.",
+    "abilityNet": "<link>AbilityNet</link> has advice on making your device easier to use if you have a disability.",
 
     "complianceHeading": "Compliance Status",
-    "wcagCompliance": "This website is fully compliant with the <a href=\"{{url}}\">Web Content Accessibility Guidelines version 2.2 AA standard</a>.",
-    "testedBy": "It was last tested by <a href=\"{{url}}\">User Vision</a> in October 2024 against the WCAG 2.2 AA standard.",
+    "wcagCompliance": "This website is fully compliant with the <link>Web Content Accessibility Guidelines version 2.2 AA standard</link>.",
+    "testedBy": "It was last tested by <link>User Vision</link> in October 2024 against the WCAG 2.2 AA standard.",
     "testedUsing": "User Vision assessed pages using the following assistive technology:",
     "assistiveTech": {
       "nvda": "NVDA (using Edge, Chrome and Firefox browsers)",
@@ -20,10 +20,10 @@
     "issuesFix": "This testing identified 3 non-compliance issues. These issues were fixed on 24 June 2025. They were tested to check compliance with the WCAG 2.2 AA standard by our website team.",
 
     "feedbackHeading": "Feedback",
-    "sendFeedback": "If you find any problems or think we’re not meeting accessibility requirements, you can <a href=\"{{url}}\">send us feedback</a>.",
+    "sendFeedback": "If you find any problems or think we’re not meeting accessibility requirements, you can <link>send us feedback</link>.",
 
     "enforcementHeading": "Enforcement procedure",
-    "enforcement": "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href=\"{{url}}\">contact the Equality Advisory and Support Service (EASS)</a>.",
+    "enforcement": "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <link>contact the Equality Advisory and Support Service (EASS)</link>.",
 
     "technicalHeading": "Technical information about this website’s accessibility",
     "technical": "HMPPS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.",
@@ -34,7 +34,7 @@
 
   "cookies": {
     "title": "Cookies",
-    "policyAppliesTo": "This cookies policy only covers ‘Visit someone in prison’. Read the main <a href=\"https://www.gov.uk/help/cookies\">GOV.UK cookies policy</a> to find out about cookies that are used on GOV.UK.",
+    "policyAppliesTo": "This cookies policy only covers ‘Visit someone in prison’. Read the main <link>GOV.UK cookies policy</link> to find out about cookies that are used on GOV.UK.",
     "whatAreCookies": "Cookies are files saved on your phone, tablet or computer when you visit a website. We use cookies to make ‘Visit someone in prison’ work.",
     "mayUseAnalytics": "We may also use analytics cookies to learn about how you use ‘Visit someone in prison’ and help us improve it. We’ll ask for your permission before we do this.",
     "notUsedToIdentify": "Cookies are not used to identify you personally.",
@@ -70,15 +70,15 @@
     "title": "Sorry, the service is unavailable",
     "availableFrom": "You will be able to use the service from {{time}} on {{date}}.",
     "availableLater": "You will be able to use the service later.",
-    "notSaved": "We have not saved your answers. When the service is available you will need to <a href=\"{{url}}\">start again</a>."
+    "notSaved": "We have not saved your answers. When the service is available you will need to <link>start again</link>."
   },
 
   "privacy": {
     "title": "Privacy notice",
-    "intro": "The ‘Visit someone in prison’ service is managed by HM Prison and Probation Service (HMPPS), an executive agency of the Ministry of Justice (MOJ). Our <a href=\"{{url}}\">personal information charter</a> explains your rights and how we deal with your personal information.",
+    "intro": "The ‘Visit someone in prison’ service is managed by HM Prison and Probation Service (HMPPS), an executive agency of the Ministry of Justice (MOJ). Our <link>personal information charter</link> explains your rights and how we deal with your personal information.",
     "dataController": "MOJ is the data controller for the personal information we hold.",
-    "dataControllerDetails": "A data controller determines how and why personal data is processed. For more information, read the Cabinet Office’s entry in the <a href=\"{{url}}\">Data Protection Public Register</a>.",
-    "oneLogin": "You need a GOV.UK One Login to use the service. Read the <a href=\"{{url}}\">full GOV.UK One Login privacy notice</a> to find out how it stores, processes and shares your personal information.",
+    "dataControllerDetails": "A data controller determines how and why personal data is processed. For more information, read the Cabinet Office’s entry in the <link>Data Protection Public Register</link>.",
+    "oneLogin": "You need a GOV.UK One Login to use the service. Read the <link>full GOV.UK One Login privacy notice</link> to find out how it stores, processes and shares your personal information.",
 
     "whatDataHeading": "What data we collect",
     "whatDataIntro": "The personal data we collect from you includes:",
@@ -94,7 +94,7 @@
       "personalInfo": "any personal information you include in questions, queries or feedback you leave"
     },
 
-    "analyticsData": "Information about how you use the site is collected in Google Analytics using cookies and page tagging techniques. It does not contain any personal data and is only collected if you <a href=\"{{url}}\">consent</a> to this. It is shared with the Government Digital Service.",
+    "analyticsData": "Information about how you use the site is collected in Google Analytics using cookies and page tagging techniques. It does not contain any personal data and is only collected if you <link>consent</link> to this. It is shared with the Government Digital Service.",
 
     "whyNeedHeading": "Why we need your data",
     "whyNeedIntro": "We collect your personal data to:",
@@ -123,11 +123,10 @@
     "sharedWithHeading": "Who the information may be shared with",
     "sharedWithIntro": "The data we collect may be shared with other government departments, agencies and public bodies. It may also be shared with our technology suppliers, for example our hosting provider.",
     "sharedWithOrgs": "The organisations we share personal information with are:",
-    "notifyOrg": "<a href=\"{{url}}\">GOV.UK Notify</a> to send texts and emails.",
-    "notifyPrivacy": "See their <a href=\"{{url}}\">privacy notice</a>.",
-    "formsOrg": "<a href=\"{{url}}\">GOV.UK Forms</a> to collect feedback.",
-    "formsPrivacy": "See their <a href=\"{{url}}\">privacy notice</a>.",
-
+    "notifyOrg": "<link>GOV.UK Notify</link> to send texts and emails.",
+    "notifyPrivacy": "See their <link>privacy notice</link>.",
+    "formsOrg": "<link>GOV.UK Forms</link> to collect feedback.",
+    "formsPrivacy": "See their <link>privacy notice</link>.",
     "analyticsTransfer": "The data we collect with Google Analytics cookies is transferred and stored with Google where we analyse it with Google Analytics software (Universal Analytics). We do not allow Google to use or share this data for their own purposes.",
     "agentsReps": "We may share your information with our agents or representatives, so they can manage your visits. Our agents or representatives will only use your personal data in line with what we have set out in this privacy notice.",
 
@@ -139,25 +138,24 @@
     "lawRequired": "We will share your data if we are required to do so by law - for example, by court order, or to prevent fraud or other crime.",
 
     "howLongHeading": "How long we keep data",
-    "howLong": "Data is retained for seven years in accordance with <a href=\"{{url}}\">HMPPS retention policy</a>.",
-
+    "howLong": "Data is retained for seven years in accordance with <link>HMPPS retention policy</link>.",
     "whereProcessedHeading": "Where your data is processed and stored",
     "whereProcessed": "We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored.",
-    "whereProcessedPersonal": "All personal data is stored in the <a href=\"{{url}}\">European Economic Area</a> (EEA). Data collected by Google Analytics may be transferred outside the EEA for processing.",
-    "usDataBridge": "Where data processing happens in the US, suppliers need to meet the certification standards set out in the <a href=\"{{url}}\">UK-US data bridge</a> agreement. This facilitates flows of personal data to certified US companies that have opted in to the EU-US Data Privacy Framework.",
+    "whereProcessedPersonal": "All personal data is stored in the <link>European Economic Area</link> (EEA). Data collected by Google Analytics may be transferred outside the EEA for processing.",
+    "usDataBridge": "Where data processing happens in the US, suppliers need to meet the certification standards set out in the <link>UK-US data bridge</link> agreement. This facilitates flows of personal data to certified US companies that have opted in to the EU-US Data Privacy Framework.",
 
     "howProtectHeading": "How we protect your data and keep it secure",
     "howProtect1": "We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.",
     "howProtect2": "We also make sure that any third parties that we deal with keep all personal data they process on our behalf secure.",
 
     "yourRightsHeading": "Your rights",
-    "yourRights": "Your rights are set out in the <a href=\"{{url}}\">Ministry of Justice personal information charter</a>.",
+    "yourRights": "Your rights are set out in the <link>Ministry of Justice personal information charter</link>.",
     "contactDPT": "For more information please contact the Data Protection Team.",
     "emailHeading": "Email",
     "postHeading": "Post",
 
     "accessHeading": "Access to personal information",
-    "access": "You can find out if we hold any personal data about you by making a ‘subject access request’. This process is set out in the <a href=\"{{url}}\">Ministry of Justice personal information charter</a>.",
+    "access": "You can find out if we hold any personal data about you by making a ‘subject access request’. This process is set out in the <link>Ministry of Justice personal information charter</link>.",
 
     "complaintHeading": "Make a complaint",
     "complaint": "When we ask you for information, we will keep to the law. If you think that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection.",
@@ -176,7 +174,7 @@
 
   "signedOut": {
     "title": "You have signed out",
-    "signInAgain": "You can book a visit or view your visits by <a href=\"{{url}}\">signing into the service using GOV.UK One Login</a>."
+    "signInAgain": "You can book a visit or view your visits by <link>signing into the service using GOV.UK One Login</link>."
   },
 
   "terms": {

--- a/server/locales/en/validation.json
+++ b/server/locales/en/validation.json
@@ -18,10 +18,13 @@
   "prisonSelectRequired": "Select a prison",
   "supportDetailsLength": "Please enter at least 3 and no more than 200 characters",
   "supportDetailsRequired": "Enter details of the request",
-  "visitorsAdultsTooMany": "Select no more than $t(common:plurals.visitor, {\"count\": {{count}} }) $t(common:plurals.ageYears, {\"count\": {{age}} }) or older",
-  "visitorsChildrenTooMany": "Select no more than $t(common:plurals.visitor, {\"count\": {{count}} }) under $t(common:plurals.ageYears, {\"count\": {{age}} })",
+  "visitorsAdultsTooMany_one": "Select no more than {{count}} visitor {{age}} years old or older",
+  "visitorsAdultsTooMany_other": "Select no more than {{count}} visitors {{age}} years old or older",
+  "visitorsChildrenTooMany_one": "Select no more than {{count}} visitor under {{age}} years old",
+  "visitorsChildrenTooMany_other": "Select no more than {{count}} visitors under {{age}} years old",
   "visitorsNeedAdult": "Add a visitor who is 18 years old or older",
   "visitorsNoneSelected": "No visitors selected",
-  "visitorsTooMany": "Select no more than $t(common:plurals.visitor, {\"count\": {{count}} })",
+  "visitorsTooMany_one": "Select no more than {{count}} visitor",
+  "visitorsTooMany_other": "Select no more than {{count}} visitors",
   "visitTimeRequired": "No visit time selected"
 }

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -73,4 +73,17 @@ describe('Nunjucks Filters', () => {
       expect(result).toEqual(null)
     })
   })
+
+  describe('renderLinkTag', () => {
+    it('should render link token as an anchor and escape other html', () => {
+      const result = njk.getFilter('renderLinkTag')(
+        'Text <link>label</link> <script>alert(1)</script>',
+        'https://example.test?a=1&b=2',
+      )
+
+      expect(result).toEqual(
+        'Text <a href="https://example.test?a=1&amp;b=2">label</a> &lt;script&gt;alert(1)&lt;/script&gt;',
+      )
+    })
+  })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -12,6 +12,7 @@ import {
   formatTimeFromDateTime,
   getPrisonName,
   initialiseName,
+  renderLinkTag,
 } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
@@ -97,6 +98,8 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('initialiseName', initialiseName)
 
   njkEnv.addFilter('getPrisonName', getPrisonName)
+
+  njkEnv.addFilter('renderLinkTag', renderLinkTag)
 
   return njkEnv
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -221,6 +221,9 @@ describe('renderLinkTag', () => {
     ['null input', null, 'https://example.test', ''],
     ['undefined input', undefined, 'https://example.test', ''],
     ['no link tag', 'No link here', 'https://example.test', 'No link here'],
+    ['undefined link', 'undefined link', undefined, 'undefined link'],
+    ['null link', 'null link', null, 'null link'],
+    ['empty link', 'empty link', '', 'empty link'],
     [
       'single link tag',
       'Some text <link>link text</link> more text.',
@@ -251,7 +254,7 @@ describe('renderLinkTag', () => {
       'https://example.test',
       'Some text &lt;/link&gt;wrong order&lt;link&gt;',
     ],
-  ])('%s', (_: string, text: string | undefined | null, url: string, expected: string) => {
+  ])('%s', (_: string, text: string | undefined | null, url: string | undefined | null, expected: string) => {
     expect(renderLinkTag(text, url)).toBe(expected)
   })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -4,6 +4,7 @@ import {
   clearSession,
   convertToTitleCase,
   displayAge,
+  escapeHtml,
   formatDate,
   formatTime,
   formatTimeDuration,
@@ -13,6 +14,7 @@ import {
   initialiseName,
   isAdult,
   isMobilePhoneNumber,
+  renderLinkTag,
 } from './utils'
 import TestData from '../routes/testutils/testData'
 import { Visitor } from '../services/bookerService'
@@ -200,5 +202,62 @@ describe('getPrisonName', () => {
     ['returns prison ID if prison is not found', 'C', prisonNames, 'en', 'C'],
   ] as const)('%s', (_: string, prisonId: string, names: PrisonNames, lng: Locale, expected: string) => {
     expect(getPrisonName(prisonId, names, lng)).toBe(expected)
+  })
+})
+
+describe('escapeHtml', () => {
+  it('should escape HTML characters', () => {
+    expect(escapeHtml('Escape <this> & "that" !')).toBe('Escape &lt;this&gt; &amp; &quot;that&quot; !')
+  })
+
+  it('should handle undefined and null', () => {
+    expect(escapeHtml(null)).toBe('')
+    expect(escapeHtml(undefined)).toBe('')
+  })
+})
+
+describe('renderLinkTag', () => {
+  it.each([
+    ['null input', null, 'https://example.test', ''],
+    ['undefined input', undefined, 'https://example.test', ''],
+    ['no link tag', 'No link here', 'https://example.test', 'No link here'],
+    [
+      'single link tag',
+      'Some text <link>link text</link> more text.',
+      'https://example.test',
+      'Some text <a href="https://example.test">link text</a> more text.',
+    ],
+    [
+      'multiple link tags (only first is rendered)',
+      'Start <link>one</link> middle <link>two</link> end',
+      'https://example.test',
+      'Start <a href="https://example.test">one</a> middle &lt;link&gt;two&lt;/link&gt; end',
+    ],
+    [
+      'escapes non-link html and attributes',
+      'Before <script>alert("x")</script> <link>Click <b>here</b></link> after',
+      'https://example.test?a=1&b=2',
+      'Before &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; <a href="https://example.test?a=1&amp;b=2">Click &lt;b&gt;here&lt;/b&gt;</a> after',
+    ],
+    [
+      'returns escaped text for open tag only',
+      'Some text <link>missing close',
+      'https://example.test',
+      'Some text &lt;link&gt;missing close',
+    ],
+    [
+      'returns escaped text for wrongly ordered tags',
+      'Some text </link>wrong order<link>',
+      'https://example.test',
+      'Some text &lt;/link&gt;wrong order&lt;link&gt;',
+    ],
+  ])('%s', (_: string, text: string | undefined | null, url: string, expected: string) => {
+    expect(renderLinkTag(text, url)).toBe(expected)
+  })
+
+  it('supports optional new-tab behavior with rel attributes', () => {
+    expect(renderLinkTag('Read <link>more</link>.', 'https://example.test', true)).toBe(
+      'Read <a href="https://example.test" target="_blank" rel="noreferrer noopener">more</a>.',
+    )
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,10 +1,13 @@
 import { Request } from 'express'
 import { differenceInYears, format, formatDuration, intervalToDuration, isAfter, parse, parseISO } from 'date-fns'
 import { parsePhoneNumberFromString as parsePhoneNumber } from 'libphonenumber-js/mobile'
+import nunjucks from 'nunjucks'
 import type { TFunction } from 'i18next'
 import type { Visitor } from '../services/bookerService'
 import { PrisonNames } from '../services/prisonService'
 import { DATE_FNS_LOCALE, Locale } from '../constants/locales'
+
+const nunjucksEnvironment = new nunjucks.Environment()
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -115,4 +118,26 @@ export const getPrisonName = (prisonId: string, prisonNames: PrisonNames, lng: L
   }
 
   return prison.name?.[lng] ?? prison.name.en
+}
+
+export const escapeHtml = (value: string | undefined | null): string => {
+  const escape = nunjucksEnvironment.getFilter('escape')
+  return escape(value).val
+}
+
+export const renderLinkTag = (text: string | undefined | null, url: string, openInNewTab = false): string => {
+  if (!text) return ''
+
+  const match = text.match(/<link>(.*?)<\/link>/s)
+  if (!match || match.index === undefined) return escapeHtml(text)
+
+  const escapedUrl = escapeHtml(url)
+  const targetAttribute = openInNewTab ? ' target="_blank"' : ''
+  const relAttribute = openInNewTab ? ' rel="noreferrer noopener"' : ''
+  const fullMatch = match[0]
+  const linkText = match[1]
+  const before = escapeHtml(text.slice(0, match.index))
+  const after = escapeHtml(text.slice(match.index + fullMatch.length))
+
+  return `${before}<a href="${escapedUrl}"${targetAttribute}${relAttribute}>${escapeHtml(linkText)}</a>${after}`
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -122,14 +122,18 @@ export const getPrisonName = (prisonId: string, prisonNames: PrisonNames, lng: L
 
 export const escapeHtml = (value: string | undefined | null): string => {
   const escape = nunjucksEnvironment.getFilter('escape')
-  return escape(value).val
+  return String(escape(value))
 }
 
-export const renderLinkTag = (text: string | undefined | null, url: string, openInNewTab = false): string => {
+export const renderLinkTag = (
+  text: string | undefined | null,
+  url: string | undefined | null,
+  openInNewTab = false,
+): string => {
   if (!text) return ''
 
   const match = text.match(/<link>(.*?)<\/link>/s)
-  if (!match || match.index === undefined) return escapeHtml(text)
+  if (!url || !match || match.index === undefined) return escapeHtml(text)
 
   const escapedUrl = escapeHtml(url)
   const targetAttribute = openInNewTab ? ' target="_blank"' : ''

--- a/server/views/authError.njk
+++ b/server/views/authError.njk
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
       <p>
-        {{- t("errors:authError.tryAgain", { url: paths.SIGN_IN }) | safe -}}
+        {{- t("errors:authError.tryAgain") | renderLinkTag(paths.SIGN_IN) | safe -}}
       </p>
 
     </div>

--- a/server/views/pages/addPrisoner/prisonerLocation.njk
+++ b/server/views/pages/addPrisoner/prisonerLocation.njk
@@ -40,14 +40,14 @@
         }) }}
 
         <p>
-          {{- t("addPrisoner:prisonerLocation.findPrisonerLink", { url: "https://www.gov.uk/find-prisoner" }) | safe -}}
+          {{- t("addPrisoner:prisonerLocation.findPrisonerLink") | renderLinkTag("https://www.gov.uk/find-prisoner") | safe -}}
         </p>
 
         {{ govukButton({
           text: t("common:buttons.continue"),
           attributes: { "data-test": "continue-button" },
           preventDoubleClick: true
-        }) }} 
+        }) }}
       </form>
     </div>
   </div>

--- a/server/views/pages/addPrisoner/prisonerNotMatched.njk
+++ b/server/views/pages/addPrisoner/prisonerNotMatched.njk
@@ -22,7 +22,7 @@
       </ul>
 
       <p data-test="check-details">
-        {{- t("addPrisoner:prisonerNotMatched.checkDetails", { url: paths.ADD_PRISONER.DETAILS }) | safe -}}
+        {{- t("addPrisoner:prisonerNotMatched.checkDetails") | renderLinkTag(paths.ADD_PRISONER.DETAILS) | safe -}}
       </p>
 
       <p>{{ t("addPrisoner:prisonerNotMatched.contact") }}</p>

--- a/server/views/pages/addVisitor/addVisitorStart.njk
+++ b/server/views/pages/addVisitor/addVisitorStart.njk
@@ -13,9 +13,9 @@
       <p class="govuk-body-l">{{ t("addVisitor:addVisitorStart.identityRequirement") }}</p>
 
       <p>
-        {{- t("addVisitor:addVisitorStart.acceptableId", {
-          url: "https://www.gov.uk/government/publications/management-of-security-at-visits-policy-framework-open-estate/acceptable-forms-of-identification-id-when-visiting-a-prison-in-england-and-wales-annex-a"
-        }) | safe -}}
+        {{- t("addVisitor:addVisitorStart.acceptableId")
+          | renderLinkTag("https://www.gov.uk/government/publications/management-of-security-at-visits-policy-framework-open-estate/acceptable-forms-of-identification-id-when-visiting-a-prison-in-england-and-wales-annex-a")
+          | safe -}}
       </p>
 
       <p>{{ t("addVisitor:addVisitorStart.visitorList") }}</p>
@@ -27,7 +27,7 @@
         href: paths.ADD_VISITOR.DETAILS,
         attributes: { "data-test": "continue-button" },
         preventDoubleClick: true
-      }) }} 
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/server/views/pages/addVisitor/checkVisitorDetails.njk
+++ b/server/views/pages/addVisitor/checkVisitorDetails.njk
@@ -79,9 +79,9 @@
       <p>{{ t("addVisitor:checkVisitorDetails.confirmInformation") }}</p>
 
       <p>
-        {{- t("addVisitor:checkVisitorDetails.acceptableId", {
-          url: "https://www.gov.uk/government/publications/management-of-security-at-visits-policy-framework-open-estate/acceptable-forms-of-identification-id-when-visiting-a-prison-in-england-and-wales-annex-a"
-        }) | safe -}}
+        {{- t("addVisitor:checkVisitorDetails.acceptableId")
+          | renderLinkTag("https://www.gov.uk/government/publications/management-of-security-at-visits-policy-framework-open-estate/acceptable-forms-of-identification-id-when-visiting-a-prison-in-england-and-wales-annex-a")
+          | safe -}}
       </p>
 
       <form action="{{ paths.ADD_VISITOR.CHECK }}" method="POST" novalidate>

--- a/server/views/pages/addVisitor/visitorRequestFailTooManyRequests.njk
+++ b/server/views/pages/addVisitor/visitorRequestFailTooManyRequests.njk
@@ -9,13 +9,13 @@
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
       <p>{{ t("addVisitor:visitorRequestFailTooManyRequests.limitReached") }}</p>
-      
+
       <p>{{ t("addVisitor:visitorRequestFailTooManyRequests.cannotMakeAnotherRequest") }}</p>
 
       <p class="no-visited-state">
-        {{- t("addVisitor:visitorRequestFailTooManyRequests.viewLinkedAndRequestedVisitors", {
-          url: paths.VISITORS
-        }) | safe -}}
+        {{- t("addVisitor:visitorRequestFailTooManyRequests.viewLinkedAndRequestedVisitors")
+          | renderLinkTag(paths.VISITORS)
+          | safe -}}
       </p>
 
     </div>

--- a/server/views/pages/addVisitor/visitorRequested.njk
+++ b/server/views/pages/addVisitor/visitorRequested.njk
@@ -16,9 +16,9 @@
       <p>{{ t("addVisitor:visitorRequested.approvedOrRejected") }}</p>
 
       <p>
-        {{- t("addVisitor:visitorRequested.statusOnVisitorsPage", {
-          url: paths.VISITORS
-        }) | safe -}}
+        {{- t("addVisitor:visitorRequested.statusOnVisitorsPage")
+          | renderLinkTag(paths.VISITORS)
+          | safe -}}
       </p>
 
       {{ govukButton({

--- a/server/views/pages/bookVisit/cannotBook.njk
+++ b/server/views/pages/bookVisit/cannotBook.njk
@@ -31,13 +31,13 @@
         </p>
 
         <p>
-          {{- t("bookVisit:cannotBook.findHowToBook", {
-            url: "https://www.gov.uk/government/collections/prisons-in-england-and-wales"
-          }) | safe -}}
+          {{- t("bookVisit:cannotBook.findHowToBook")
+            | renderLinkTag("https://www.gov.uk/government/collections/prisons-in-england-and-wales")
+            | safe -}}
         </p>
-      
+
         <p>
-          {{- t("bookVisit:cannotBook.findPrisoner", { url: "https://www.gov.uk/find-prisoner" }) | safe -}}
+          {{- t("bookVisit:cannotBook.findPrisoner") | renderLinkTag("https://www.gov.uk/find-prisoner") | safe -}}
         </p>
       {% endif %}
 
@@ -50,9 +50,9 @@
         </p>
 
         <p>
-          {{- t("bookVisit:cannotBook.bookAtThisPrison", {
-            url: "https://www.gov.uk/government/collections/prisons-in-england-and-wales"
-          }) | safe -}}
+          {{- t("bookVisit:cannotBook.bookAtThisPrison")
+            | renderLinkTag("https://www.gov.uk/government/collections/prisons-in-england-and-wales")
+            | safe -}}
         </p>
       {% endif %}
 
@@ -63,7 +63,7 @@
         <p>{{ t("bookVisit:cannotBook.addNewVisitorDescription") }}</p>
 
         <p>
-          {{- t("bookVisit:cannotBook.addNewVisitorRequest", { url: paths.ADD_VISITOR.START }) | safe -}}
+          {{- t("bookVisit:cannotBook.addNewVisitorRequest") | renderLinkTag(paths.ADD_VISITOR.START) | safe -}}
         </p>
       {% endif %}
     </div>

--- a/server/views/pages/bookVisit/chooseVisitTimeNoSessions.njk
+++ b/server/views/pages/bookVisit/chooseVisitTimeNoSessions.njk
@@ -17,7 +17,7 @@
       <p>{{ t("bookVisit:chooseVisitTimeNoSessions.tryLater") }}</p>
 
       <p data-test="contact-prison">
-        {{- t("bookVisit:chooseVisitTimeNoSessions.contactPrison", { url: prison.webAddress }) | safe -}}
+        {{- t("bookVisit:chooseVisitTimeNoSessions.contactPrison") | renderLinkTag(prison.webAddress) | safe -}}
       </p>
     </div>
   </div>

--- a/server/views/pages/bookVisit/selectVisitors.njk
+++ b/server/views/pages/bookVisit/selectVisitors.njk
@@ -55,20 +55,20 @@
 
         <p data-test="max-visitors">
           {{- t("bookVisit:selectVisitors.visitorLimits.maxVisitors", {
-            maxVisitors: prison.maxTotalVisitors,
+            count: prison.maxTotalVisitors,
             prisonName: prison.code | getPrisonName(prisonNames, language)
           }) -}}
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li data-test="max-adults">
             {{- t("bookVisit:selectVisitors.visitorLimits.maxAdults", {
-              maxAdultVisitors: prison.maxAdultVisitors,
+              count: prison.maxAdultVisitors,
               adultAgeYears: prison.adultAgeYears
             }) -}}
           </li>
           <li data-test="max-children">
             {{- t("bookVisit:selectVisitors.visitorLimits.maxChildren", {
-              maxChildVisitors: prison.maxChildVisitors,
+              count: prison.maxChildVisitors,
               adultAgeYears: prison.adultAgeYears
             }) -}}
           </li>
@@ -104,11 +104,11 @@
 
             {% set visitorList = (visitorList.push({
               value: visitor.visitorDisplayId,
-              text: visitorNameAge 
+              text: visitorNameAge
             }), visitorList) %}
           {% endif%}
         {% endfor %}
-  
+
         <form action="{{ paths.BOOK_VISIT.SELECT_VISITORS }}" method="POST" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
@@ -189,7 +189,7 @@
           href: paths.ADD_VISITOR.START,
           attributes: { "data-test": "link-a-visitor" },
           preventDoubleClick: true
-        }) }} 
+        }) }}
       {% endif %}
 
     </div>

--- a/server/views/pages/bookVisit/visitBooked.njk
+++ b/server/views/pages/bookVisit/visitBooked.njk
@@ -31,13 +31,13 @@
       {% endif %}
 
       <p class="no-visited-state">
-        {{- t("common:postBooking.checkVisitDetails", { url: paths.VISITS.HOME }) | safe -}}
+        {{- t("common:postBooking.checkVisitDetails") | renderLinkTag(paths.VISITS.HOME) | safe -}}
       </p>
 
       <p>
-        {{- t("common:postBooking.feedback", {
-          url: "https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/"
-        }) | safe -}}
+        {{- t("common:postBooking.feedback")
+          | renderLinkTag("https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/")
+          | safe -}}
       </p>
 
       <div data-test="prison-specific-content">

--- a/server/views/pages/bookVisit/visitRequested.njk
+++ b/server/views/pages/bookVisit/visitRequested.njk
@@ -53,9 +53,9 @@
       {% if responseMessage %}
         <p data-test="response-message">{{ responseMessage }}</p>
       {% endif %}
-      
+
       <p class="no-visited-state">
-        {{- t("bookVisit:visitRequested.upcomingVisitsStatus", { url: paths.VISITS.HOME }) | safe -}}
+        {{- t("bookVisit:visitRequested.upcomingVisitsStatus") | renderLinkTag(paths.VISITS.HOME) | safe -}}
       </p>
 
     </div>

--- a/server/views/pages/cookies/cookies.njk
+++ b/server/views/pages/cookies/cookies.njk
@@ -12,7 +12,7 @@
       {% include "partials/errorSummary.njk" %}
 
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
-      <p>{{ t("staticPages:cookies.policyAppliesTo") | safe }}</p>
+  <p>{{ t("staticPages:cookies.policyAppliesTo") | renderLinkTag("https://www.gov.uk/help/cookies") | safe }}</p>
       <p>{{ t("staticPages:cookies.whatAreCookies") }}</p>
       <p>{{ t("staticPages:cookies.mayUseAnalytics") }}</p>
       <p>{{ t("staticPages:cookies.notUsedToIdentify") }}</p>

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -9,7 +9,7 @@
   {% if production %}
     <p>{{ t("errors:error.logged") }}</p>
     <p class="no-visited-state">
-      {{- t("errors:error.tryReload", { url: paths.VISITS.HOME }) | safe -}}
+      {{- t("errors:error.tryReload") | renderLinkTag(paths.VISITS.HOME) | safe -}}
     </p>
     <p>
       <a href="https://www.gov.uk/government/collections/prisons-in-england-and-wales">

--- a/server/views/pages/maintenancePage.njk
+++ b/server/views/pages/maintenancePage.njk
@@ -11,7 +11,7 @@
       <p data-test="maintenance-message">{{ maintenanceMessage }}</p>
 
       <p>
-        {{- t("staticPages:maintenance.notSaved", { url: paths.GOVUK_START_PAGE }) | safe -}}
+        {{- t("staticPages:maintenance.notSaved") | renderLinkTag(paths.GOVUK_START_PAGE) | safe -}}
       </p>
 
       <p>

--- a/server/views/pages/selectPrison/selectPrison.njk
+++ b/server/views/pages/selectPrison/selectPrison.njk
@@ -43,15 +43,13 @@
           text: t("common:buttons.continue"),
           attributes: { "data-test": "continue-button" },
           preventDoubleClick: true
-        }) }} 
+        }) }}
 
       </form>
 
       <h2 class="govuk-heading-m">{{ t("selectPrison:selectPrison.unknownLocationHeading") }}</h2>
       <p>
-        {{- t("selectPrison:selectPrison.findPrisonerLink", {
-          url: "https://www.gov.uk/find-prisoner"
-        }) | safe -}}
+        {{- t("selectPrison:selectPrison.findPrisonerLink") | renderLinkTag("https://www.gov.uk/find-prisoner") | safe -}}
       </p>
     </div>
   </div>

--- a/server/views/pages/selectPrison/selectedPrison.njk
+++ b/server/views/pages/selectPrison/selectedPrison.njk
@@ -10,9 +10,10 @@
 
 {% set insetText -%}
   {{- t("selectPrison:selectedPrison.onlyOnePrisoner", {
-    prisonName: prisonId | getPrisonName(prisonNames, language),
-    url: "https://www.gov.uk/government/collections/prisons-in-england-and-wales"
-  }) | safe -}}
+    prisonName: prisonId | getPrisonName(prisonNames, language)
+  })
+    | renderLinkTag("https://www.gov.uk/government/collections/prisons-in-england-and-wales")
+    | safe -}}
 {%- endset %}
 
 {% block content %}
@@ -39,9 +40,9 @@
         }) }}
       {% else %}
         <p data-test="no-digital-service">
-          {{ t("selectPrison:selectedPrison.noDigitalService", {
-            url: "https://www.gov.uk/government/collections/prisons-in-england-and-wales"
-          }) | safe -}}
+          {{ t("selectPrison:selectedPrison.noDigitalService")
+            | renderLinkTag("https://www.gov.uk/government/collections/prisons-in-england-and-wales")
+            | safe -}}
         </p>
       {% endif %}
     </div>

--- a/server/views/pages/staticPages/accessibilityStatement.njk
+++ b/server/views/pages/staticPages/accessibilityStatement.njk
@@ -13,22 +13,22 @@
       <p>{{ t("staticPages:accessibility.runBy") }}</p>
 
       <p>{{ t("staticPages:accessibility.wantManyPeople") }}</p>
-      
+
       <p>
-        {{- t("staticPages:accessibility.abilityNet", {
-          url: "https://mcmw.abilitynet.org.uk/"
-        }) | safe -}}
+        {{- t("staticPages:accessibility.abilityNet")
+          | renderLinkTag("https://mcmw.abilitynet.org.uk/")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:accessibility.complianceHeading") }}</h2>
 
-      <p>{{- t("staticPages:accessibility.wcagCompliance", {
-          url: "https://www.w3.org/TR/WCAG22/"
-        }) | safe -}}</p>
+      <p>{{- t("staticPages:accessibility.wcagCompliance")
+          | renderLinkTag("https://www.w3.org/TR/WCAG22/")
+          | safe -}}</p>
 
-      <p>{{- t("staticPages:accessibility.testedBy", {
-          url: "https://uservision.co.uk/"
-        }) | safe -}}</p>
+      <p>{{- t("staticPages:accessibility.testedBy")
+          | renderLinkTag("https://uservision.co.uk/")
+          | safe -}}</p>
 
       <p>{{ t("staticPages:accessibility.testedUsing") }}</p>
 
@@ -45,17 +45,17 @@
       <h2 class="govuk-heading-m">{{ t("staticPages:accessibility.feedbackHeading") }}</h2>
 
       <p>
-        {{- t("staticPages:accessibility.sendFeedback", {
-          url: "https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/"
-        }) | safe -}}
+        {{- t("staticPages:accessibility.sendFeedback")
+          | renderLinkTag("https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:accessibility.enforcementHeading") }}</h2>
 
       <p>
-        {{- t("staticPages:accessibility.enforcement", {
-          url: "https://www.equalityadvisoryservice.com/"
-        }) | safe -}}
+        {{- t("staticPages:accessibility.enforcement")
+          | renderLinkTag("https://www.equalityadvisoryservice.com/")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:accessibility.technicalHeading") }}</h2>

--- a/server/views/pages/staticPages/privacyNotice.njk
+++ b/server/views/pages/staticPages/privacyNotice.njk
@@ -9,23 +9,23 @@
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
       <p>
-        {{- t("staticPages:privacy.intro", {
-          url: "https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter"
-        }) | safe -}}
+        {{- t("staticPages:privacy.intro")
+          | renderLinkTag("https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter")
+          | safe -}}
       </p>
 
       <p>{{ t("staticPages:privacy.dataController") }}</p>
 
       <p>
-        {{- t("staticPages:privacy.dataControllerDetails", {
-          url: "https://ico.org.uk/ESDWebPages/Entry/Z7414053"
-        }) | safe -}}
+        {{- t("staticPages:privacy.dataControllerDetails")
+          | renderLinkTag("https://ico.org.uk/ESDWebPages/Entry/Z7414053")
+          | safe -}}
       </p>
 
       <p>
-        {{- t("staticPages:privacy.oneLogin", {
-          url: "https://signin.account.gov.uk/privacy-notice"
-        }) | safe -}}
+        {{- t("staticPages:privacy.oneLogin")
+          | renderLinkTag("https://signin.account.gov.uk/privacy-notice")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.whatDataHeading") }}</h2>
@@ -46,7 +46,7 @@
       </ul>
 
       <p>
-        {{- t("staticPages:privacy.analyticsData", { url: paths.COOKIES }) | safe -}}
+        {{- t("staticPages:privacy.analyticsData") | renderLinkTag(paths.COOKIES) | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.whyNeedHeading") }}</h2>
@@ -87,20 +87,12 @@
 
       <ul class="govuk-list govuk-list--bullet">
           <li>
-            {{ t("staticPages:privacy.notifyOrg", {
-              url: "https://www.notifications.service.gov.uk/"
-            }) | safe }}
-            {{ t("staticPages:privacy.notifyPrivacy", {
-              url: "https://www.notifications.service.gov.uk/privacy"
-            }) | safe }}
+            {{ t("staticPages:privacy.notifyOrg") | renderLinkTag("https://www.notifications.service.gov.uk/") | safe }}
+            {{ t("staticPages:privacy.notifyPrivacy") | renderLinkTag("https://www.notifications.service.gov.uk/privacy") | safe }}
           </li>
           <li>
-            {{ t("staticPages:privacy.formsOrg", {
-              url: "https://www.forms.service.gov.uk/"
-            }) | safe }}
-             {{ t("staticPages:privacy.formsPrivacy", {
-              url: "https://www.forms.service.gov.uk/privacy"
-            }) | safe }}
+            {{ t("staticPages:privacy.formsOrg") | renderLinkTag("https://www.forms.service.gov.uk/") | safe }}
+             {{ t("staticPages:privacy.formsPrivacy") | renderLinkTag("https://www.forms.service.gov.uk/privacy") | safe }}
           </li>
       </ul>
 
@@ -120,9 +112,9 @@
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.howLongHeading") }}</h2>
 
       <p>
-        {{- t("staticPages:privacy.howLong", {
-          url: "https://www.gov.uk/government/publications/records-information-management-policy-psi-042018-pi-022018"
-        }) | safe -}}
+        {{- t("staticPages:privacy.howLong")
+          | renderLinkTag("https://www.gov.uk/government/publications/records-information-management-policy-psi-042018-pi-022018")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.whereProcessedHeading") }}</h2>
@@ -130,15 +122,15 @@
       <p>{{ t("staticPages:privacy.whereProcessed") }}</p>
 
       <p>
-        {{- t("staticPages:privacy.whereProcessedPersonal", {
-          url: "https://www.gov.uk/eu-eea"
-        }) | safe -}}
+        {{- t("staticPages:privacy.whereProcessedPersonal")
+          | renderLinkTag("https://www.gov.uk/eu-eea")
+          | safe -}}
       </p>
 
       <p>
-        {{- t("staticPages:privacy.usDataBridge", {
-          url: "https://www.gov.uk/government/publications/uk-us-data-bridge-supporting-documents/uk-us-data-bridge-explainer"
-        }) | safe -}}
+        {{- t("staticPages:privacy.usDataBridge")
+          | renderLinkTag("https://www.gov.uk/government/publications/uk-us-data-bridge-supporting-documents/uk-us-data-bridge-explainer")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.howProtectHeading") }}</h2>
@@ -150,11 +142,11 @@
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.yourRightsHeading") }}</h2>
 
       <p>
-        {{- t("staticPages:privacy.yourRights", {
-          url: "https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter"
-        }) | safe -}}
+        {{- t("staticPages:privacy.yourRights")
+          | renderLinkTag("https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter")
+          | safe -}}
       </p>
-      
+
       <p>{{ t("staticPages:privacy.contactDPT") }}</p>
 
       <h3 class="govuk-heading-s">{{ t("staticPages:privacy.emailHeading") }}</h3>
@@ -175,9 +167,9 @@
       <h3 class="govuk-heading-s">{{ t("staticPages:privacy.accessHeading") }}</h3>
 
       <p>
-        {{- t("staticPages:privacy.access", {
-          url: "https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter"
-        }) | safe -}}
+        {{- t("staticPages:privacy.access")
+          | renderLinkTag("https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter")
+          | safe -}}
       </p>
 
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.complaintHeading") }}</h2>
@@ -187,10 +179,10 @@
       <h3 class="govuk-heading-s">{{ t("staticPages:privacy.icoEmailHeading") }}</h3>
 
       <p><a href="mailto:icocasework@ico.org.uk">icocasework@ico.org.uk</a></p>
-      
+
       <h3 class="govuk-heading-s">{{ t("staticPages:privacy.icoPhoneHeading") }}</h3>
       <p>0303 123 1113</p>
-      
+
       <h3 class="govuk-heading-s">{{ t("staticPages:privacy.icoTextphoneHeading") }}</h3>
       <p>
         01625 545860<br>
@@ -212,11 +204,11 @@
       <h2 class="govuk-heading-m">{{ t("staticPages:privacy.changesHeading") }}</h2>
 
       <p>{{ t("staticPages:privacy.changes1") }}</p>
-      
+
       <p>{{ t("staticPages:privacy.changes2") }}</p>
 
       <p>{{ t("staticPages:privacy.lastUpdated") }}</p>
-      
+
     </div>
   </div>
 {% endblock %}

--- a/server/views/pages/staticPages/signedOut.njk
+++ b/server/views/pages/staticPages/signedOut.njk
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
 
       <p class="no-visited-state" data-test="sign-in">
-        {{- t("staticPages:signedOut.signInAgain", { url: paths.SIGN_IN }) | safe -}}
+        {{- t("staticPages:signedOut.signInAgain") | renderLinkTag(paths.SIGN_IN) | safe -}}
       </p>
 
     </div>

--- a/server/views/pages/visits/cancel/cancelConfirmed.njk
+++ b/server/views/pages/visits/cancel/cancelConfirmed.njk
@@ -31,13 +31,13 @@
       {% endif %}
 
       <p class="no-visited-state">
-        {{- t("common:postBooking.checkVisitDetails", { url: paths.VISITS.HOME }) | safe -}}
+        {{- t("common:postBooking.checkVisitDetails") | renderLinkTag(paths.VISITS.HOME) | safe -}}
       </p>
 
       <p>
-        {{- t("common:postBooking.feedback", {
-          url: "https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/"
-        }) | safe -}}
+        {{- t("common:postBooking.feedback")
+          | renderLinkTag("https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/")
+          | safe -}}
       </p>
 
     </div>

--- a/server/views/partials/cookieBanner.njk
+++ b/server/views/partials/cookieBanner.njk
@@ -20,14 +20,14 @@
 {% endset %}
 
 {{ govukCookieBanner({
-  ariaLabel: t("common:cookieBanner.cookiesOn"),
+  ariaLabel: t("common:cookieBanner.cookiesOn", { serviceName: t("common:applicationName") }),
   attributes: {
     id: "cookie-banner"
   },
   hidden: true,
   messages: [
     {
-      headingText: t("common:cookieBanner.cookiesOn"),
+      headingText: t("common:cookieBanner.cookiesOn", { serviceName: t("common:applicationName") }),
       attributes: {
         id: "cookie-banner-main"
       },

--- a/server/views/partials/cookieBanner.njk
+++ b/server/views/partials/cookieBanner.njk
@@ -8,14 +8,14 @@
 {% set acceptHtml %}
   <p class="no-visited-state">
     {{- t("common:cookieBanner.acceptedAnalytics") }}
-    {{ t("common:cookieBanner.changeSettings", { url: paths.COOKIES }) | safe }}
+    {{ t("common:cookieBanner.changeSettings") | renderLinkTag(paths.COOKIES) | safe }}
   </p>
 {% endset %}
 
 {% set rejectHtml %}
   <p class="no-visited-state">
     {{- t("common:cookieBanner.rejectedAnalytics") }}
-    {{ t("common:cookieBanner.changeSettings", { url: paths.COOKIES }) | safe }}
+    {{ t("common:cookieBanner.changeSettings") | renderLinkTag(paths.COOKIES) | safe }}
   </p>
 {% endset %}
 

--- a/server/views/partials/howToChangeVisit.njk
+++ b/server/views/partials/howToChangeVisit.njk
@@ -12,9 +12,8 @@
       }) -}}
     {% else %}
       {{- t("shared:howToChangeVisit.contactPrisonWebsite", {
-        prisonName: prison.code | getPrisonName(prisonNames, language),
-        url: prison.webAddress
-      }) | safe -}}
+        prisonName: prison.code | getPrisonName(prisonNames, language)
+      }) | renderLinkTag(prison.webAddress) | safe -}}
     {% endif -%}
   </p>
 
@@ -24,6 +23,6 @@
 
 {% if bookVisitConfirmed %}
   <p class="no-visited-state" data-test="cancel-visit-content">
-    {{- t("shared:howToChangeVisit.cancelVisit", { url: paths.VISITS.HOME }) | safe -}}
+    {{- t("shared:howToChangeVisit.cancelVisit") | renderLinkTag(paths.VISITS.HOME) | safe -}}
   </p>
 {% endif %}

--- a/server/views/partials/howToUpdateRequest.njk
+++ b/server/views/partials/howToUpdateRequest.njk
@@ -10,9 +10,8 @@
     }) -}}
   {% else %}
     {{- t("shared:howToUpdateRequest.contactPrisonWebsite", {
-      prisonName: prison.code | getPrisonName(prisonNames, language),
-      url: prison.webAddress
-    }) | safe -}}
+      prisonName: prison.code | getPrisonName(prisonNames, language)
+    }) | renderLinkTag(prison.webAddress) | safe -}}
   {% endif -%}
 </p>
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -59,7 +59,7 @@
 {% block govukHeader %}
 {# If user authenticated then use GOVUK One Login Header; otherwise default header #}
 {% if user and user.sub %}
-  {{ govukOneLoginServiceHeader({ 
+  {{ govukOneLoginServiceHeader({
     signOutLink: signOutLink,
     oneLoginLink: oneLoginLink,
     lng: language
@@ -87,6 +87,7 @@
       role: "complementary"
     },
     html: t("common:phase.feedback")
+      | renderLinkTag("https://submit.forms.service.gov.uk/form/263703/visit-someone-in-prison/", true)
   }) }}
 
   {% if backLinkHref %}

--- a/server/views/partials/visitingInfo.njk
+++ b/server/views/partials/visitingInfo.njk
@@ -5,18 +5,17 @@
 </h2>
 
 <p>
-  {{- t("shared:visitingInfo.acceptableId", {
-    url: "https://www.gov.uk/government/publications/management-of-security-at-visits-policy-framework-open-estate/acceptable-forms-of-identification-id-when-visiting-a-prison-in-england-and-wales-annex-a"
-  }) | safe -}}
-</p> 
+  {{- t("shared:visitingInfo.acceptableId")
+    | renderLinkTag("https://www.gov.uk/government/publications/management-of-security-at-visits-policy-framework-open-estate/acceptable-forms-of-identification-id-when-visiting-a-prison-in-england-and-wales-annex-a")
+    | safe -}}
+</p>
 
 <p>{{ t("shared:visitingInfo.arriveEarly") }}</p>
 
 <p data-test="more-visits-info">
   {{- t("shared:visitingInfo.moreVisitsInfo", {
-    url: prison.webAddress,
     prisonName: prison.code | getPrisonName(prisonNames, language)
-  }) | safe -}}
+  }) | renderLinkTag(prison.webAddress) | safe -}}
 </p>
 
 <h3 class="govuk-heading-s">{{ t("shared:visitingInfo.expectationsHeading") }}</h3>
@@ -27,7 +26,5 @@
 <h2 class="govuk-heading-m">{{ t("shared:visitingInfo.helpWithCostHeading") }}</h2>
 
 <p>
-  {{- t("shared:visitingInfo.helpWithCostDetails", {
-    url: "https://www.gov.uk/help-with-prison-visits"
-  }) | safe -}}
+  {{- t("shared:visitingInfo.helpWithCostDetails") | renderLinkTag("https://www.gov.uk/help-with-prison-visits") | safe -}}
 </p>


### PR DESCRIPTION
* Avoid HTML markup for links in translation values; instead use custom `<link>` tag and a Nunjucks render helper
* Avoid nesting translations within other translations