### PR TITLE
Use UUID type for visitDisplayId

### DIFF
--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -279,7 +279,7 @@ export default class TestData {
   } = {}): PrisonNameDto[] => prisons
 
   static visitDetails = ({
-    visitDisplayId = 'uuidv4-1',
+    visitDisplayId = 'uuidv4-1-1-1-1',
     reference = 'ab-cd-ef-gh',
     prisonerId = 'A1234BC',
     prisonerFirstName = 'JOHN',

--- a/server/routes/visits/cancel/cancelVisitController.ts
+++ b/server/routes/visits/cancel/cancelVisitController.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express'
 import { ValidationChain, matchedData, body, validationResult } from 'express-validator'
+import { type UUID } from 'crypto'
 import { VisitService } from '../../../services'
 import paths from '../../../constants/paths'
 import { isMobilePhoneNumber } from '../../../utils/utils'
@@ -17,7 +18,7 @@ export default class CancelVisitController {
         return res.redirect(paths.VISITS.HOME)
       }
 
-      const { visitDisplayId } = matchedData<{ visitDisplayId: string }>(req)
+      const { visitDisplayId } = matchedData<{ visitDisplayId: UUID }>(req)
 
       const visit = bookedVisits.visits.find(v => v.visitDisplayId === visitDisplayId)!
 
@@ -34,7 +35,7 @@ export default class CancelVisitController {
     return async (req, res, next) => {
       const { cancelVisit, visitDisplayId } = matchedData<{
         cancelVisit: 'yes' | 'no'
-        visitDisplayId: string
+        visitDisplayId: UUID
       }>(req)
 
       const errors = validationResult(req)

--- a/server/routes/visits/visitDetailsController.ts
+++ b/server/routes/visits/visitDetailsController.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express'
 import { ValidationChain, matchedData, validationResult } from 'express-validator'
+import { type UUID } from 'crypto'
 import { PrisonService } from '../../services'
 import paths from '../../constants/paths'
 import { getVisitMessages } from './visitsUtils'
@@ -29,7 +30,7 @@ export default class VisitDetailsController {
         return res.redirect(paths.VISITS.HOME)
       }
 
-      const { visitDisplayId } = matchedData<{ visitDisplayId: string }>(req)
+      const { visitDisplayId } = matchedData<{ visitDisplayId: UUID }>(req)
 
       const { visits } = bookedVisits
       const visit = visits.find(v => v.visitDisplayId === visitDisplayId)!

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -8,7 +8,7 @@ const token = 'some token'
 
 jest.mock('crypto', () => {
   return {
-    randomUUID: () => 'uuidv4-1',
+    randomUUID: () => 'uuidv4-1-1-1-1',
   }
 })
 

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto'
+import { randomUUID, type UUID } from 'crypto'
 import { intervalToDuration, isValid, parseISO } from 'date-fns'
 import logger from '../../logger'
 import { type BookVisitJourney } from '../@types/bapv'
@@ -13,8 +13,9 @@ import { getMainContactName } from '../utils/utils'
 import { Visitor } from './bookerService'
 
 export interface VisitDetails extends OrchestrationVisitDto {
-  visitDisplayId: string
+  visitDisplayId: UUID
 }
+
 export default class VisitService {
   constructor(
     private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,


### PR DESCRIPTION
Improve typing of `visiDisplayId` to use the `UUID` type - and for consistency with how this is done for visitor/prisoner display IDs.