### PR TITLE
VB-3749 Improve language toggle component spacing

### DIFF
--- a/assets/scss/components/_language-toggle.scss
+++ b/assets/scss/components/_language-toggle.scss
@@ -24,6 +24,7 @@
       position: relative;
       top: 0.1875em;
       height: 1em;
+      margin: 0 govuk-spacing(1);
 
       border-right: 1px solid govuk-functional-colour("text");
     }


### PR DESCRIPTION
Add more space either side of the pipe separating the languages (`English | Cymraeg`).