### PR TITLE
VB-6844 Add script (from Copilot) to compare en/cy locale files

### DIFF
--- a/bin/i18nLocaleCompare.ts
+++ b/bin/i18nLocaleCompare.ts
@@ -64,11 +64,15 @@ function main() {
       console.log(`\n${fileName}:`)
       if (enOnlyKeys.length) {
         console.log(`  Keys only in 'en':`)
-        enOnlyKeys.forEach(key => console.log(`    ${namespace}:${key}, ${enEntries.get(key)}`))
+        enOnlyKeys.forEach(key =>
+          console.log(`    [\x1b[31m${namespace}:${key}\x1b[0m]: \x1b[34m${enEntries.get(key)}\x1b[0m`),
+        )
       }
       if (cyOnlyKeys.length) {
         console.log(`  Keys only in 'cy':`)
-        cyOnlyKeys.forEach(key => console.log(`    ${namespace}:${key}, ${cyEntries.get(key)}`))
+        cyOnlyKeys.forEach(key =>
+          console.log(`    [\x1b[31m${namespace}:${key}\x1b[0m]: \x1b[34m${cyEntries.get(key)}\x1b[0m`),
+        )
       }
     }
   })

--- a/bin/i18nLocaleCompare.ts
+++ b/bin/i18nLocaleCompare.ts
@@ -1,0 +1,80 @@
+/* eslint-disable no-console */
+/* eslint-disable import/extensions */
+
+/**
+ * Compares the English and Welsh i18next locale JSON files (server/locales/en/*.json vs
+ * server/locales/cy/*.json) and reports:
+ *   1. Any file present in one locale but not the other.
+ *   2. Any key present in one locale's file but not the corresponding file in the other locale.
+ *
+ * Usage: npm run i18n:locale-compare
+ *
+ * (Code from Copilot)
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { flattenLocale, readLocaleJson } from './i18nLocaleFlatten.ts'
+
+const EN_LOCALES_DIR = path.join(process.cwd(), 'server', 'locales', 'en')
+const CY_LOCALES_DIR = path.join(process.cwd(), 'server', 'locales', 'cy')
+
+function jsonFileNames(dir: string): string[] {
+  return fs
+    .readdirSync(dir)
+    .filter(fileName => fileName.endsWith('.json'))
+    .sort()
+}
+
+function keysOf(filePath: string): Set<string> {
+  return new Set(flattenLocale(readLocaleJson(filePath)).map(entry => entry.key))
+}
+
+function main() {
+  let problemsFound = false
+
+  const enFileNames = new Set(jsonFileNames(EN_LOCALES_DIR))
+  const cyFileNames = new Set(jsonFileNames(CY_LOCALES_DIR))
+
+  const enOnlyFiles = [...enFileNames].filter(fileName => !cyFileNames.has(fileName))
+  const cyOnlyFiles = [...cyFileNames].filter(fileName => !enFileNames.has(fileName))
+
+  if (enOnlyFiles.length) {
+    problemsFound = true
+    console.log(`Files only in 'en': ${enOnlyFiles.join(', ')}`)
+  }
+  if (cyOnlyFiles.length) {
+    problemsFound = true
+    console.log(`Files only in 'cy': ${cyOnlyFiles.join(', ')}`)
+  }
+
+  const commonFileNames = [...enFileNames].filter(fileName => cyFileNames.has(fileName)).sort()
+
+  commonFileNames.forEach(fileName => {
+    const enKeys = keysOf(path.join(EN_LOCALES_DIR, fileName))
+    const cyKeys = keysOf(path.join(CY_LOCALES_DIR, fileName))
+
+    const enOnlyKeys = [...enKeys].filter(key => !cyKeys.has(key)).sort()
+    const cyOnlyKeys = [...cyKeys].filter(key => !enKeys.has(key)).sort()
+
+    if (enOnlyKeys.length || cyOnlyKeys.length) {
+      problemsFound = true
+      console.log(`\n${fileName}:`)
+      if (enOnlyKeys.length) {
+        console.log(`  Keys only in 'en': ${enOnlyKeys.join(', ')}`)
+      }
+      if (cyOnlyKeys.length) {
+        console.log(`  Keys only in 'cy': ${cyOnlyKeys.join(', ')}`)
+      }
+    }
+  })
+
+  if (!problemsFound) {
+    console.log('No differences found between en and cy locale files.')
+  }
+
+  process.exitCode = problemsFound ? 1 : 0
+}
+
+main()

--- a/bin/i18nLocaleCompare.ts
+++ b/bin/i18nLocaleCompare.ts
@@ -27,8 +27,8 @@ function jsonFileNames(dir: string): string[] {
     .sort()
 }
 
-function keysOf(filePath: string): Set<string> {
-  return new Set(flattenLocale(readLocaleJson(filePath)).map(entry => entry.key))
+function entriesOf(filePath: string): Map<string, string> {
+  return new Map(flattenLocale(readLocaleJson(filePath)).map(entry => [entry.key, entry.value]))
 }
 
 function main() {
@@ -52,20 +52,23 @@ function main() {
   const commonFileNames = [...enFileNames].filter(fileName => cyFileNames.has(fileName)).sort()
 
   commonFileNames.forEach(fileName => {
-    const enKeys = keysOf(path.join(EN_LOCALES_DIR, fileName))
-    const cyKeys = keysOf(path.join(CY_LOCALES_DIR, fileName))
+    const namespace = path.basename(fileName, '.json')
+    const enEntries = entriesOf(path.join(EN_LOCALES_DIR, fileName))
+    const cyEntries = entriesOf(path.join(CY_LOCALES_DIR, fileName))
 
-    const enOnlyKeys = [...enKeys].filter(key => !cyKeys.has(key)).sort()
-    const cyOnlyKeys = [...cyKeys].filter(key => !enKeys.has(key)).sort()
+    const enOnlyKeys = [...enEntries.keys()].filter(key => !cyEntries.has(key)).sort()
+    const cyOnlyKeys = [...cyEntries.keys()].filter(key => !enEntries.has(key)).sort()
 
     if (enOnlyKeys.length || cyOnlyKeys.length) {
       problemsFound = true
       console.log(`\n${fileName}:`)
       if (enOnlyKeys.length) {
-        console.log(`  Keys only in 'en': ${enOnlyKeys.join(', ')}`)
+        console.log(`  Keys only in 'en':`)
+        enOnlyKeys.forEach(key => console.log(`    ${namespace}:${key}, ${enEntries.get(key)}`))
       }
       if (cyOnlyKeys.length) {
-        console.log(`  Keys only in 'cy': ${cyOnlyKeys.join(', ')}`)
+        console.log(`  Keys only in 'cy':`)
+        cyOnlyKeys.forEach(key => console.log(`    ${namespace}:${key}, ${cyEntries.get(key)}`))
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "i18n:export-xlsx": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON bin/i18nExportXlsx.ts",
     "i18n:import-xlsx": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON bin/i18nImportXlsx.ts",
+    "i18n:locale-compare": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON bin/i18nLocaleCompare.ts",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",
     "clean": "rm -rf dist build node_modules stylesheets",

--- a/server/locales/README.md
+++ b/server/locales/README.md
@@ -98,6 +98,11 @@ Translators work from a single `.xlsx` workbook rather than editing JSON directl
 
 Workflow: run `i18n:export-xlsx`, send `server/locales/translations.xlsx` to the translator, then run `i18n:import-xlsx` once it's returned completed. The `.xlsx` file itself is git-ignored - it's a working file, not a source of truth.
 
+## Checking for missing translations
+Use `npm run i18n:locale-compare` to compare the set of English and Welsh translations. It will report on:
+* any JSON files missing from either locale
+* any translation keys missing from either locale
+
 ## Namespace Overview
 
 Translator guidance:

--- a/server/locales/cy/visits.json
+++ b/server/locales/cy/visits.json
@@ -34,7 +34,7 @@
     "noFutureVisits": "Nid oes unrhyw ymweliadau na cheisiadau wedi'u archebu ar gyfer y dyfodol.",
     "viewPastVisits": "Gweld ymweliadau blaenorol",
     "viewCancelledVisits": "Gweld ymweliadau a wrthodwyd ac a ganslwyd",
-    "noPrisonerError": "Mae angen i chi ychwanegu carcharor i archebu ymweliad.P",
+    "noPrisonerError": "Mae angen i chi ychwanegu carcharor i archebu ymweliad.",
     "addPrisoner": "Ychwanegu carcharor"
   },
   "past": {


### PR DESCRIPTION
Script (generated by Copilot) to compare the set of English and Welsh translations. It will report on:
* any JSON files missing from either locale
* any translation keys missing from either locale

Usage: `npm run i18n:locale-compare`. 

E.g.
```
$ npm run i18n:locale-compare            

Files only in 'en': newFeature.json

bookVisit.json:
  Keys only in 'en':
    bookVisit:cannotBook.newButton, Button for a new thing
    bookVisit:cannotBook.newLabel, Label for a new thing
```