### PR TITLE
VB-6811 Add JSON/.xlsx converter for translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ integration_tests/videos/
 integration_tests/screenshots/
 */*.iml
 **/Chart.lock
+**/.DS_Store
+
+# generated translation workbook
+server/locales/translations.xlsx

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then run the server in test mode by:
 And then either, run tests in headless mode with:
 
 `npm run int-test`
- 
+
 Or run tests with the cypress UI:
 
 `npm run int-test-ui`
@@ -138,6 +138,8 @@ The application supports English and Welsh through i18next. For detailed informa
 - **Plural Forms**: Automatically handled via `_one` and `_other` suffixes
 
 For translators, see [server/locales/TRANSLATOR_CONTEXT.md](server/locales/TRANSLATOR_CONTEXT.md) for namespace-to-screen mapping and interpolation variable reference.
+
+Welsh translations are managed via an Excel workbook (`npm run i18n:export-xlsx` / `npm run i18n:import-xlsx`) - see [server/locales/README.md](server/locales/README.md#translating-to-welsh-via-excel) for details.
 
 ---
 

--- a/bin/i18nExportXlsx.ts
+++ b/bin/i18nExportXlsx.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+/* eslint-disable import/extensions */
+
+/**
+ * Exports all English i18next locale JSON files (server/locales/en/*.json) to a single
+ * .xlsx workbook, with one worksheet per JSON file. Each worksheet has three columns:
+ * Translation key | English text | Welsh text (left blank, for the translator to fill in).
+ *
+ * Usage: npm run i18n:export-xlsx
+ *
+ * (Code from Copilot)
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import writeExcelFile from 'write-excel-file/node'
+
+import { flattenLocale, readLocaleJson } from './i18nLocaleFlatten.ts'
+
+const EN_LOCALES_DIR = path.join(process.cwd(), 'server', 'locales', 'en')
+const CY_LOCALES_DIR = path.join(process.cwd(), 'server', 'locales', 'cy')
+const OUTPUT_FILE = path.join(process.cwd(), 'server', 'locales', 'translations.xlsx')
+
+const HEADER_ROW = ['Translation key', 'English text', 'Welsh text']
+
+function buildSheet(fileName: string) {
+  const namespace = path.basename(fileName, '.json')
+  const entries = flattenLocale(readLocaleJson(path.join(EN_LOCALES_DIR, fileName)))
+
+  // Carry forward any translations that already exist in server/locales/cy, so that
+  // re-exporting (e.g. after adding new English keys) doesn't lose completed translation work.
+  // Newly added English keys will simply have a blank Welsh cell for the translator to fill in.
+  const cyFilePath = path.join(CY_LOCALES_DIR, fileName)
+  const existingWelshByKey = new Map<string, string>(
+    fs.existsSync(cyFilePath) ? flattenLocale(readLocaleJson(cyFilePath)).map(entry => [entry.key, entry.value]) : [],
+  )
+
+  return {
+    sheet: namespace,
+    stickyRowsCount: 1,
+    columns: [{ width: 50 }, { width: 70 }, { width: 70 }],
+    data: [
+      HEADER_ROW.map(value => ({ value, fontWeight: 'bold' as const })),
+      ...entries.map(({ key, value }) => [{ value: key }, { value }, { value: existingWelshByKey.get(key) ?? '' }]),
+    ],
+  }
+}
+
+async function main() {
+  const fileNames = fs
+    .readdirSync(EN_LOCALES_DIR)
+    .filter(fileName => fileName.endsWith('.json'))
+    .sort()
+
+  const sheets = fileNames.map(buildSheet)
+
+  await writeExcelFile(sheets).toFile(OUTPUT_FILE)
+
+  console.log(`Wrote ${sheets.length} worksheet(s) to ${OUTPUT_FILE}`)
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/bin/i18nImportXlsx.ts
+++ b/bin/i18nImportXlsx.ts
@@ -1,0 +1,94 @@
+/* eslint-disable no-console */
+/* eslint-disable import/extensions */
+
+/**
+ * Reads the Welsh translations from server/locales/translations.xlsx (produced by
+ * `npm run i18n:export-xlsx`, then filled in by a translator) and writes out the
+ * corresponding server/locales/cy/*.json files.
+ *
+ * Only keys with a non-empty Welsh translation are written, so that i18next continues to
+ * fall back to the English text for any keys not yet translated.
+ *
+ * Usage: npm run i18n:import-xlsx
+ *
+ * (Code from Copilot)
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import readXlsxFile from 'read-excel-file/node'
+
+import { flattenLocale, readLocaleJson, unFlattenLocale, type LocaleEntry } from './i18nLocaleFlatten.ts'
+
+const EN_LOCALES_DIR = path.join(process.cwd(), 'server', 'locales', 'en')
+const CY_LOCALES_DIR = path.join(process.cwd(), 'server', 'locales', 'cy')
+const INPUT_FILE = path.join(process.cwd(), 'server', 'locales', 'translations.xlsx')
+
+const HEADER_ROW_COUNT = 1
+const KEY_COLUMN_INDEX = 0
+const WELSH_COLUMN_INDEX = 2
+
+function cellToString(cellValue: unknown): string {
+  if (cellValue === null || cellValue === undefined) {
+    return ''
+  }
+  return String(cellValue).trim()
+}
+
+function importSheet(namespace: string, rows: unknown[][]): number {
+  const englishEntries = flattenLocale(readLocaleJson(path.join(EN_LOCALES_DIR, `${namespace}.json`)))
+  const englishKeys = new Set(englishEntries.map(entry => entry.key))
+
+  const welshByKey = new Map<string, string>()
+  rows.slice(HEADER_ROW_COUNT).forEach(row => {
+    const key = cellToString(row[KEY_COLUMN_INDEX])
+    if (!key) {
+      return
+    }
+    welshByKey.set(key, cellToString(row[WELSH_COLUMN_INDEX]))
+
+    if (!englishKeys.has(key)) {
+      console.warn(`[${namespace}] key "${key}" found in spreadsheet but not in server/locales/en/${namespace}.json`)
+    }
+  })
+
+  const missingFromSheet = englishEntries.filter(entry => !welshByKey.has(entry.key))
+  missingFromSheet.forEach(entry => {
+    console.warn(`[${namespace}] key "${entry.key}" is missing from the spreadsheet`)
+  })
+
+  // Preserve the English key order; only include keys that have a non-empty Welsh translation.
+  const translatedEntries: LocaleEntry[] = englishEntries
+    .filter(entry => welshByKey.get(entry.key))
+    .map(entry => ({ key: entry.key, value: welshByKey.get(entry.key) as string }))
+
+  const cyObject = unFlattenLocale(translatedEntries)
+  fs.writeFileSync(path.join(CY_LOCALES_DIR, `${namespace}.json`), `${JSON.stringify(cyObject, null, 2)}\n`)
+
+  return translatedEntries.length
+}
+
+async function main() {
+  if (!fs.existsSync(INPUT_FILE)) {
+    throw new Error(`Could not find ${INPUT_FILE}. Run "npm run i18n:export-xlsx" first, or check the file path.`)
+  }
+
+  const sheets = await readXlsxFile(INPUT_FILE)
+
+  sheets.forEach(({ sheet: namespace, data: rows }) => {
+    const englishJsonPath = path.join(EN_LOCALES_DIR, `${namespace}.json`)
+    if (!fs.existsSync(englishJsonPath)) {
+      console.warn(`Skipping worksheet "${namespace}": no matching server/locales/en/${namespace}.json`)
+      return
+    }
+
+    const translatedCount = importSheet(namespace, rows)
+    const totalCount = flattenLocale(readLocaleJson(englishJsonPath)).length
+    console.log(`${namespace}: wrote ${translatedCount}/${totalCount} translated keys`)
+  })
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/bin/i18nLocaleFlatten.ts
+++ b/bin/i18nLocaleFlatten.ts
@@ -1,0 +1,62 @@
+/**
+ * Locale JSON files (as used by i18next) are nested objects whose leaf values are strings.
+ * These helpers flatten/un-flatten that structure to/from a flat list of dot-separated
+ * "key" / "value" pairs, suitable for a two-column spreadsheet representation.
+ *
+ * Flattening preserves the original key order, and un-flattening reconstructs an object with
+ * keys inserted in the same order, so `un-flatten(flatten(x))` round-trips to an object with
+ * identical structure, key order and values as `x`.
+ *
+ * (Code from Copilot)
+ */
+
+import fs from 'node:fs'
+
+export type LocaleEntry = { key: string; value: string }
+
+export type LocaleObject = { [key: string]: string | LocaleObject }
+
+export function readLocaleJson(filePath: string): LocaleObject {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+}
+
+export function flattenLocale(obj: LocaleObject, prefix = ''): LocaleEntry[] {
+  const entries: LocaleEntry[] = []
+
+  Object.entries(obj).forEach(([key, value]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+
+    if (typeof value === 'string') {
+      entries.push({ key: fullKey, value })
+    } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      entries.push(...flattenLocale(value, fullKey))
+    } else {
+      throw new Error(`Unsupported value at key "${fullKey}": expected a string or object, got ${typeof value}`)
+    }
+  })
+
+  return entries
+}
+
+export function unFlattenLocale(entries: LocaleEntry[]): LocaleObject {
+  const result: LocaleObject = {}
+
+  entries.forEach(({ key, value }) => {
+    const segments = key.split('.')
+    let current = result
+
+    segments.forEach((segment, index) => {
+      if (index === segments.length - 1) {
+        current[segment] = value
+        return
+      }
+
+      if (typeof current[segment] !== 'object' || current[segment] === null) {
+        current[segment] = {}
+      }
+      current = current[segment] as LocaleObject
+    })
+  })
+
+  return result
+}

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,5 +2,5 @@ import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
 
 export default hmppsConfig({
   extraIgnorePaths: ['assets/**/*.js'],
-  extraPathsAllowingDevDependencies: ['.allowed-scripts.mjs'],
+  extraPathsAllowingDevDependencies: ['.allowed-scripts.mjs', 'bin/**'],
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,10 +78,12 @@
         "nodemon": "^3.1.14",
         "prettier": "^3.8.4",
         "prettier-plugin-jinja-template": "^2.2.0",
+        "read-excel-file": "9.2.0",
         "sass": "^1.101.0",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.11",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "write-excel-file": "4.1.1"
       },
       "engines": {
         "node": "^24",
@@ -4101,6 +4103,16 @@
         "win32"
       ]
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -7528,6 +7540,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -13164,6 +13183,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/read-excel-file": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.2.0.tgz",
+      "integrity": "sha512-jwSi8Q9oCmswrYMkuiKvJ6VdHbAXGQnANSOaHBNQZEm2XvaXx8d0t/V7oepgHqT9YWxlQE3HEuCtDZq8BZBmvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "fflate": "^0.8.3",
+        "unzipper-esm": "^0.13.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -15142,6 +15176,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/unzipper-esm": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.2.tgz",
+      "integrity": "sha512-lt8GtgDYV8YcAFZNQuLyR2QvHI8C/TstpgsdjUn9ZxiWLJgn+e5uW6DsO3e/HUJVuWD57ZLLFMZ9xk26tePuHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -15569,6 +15617,19 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/write-excel-file": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/write-excel-file/-/write-excel-file-4.1.1.tgz",
+      "integrity": "sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "start-feature:dev": "concurrently -k -p \"[{name}]\" -n \"Views,Locales,TypeScript,Node,Sass\" -c \"yellow.bold,magenta.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-views\" \"npm run watch-locales\" \"npm run watch-ts\" \"npm run watch-node-feature\" \"npm run watch-sass\"",
     "lint": "eslint . --cache --max-warnings 0",
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
-    "typecheck": "tsc && tsc -p integration_tests",
+    "typecheck": "tsc && tsc -p integration_tests && tsc -p bin",
     "test": "jest",
     "test:ci": "jest --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
+    "i18n:export-xlsx": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON bin/i18nExportXlsx.ts",
+    "i18n:import-xlsx": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON bin/i18nImportXlsx.ts",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",
     "clean": "rm -rf dist build node_modules stylesheets",
@@ -105,10 +107,12 @@
     "nodemon": "^3.1.14",
     "prettier": "^3.8.4",
     "prettier-plugin-jinja-template": "^2.2.0",
+    "read-excel-file": "9.2.0",
     "sass": "^1.101.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.11",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "write-excel-file": "4.1.1"
   },
   "overrides": {
     "@opentelemetry/core": "2.8.0",

--- a/server/locales/README.md
+++ b/server/locales/README.md
@@ -89,6 +89,15 @@ Usage in templates:
 
 ---
 
+## Translating to Welsh via Excel
+
+Translators work from a single `.xlsx` workbook rather than editing JSON directly. Two scripts convert between the two formats:
+
+- `npm run i18n:export-xlsx` - reads `server/locales/en/*.json` and writes `server/locales/translations.xlsx`, one worksheet per namespace, with columns `Translation key | English text | Welsh text`. Keys are flattened with dot-separated paths (e.g. `checkVisitDetails.title`). Any translations already present in `server/locales/cy/*.json` are carried over into the Welsh column, so re-running after adding new English keys only leaves the new rows blank.
+- `npm run i18n:import-xlsx` - reads the completed `server/locales/translations.xlsx` and writes `server/locales/cy/*.json`. Only rows with a non-empty Welsh cell are written, so untranslated keys keep falling back to English. Warns if the sheet has keys missing from, or not found in, the corresponding English JSON file.
+
+Workflow: run `i18n:export-xlsx`, send `server/locales/translations.xlsx` to the translator, then run `i18n:import-xlsx` once it's returned completed. The `.xlsx` file itself is git-ignored - it's a working file, not a source of truth.
+
 ## Namespace Overview
 
 Translator guidance:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "node_modules",
     "assets/**/*.js",
     "integration_tests",
+    "bin",
     "dist",
     "coverage",
     "test_results",


### PR DESCRIPTION
The application uses JSON files for English / Welsh locales. These are not easy for our translators to work with. Their preference is to have these in Excel format, with JSON keys flattened and one translation per row.

This change adds some (Copilot CLI generated) tooling to convert between the application's internal JSON format. The scripts are documented in the READMEs and are intended to be run only on developers' local installations. There is no CI automation, for example.