### PR TITLE
VB-6847 Fix language-toggle on add visitor / prisoner confirmation pages

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -40,7 +40,12 @@ export type AddVisitorJourney = {
     visitorDob: string
     languagePreference: Locale
   }
-  result?: CreateVisitorRequestResponseDto['status'] | BookerVisitorRequestValidationErrorResponse['validationError']
+}
+
+export type AddVisitorJourneyResult = {
+  firstName: string
+  lastName: string
+  result: CreateVisitorRequestResponseDto['status'] | BookerVisitorRequestValidationErrorResponse['validationError']
 }
 
 // data that is built up during a visit booking journey

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -26,7 +26,11 @@ export type AddPrisonerJourney = {
     'prisonerDob-year': string
     prisonNumber: string
   }
-  result?: boolean
+}
+
+export type AddPrisonerJourneyResult = {
+  selectedPrisonId: string
+  result: boolean
 }
 
 // data that is built up during an add visitor request journey

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,6 +1,7 @@
 import type { ValidationError } from 'express-validator'
 import type {
   AddPrisonerJourney,
+  AddPrisonerJourneyResult,
   AddVisitorJourney,
   AddVisitorJourneyResult,
   Booker,
@@ -24,6 +25,7 @@ declare module 'express-session' {
     booker?: Booker
 
     addPrisonerJourney?: AddPrisonerJourney
+    addPrisonerJourneyResult?: AddPrisonerJourneyResult
 
     addVisitorJourney?: AddVisitorJourney
     addVisitorJourneyResult?: AddVisitorJourneyResult

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,7 +1,8 @@
-import { ValidationError } from 'express-validator'
-import {
+import type { ValidationError } from 'express-validator'
+import type {
   AddPrisonerJourney,
   AddVisitorJourney,
+  AddVisitorJourneyResult,
   Booker,
   VisitCancelled,
   BookVisitConfirmed,
@@ -10,7 +11,7 @@ import {
   MoJAlert,
   BookedVisits,
 } from '../bapv'
-import { PrisonNames } from '../../services/prisonService'
+import type { PrisonNames } from '../../services/prisonService'
 
 export default {}
 
@@ -25,6 +26,7 @@ declare module 'express-session' {
     addPrisonerJourney?: AddPrisonerJourney
 
     addVisitorJourney?: AddVisitorJourney
+    addVisitorJourneyResult?: AddVisitorJourneyResult
 
     bookVisitJourney?: BookVisitJourney
     bookVisitConfirmed?: BookVisitConfirmed

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -19,6 +19,6 @@ export default function createErrorHandler(production: boolean) {
 
     res.status(error.status || 500)
 
-    return res.render('pages/error', { showOLServiceNav: !!req.session.booker })
+    return res.render('pages/error', { showOLServiceNav: !!req.session?.booker })
   }
 }

--- a/server/routes/addPrisoner/prisonerAddedController.test.ts
+++ b/server/routes/addPrisoner/prisonerAddedController.test.ts
@@ -8,11 +8,8 @@ import paths from '../../constants/paths'
 let app: Express
 let sessionData: SessionData
 
-const selectedPrisonId = 'HEI'
-const supportedPrisonIds = [selectedPrisonId]
-
 beforeEach(() => {
-  sessionData = { addPrisonerJourney: { supportedPrisonIds, selectedPrisonId } } as SessionData
+  sessionData = {} as SessionData
 
   app = appWithAllRoutes({ sessionData })
 })
@@ -27,8 +24,11 @@ describe('Prisoner added', () => {
       return request(app).get(paths.ADD_PRISONER.SUCCESS).expect(302).expect('Location', paths.RETURN_HOME)
     })
 
-    it('should clear add prisoner journey session data and render the success page', () => {
-      sessionData.addPrisonerJourney!.result = true
+    it('should render the success page', () => {
+      sessionData.addPrisonerJourneyResult = {
+        selectedPrisonId: 'some-prison-id',
+        result: true,
+      }
 
       return request(app)
         .get(paths.ADD_PRISONER.SUCCESS)

--- a/server/routes/addPrisoner/prisonerAddedController.ts
+++ b/server/routes/addPrisoner/prisonerAddedController.ts
@@ -6,11 +6,9 @@ export default class PrisonerAddedController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      if (req.session.addPrisonerJourney?.result !== true) {
+      if (req.session.addPrisonerJourneyResult?.result !== true) {
         return res.redirect(paths.RETURN_HOME)
       }
-
-      delete req.session.addPrisonerJourney
 
       return res.render('pages/addPrisoner/prisonerAdded', { showOLServiceNav: true })
     }

--- a/server/routes/addPrisoner/prisonerDetailsController.test.ts
+++ b/server/routes/addPrisoner/prisonerDetailsController.test.ts
@@ -8,7 +8,7 @@ import { FlashData, appWithAllRoutes, flashProvider } from '../testutils/appSetu
 import TestData from '../testutils/testData'
 import paths from '../../constants/paths'
 import { createMockBookerService } from '../../services/testutils/mocks'
-import { AddPrisonerJourney, FlashFormValues } from '../../@types/bapv'
+import { AddPrisonerJourney, AddPrisonerJourneyResult, FlashFormValues } from '../../@types/bapv'
 
 let app: Express
 
@@ -146,7 +146,7 @@ describe('Prisoner details', () => {
       return request(app).post(paths.ADD_PRISONER.DETAILS).expect(302).expect('Location', paths.ADD_PRISONER.LOCATION)
     })
 
-    it('should call service to register prisoner, store result in session and redirect to success page - success', () => {
+    it('should call service to register prisoner, store result in session, clear other data and redirect to success page - success', () => {
       bookerService.registerPrisoner.mockResolvedValue(true)
 
       return request(app)
@@ -156,8 +156,11 @@ describe('Prisoner details', () => {
         .expect('Location', paths.ADD_PRISONER.SUCCESS)
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
-          expect(sessionData.addPrisonerJourney!.prisonerDetails).toBeUndefined()
-          expect(sessionData.addPrisonerJourney!.result).toBe(true)
+          expect(sessionData.addPrisonerJourney).toBeUndefined()
+          expect(sessionData.addPrisonerJourneyResult).toStrictEqual<AddPrisonerJourneyResult>({
+            selectedPrisonId,
+            result: true,
+          })
           expect(bookerService.registerPrisoner).toHaveBeenCalledWith(bookerReference, registerPrisonerDto)
         })
     })
@@ -173,7 +176,10 @@ describe('Prisoner details', () => {
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
           expect(sessionData.addPrisonerJourney!.prisonerDetails).toStrictEqual(prisonerDetails)
-          expect(sessionData.addPrisonerJourney!.result).toBe(false)
+          expect(sessionData.addPrisonerJourneyResult).toStrictEqual<AddPrisonerJourneyResult>({
+            selectedPrisonId,
+            result: false,
+          })
           expect(bookerService.registerPrisoner).toHaveBeenCalledWith(bookerReference, registerPrisonerDto)
         })
     })
@@ -188,7 +194,7 @@ describe('Prisoner details', () => {
         .expect(() => {
           expect(flashProvider).not.toHaveBeenCalled()
           expect(sessionData.addPrisonerJourney!.prisonerDetails).toBeUndefined()
-          expect(sessionData.addPrisonerJourney!.result).toBeUndefined()
+          expect(sessionData.addPrisonerJourneyResult).toBeUndefined()
           expect(bookerService.registerPrisoner).toHaveBeenCalledWith(bookerReference, registerPrisonerDto)
         })
     })

--- a/server/routes/addPrisoner/prisonerDetailsController.ts
+++ b/server/routes/addPrisoner/prisonerDetailsController.ts
@@ -62,9 +62,13 @@ export default class PrisonerDetailsController {
         prisonId: addPrisonerJourney.selectedPrisonId,
       })
 
-      addPrisonerJourney.result = result
+      req.session.addPrisonerJourneyResult = {
+        selectedPrisonId: addPrisonerJourney.selectedPrisonId,
+        result,
+      }
 
       if (result) {
+        delete req.session.addPrisonerJourney
         return res.redirect(paths.ADD_PRISONER.SUCCESS)
       }
 

--- a/server/routes/addPrisoner/prisonerLocationController.test.ts
+++ b/server/routes/addPrisoner/prisonerLocationController.test.ts
@@ -34,7 +34,9 @@ describe('Prisoner location', () => {
       flashProvider.mockImplementation((key: keyof FlashData) => flashData[key])
     })
 
-    it('should render prisoner location page with list of supported prisons and store supported prison in session', () => {
+    it('should render prisoner location page with list of supported prisons, store supported prison in session and clear any old session data', () => {
+      sessionData.addPrisonerJourneyResult = { selectedPrisonId: 'some-prison-id', result: true }
+
       return request(app)
         .get(paths.ADD_PRISONER.LOCATION)
         .expect('Content-Type', /html/)
@@ -52,6 +54,7 @@ describe('Prisoner location', () => {
           expect($('input[name=prisonId]').eq(0).val()).toBe('HEI')
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
 
+          expect(sessionData.addPrisonerJourneyResult).toBeUndefined()
           expect(sessionData.addPrisonerJourney!.supportedPrisonIds).toStrictEqual(supportedPrisonIds)
         })
     })

--- a/server/routes/addPrisoner/prisonerLocationController.ts
+++ b/server/routes/addPrisoner/prisonerLocationController.ts
@@ -8,6 +8,8 @@ export default class PrisonerLocationController {
 
   public view(): RequestHandler {
     return async (req, res) => {
+      delete req.session.addPrisonerJourneyResult
+
       const selectedPrisonId = req.session.addPrisonerJourney?.selectedPrisonId
       const prisonerDetails = req.session.addPrisonerJourney?.prisonerDetails
       const supportedPrisonIds = await this.prisonService.getSupportedPrisonIds()

--- a/server/routes/addPrisoner/prisonerNotMatchedController.test.ts
+++ b/server/routes/addPrisoner/prisonerNotMatchedController.test.ts
@@ -8,11 +8,8 @@ import paths from '../../constants/paths'
 let app: Express
 let sessionData: SessionData
 
-const selectedPrisonId = 'HEI'
-const supportedPrisonIds = [selectedPrisonId]
-
 beforeEach(() => {
-  sessionData = { addPrisonerJourney: { supportedPrisonIds, selectedPrisonId } } as SessionData
+  sessionData = {} as SessionData
 
   app = appWithAllRoutes({ sessionData })
 })
@@ -28,7 +25,10 @@ describe('Prisoner not matched', () => {
     })
 
     it('should render prisoner details do not match page', () => {
-      sessionData.addPrisonerJourney!.result = false
+      sessionData.addPrisonerJourneyResult = {
+        selectedPrisonId: 'HEI',
+        result: false,
+      }
 
       return request(app)
         .get(paths.ADD_PRISONER.FAIL)

--- a/server/routes/addPrisoner/prisonerNotMatchedController.ts
+++ b/server/routes/addPrisoner/prisonerNotMatchedController.ts
@@ -6,13 +6,13 @@ export default class PrisonerNotMatchedController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const { addPrisonerJourney } = req.session
-      if (addPrisonerJourney?.result !== false) {
+      const { addPrisonerJourneyResult } = req.session
+      if (addPrisonerJourneyResult?.result !== false) {
         return res.redirect(paths.RETURN_HOME)
       }
       return res.render('pages/addPrisoner/prisonerNotMatched', {
         showOLServiceNav: true,
-        prisonId: addPrisonerJourney.selectedPrisonId,
+        prisonId: addPrisonerJourneyResult.selectedPrisonId,
       })
     }
   }

--- a/server/routes/addVisitor/addVisitorStartController.test.ts
+++ b/server/routes/addVisitor/addVisitorStartController.test.ts
@@ -1,13 +1,16 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
+import { SessionData } from 'express-session'
 import { appWithAllRoutes } from '../testutils/appSetup'
 import paths from '../../constants/paths'
 
 let app: Express
+let sessionData: SessionData
 
 beforeEach(() => {
-  app = appWithAllRoutes({})
+  sessionData = { addVisitorJourneyResult: { previous: 'journey data' } } as unknown as SessionData
+  app = appWithAllRoutes({ sessionData })
 })
 
 afterEach(() => {
@@ -16,7 +19,7 @@ afterEach(() => {
 
 describe('Add visitor start journey page', () => {
   describe(`GET ${paths.ADD_VISITOR.START}`, () => {
-    it('should render add visitor journey start page', () => {
+    it('should render add visitor journey start page and clear any previous session data', () => {
       return request(app)
         .get(paths.ADD_VISITOR.START)
         .expect('Content-Type', /html/)
@@ -27,6 +30,8 @@ describe('Add visitor start journey page', () => {
           expect($('[data-test="back-link"]').attr('href')).toBe(paths.VISITORS)
           expect($('h1').text().trim()).toBe('Providing visitor information')
           expect($('[data-test="continue-button"]').text().trim()).toBe('Continue')
+
+          expect(sessionData.addVisitorJourneyResult).toBeUndefined()
         })
     })
   })

--- a/server/routes/addVisitor/addVisitorStartController.ts
+++ b/server/routes/addVisitor/addVisitorStartController.ts
@@ -3,6 +3,7 @@ import { RequestHandler } from 'express'
 export default class AddVisitorStartController {
   public view(): RequestHandler {
     return async (req, res) => {
+      delete req.session.addVisitorJourneyResult
       return res.render('pages/addVisitor/addVisitorStart', { showOLServiceNav: true })
     }
   }

--- a/server/routes/addVisitor/checkVisitorDetailsController.test.ts
+++ b/server/routes/addVisitor/checkVisitorDetailsController.test.ts
@@ -6,6 +6,7 @@ import { appWithAllRoutes } from '../testutils/appSetup'
 import paths from '../../constants/paths'
 import { createMockBookerService } from '../../services/testutils/mocks'
 import { BookerService } from '../../services'
+import type { AddVisitorJourneyResult } from '../../@types/bapv'
 
 let app: Express
 
@@ -82,9 +83,9 @@ describe('Check visitor request details', () => {
         })
     })
 
-    it('should return to visitor details page if no visitor request in session', () => {
+    it('should return to visitors page if no visitor request in session', () => {
       delete sessionData.addVisitorJourney
-      return request(app).get(paths.ADD_VISITOR.CHECK).expect(302).expect('location', paths.ADD_VISITOR.DETAILS)
+      return request(app).get(paths.ADD_VISITOR.CHECK).expect(302).expect('location', paths.VISITORS)
     })
   })
 
@@ -107,7 +108,12 @@ describe('Check visitor request details', () => {
           .expect(302)
           .expect('Location', redirectPath)
           .expect(() => {
-            expect(sessionData.addVisitorJourney!.result).toBe(apiResponse)
+            expect(sessionData.addVisitorJourney).toBeUndefined()
+            expect(sessionData.addVisitorJourneyResult).toStrictEqual<AddVisitorJourneyResult>({
+              firstName: 'first',
+              lastName: 'last',
+              result: apiResponse as unknown as AddVisitorJourneyResult['result'],
+            })
             expect(bookerService.addVisitorRequest).toHaveBeenCalledWith({
               bookerReference: 'aaaa-bbbb-cccc',
               prisonerId: 'A1234BC',

--- a/server/routes/addVisitor/checkVisitorDetailsController.ts
+++ b/server/routes/addVisitor/checkVisitorDetailsController.ts
@@ -10,7 +10,7 @@ export default class CheckVisitorDetailsController {
       const { addVisitorJourney } = req.session
 
       if (!addVisitorJourney) {
-        return res.redirect(paths.ADD_VISITOR.DETAILS)
+        return res.redirect(paths.VISITORS)
       }
 
       return res.render('pages/addVisitor/checkVisitorDetails', {
@@ -40,7 +40,12 @@ export default class CheckVisitorDetailsController {
         },
       })
 
-      addVisitorJourney.result = result
+      req.session.addVisitorJourneyResult = {
+        firstName: visitorDetails.firstName,
+        lastName: visitorDetails.lastName,
+        result,
+      }
+      delete req.session.addVisitorJourney
 
       switch (result) {
         case 'REQUESTED':

--- a/server/routes/addVisitor/visitorRequestFailController.test.ts
+++ b/server/routes/addVisitor/visitorRequestFailController.test.ts
@@ -10,15 +10,9 @@ let sessionData: SessionData
 
 beforeEach(() => {
   sessionData = {
-    addVisitorJourney: {
-      visitorDetails: {
-        firstName: 'first',
-        lastName: 'last',
-        'visitorDob-day': '1',
-        'visitorDob-month': '2',
-        'visitorDob-year': '2000',
-        visitorDob: '2000-02-01',
-      },
+    addVisitorJourneyResult: {
+      firstName: 'first',
+      lastName: 'last',
     },
   } as SessionData
   app = appWithAllRoutes({ sessionData })
@@ -31,7 +25,7 @@ afterEach(() => {
 describe('Add visitor request failure pages', () => {
   describe(`GET ${paths.ADD_VISITOR.SUCCESS}`, () => {
     it('should render add visitor journey request failure page - visitor already requested', () => {
-      sessionData.addVisitorJourney!.result = 'REQUEST_ALREADY_EXISTS'
+      sessionData.addVisitorJourneyResult!.result = 'REQUEST_ALREADY_EXISTS'
 
       return request(app)
         .get(paths.ADD_VISITOR.FAIL_ALREADY_REQUESTED)
@@ -47,13 +41,11 @@ describe('Add visitor request failure pages', () => {
 
           expect($('[data-test="link-a-visitor"]').text().trim()).toBe('Link another visitor')
           expect($('[data-test="link-a-visitor"]').attr('href')).toBe(paths.ADD_VISITOR.DETAILS)
-
-          expect(sessionData.addVisitorJourney).toBeUndefined()
         })
     })
 
     it('should render add visitor journey request failure page - visitor already linked', () => {
-      sessionData.addVisitorJourney!.result = 'VISITOR_ALREADY_EXISTS'
+      sessionData.addVisitorJourneyResult!.result = 'VISITOR_ALREADY_EXISTS'
 
       return request(app)
         .get(paths.ADD_VISITOR.FAIL_ALREADY_LINKED)
@@ -69,13 +61,11 @@ describe('Add visitor request failure pages', () => {
 
           expect($('[data-test="link-a-visitor"]').text().trim()).toBe('Link another visitor')
           expect($('[data-test="link-a-visitor"]').attr('href')).toBe(paths.ADD_VISITOR.DETAILS)
-
-          expect(sessionData.addVisitorJourney).toBeUndefined()
         })
     })
 
     it('should render add visitor journey request failure page - too many requests', () => {
-      sessionData.addVisitorJourney!.result = 'MAX_IN_PROGRESS_REQUESTS_REACHED'
+      sessionData.addVisitorJourneyResult!.result = 'MAX_IN_PROGRESS_REQUESTS_REACHED'
 
       return request(app)
         .get(paths.ADD_VISITOR.FAIL_TOO_MANY_REQUESTS)
@@ -86,17 +76,11 @@ describe('Add visitor request failure pages', () => {
           expect($('#navigation').length).toBe(1)
           expect($('[data-test="back-link"]').length).toBe(0)
           expect($('h1').text().trim()).toBe('Visitor request cannot be submitted')
-
-          expect(sessionData.addVisitorJourney).toBeUndefined()
         })
     })
 
-    it('should redirect to visitors page if add visitor request journey not in session', () => {
-      delete sessionData.addVisitorJourney
-      return request(app).get(paths.ADD_VISITOR.FAIL_ALREADY_REQUESTED).expect(302).expect('location', paths.VISITORS)
-    })
-
     it('should redirect to visitors page if add visitor request journey result not in session', () => {
+      delete sessionData.addVisitorJourneyResult
       return request(app).get(paths.ADD_VISITOR.FAIL_ALREADY_REQUESTED).expect(302).expect('location', paths.VISITORS)
     })
   })

--- a/server/routes/addVisitor/visitorRequestFailController.ts
+++ b/server/routes/addVisitor/visitorRequestFailController.ts
@@ -4,14 +4,14 @@ import paths from '../../constants/paths'
 export default class VisitorRequestFailController {
   public view(): RequestHandler {
     return async (req, res) => {
-      const { addVisitorJourney } = req.session
+      const { addVisitorJourneyResult } = req.session
 
-      if (addVisitorJourney?.result === undefined) {
+      if (!addVisitorJourneyResult) {
         return res.redirect(paths.VISITORS)
       }
 
       let pageTemplate
-      switch (addVisitorJourney.result) {
+      switch (addVisitorJourneyResult.result) {
         case 'MAX_IN_PROGRESS_REQUESTS_REACHED':
           pageTemplate = 'visitorRequestFailTooManyRequests'
           break
@@ -28,11 +28,10 @@ export default class VisitorRequestFailController {
           return res.redirect(paths.VISITORS)
       }
 
-      delete req.session.addVisitorJourney
-
       return res.render(`pages/addVisitor/${pageTemplate}`, {
         showOLServiceNav: true,
-        visitorDetails: addVisitorJourney.visitorDetails,
+        firstName: addVisitorJourneyResult.firstName,
+        lastName: addVisitorJourneyResult.lastName,
       })
     }
   }

--- a/server/routes/addVisitor/visitorRequestSuccessController.test.ts
+++ b/server/routes/addVisitor/visitorRequestSuccessController.test.ts
@@ -10,15 +10,9 @@ let sessionData: SessionData
 
 beforeEach(() => {
   sessionData = {
-    addVisitorJourney: {
-      visitorDetails: {
-        firstName: 'First',
-        lastName: 'Last',
-        'visitorDob-day': '1',
-        'visitorDob-month': '2',
-        'visitorDob-year': '2000',
-        visitorDob: '2000-02-01',
-      },
+    addVisitorJourneyResult: {
+      firstName: 'First',
+      lastName: 'Last',
       result: 'REQUESTED',
     },
   } as SessionData
@@ -31,7 +25,7 @@ afterEach(() => {
 
 describe('Add visitor request success page', () => {
   describe(`GET ${paths.ADD_VISITOR.SUCCESS}`, () => {
-    it('should render add visitor journey request success page and clear session data', () => {
+    it('should render add visitor journey request success page', () => {
       return request(app)
         .get(paths.ADD_VISITOR.SUCCESS)
         .expect('Content-Type', /html/)
@@ -43,12 +37,10 @@ describe('Add visitor request success page', () => {
           expect($('h1').text().trim()).toBe('Request submitted')
           expect($('[data-test="link-a-visitor"]').text().trim()).toBe('Link another visitor')
           expect($('[data-test="link-a-visitor"]').attr('href')).toBe(paths.ADD_VISITOR.DETAILS)
-
-          expect(sessionData.addVisitorJourney).toBeUndefined()
         })
     })
 
-    it('should render add visitor journey auto approved page and clear session data', () => {
+    it('should render add visitor journey auto approved page', () => {
       return request(app)
         .get(paths.ADD_VISITOR.AUTO_APPROVED)
         .expect('Content-Type', /html/)
@@ -65,13 +57,11 @@ describe('Add visitor request success page', () => {
           expect($('[data-test="visitor-approved"]').text()).toStrictEqual(
             'First Last will appear as a visitor when you book visits for John Smith.',
           )
-
-          expect(sessionData.addVisitorJourney).toBeUndefined()
         })
     })
 
     it('should redirect to visitors page if add visitor request result not in session', () => {
-      delete sessionData.addVisitorJourney!.result
+      delete sessionData.addVisitorJourneyResult
 
       return request(app).get(paths.ADD_VISITOR.SUCCESS).expect(302).expect('location', paths.VISITORS)
     })

--- a/server/routes/addVisitor/visitorRequestSuccessController.ts
+++ b/server/routes/addVisitor/visitorRequestSuccessController.ts
@@ -4,11 +4,9 @@ import paths from '../../constants/paths'
 export default class VisitorRequestSuccessController {
   public viewRequested(): RequestHandler {
     return async (req, res) => {
-      if (req.session.addVisitorJourney?.result === undefined) {
+      if (req.session.addVisitorJourneyResult === undefined) {
         return res.redirect(paths.VISITORS)
       }
-
-      delete req.session.addVisitorJourney
 
       return res.render('pages/addVisitor/visitorRequested', { showOLServiceNav: true })
     }
@@ -16,16 +14,14 @@ export default class VisitorRequestSuccessController {
 
   public viewApproved(): RequestHandler {
     return async (req, res) => {
-      if (req.session.addVisitorJourney?.result === undefined) {
+      if (req.session.addVisitorJourneyResult === undefined) {
         return res.redirect(paths.VISITORS)
       }
 
-      const visitorName = `${req.session.addVisitorJourney.visitorDetails.firstName} ${req.session.addVisitorJourney.visitorDetails.lastName}`
+      const { firstName, lastName } = req.session.addVisitorJourneyResult
       const prisoner = req.session.booker!.prisoners[0]
 
-      delete req.session.addVisitorJourney
-
-      return res.render('pages/addVisitor/visitorApproved', { showOLServiceNav: true, visitorName, prisoner })
+      return res.render('pages/addVisitor/visitorApproved', { showOLServiceNav: true, firstName, lastName, prisoner })
     }
   }
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -151,8 +151,13 @@ describe('Clear session data', () => {
     const sessionData: Partial<Record<keyof SessionData, string>> = {
       booker: 'BOOKER DATA',
       addPrisonerJourney: 'ADD PRISONER JOURNEY DATA',
+      addPrisonerJourneyResult: 'ADD PRISONER JOURNEY RESULT DATA',
+      addVisitorJourney: 'ADD VISITOR JOURNEY DATA',
+      addVisitorJourneyResult: 'ADD VISITOR JOURNEY RESULT DATA',
       bookVisitJourney: 'BOOK VISIT JOURNEY DATA',
       bookVisitConfirmed: 'BOOK VISIT CONFIRMATION DATA',
+      bookedVisits: 'BOOKED VISITS DATA',
+      visitCancelled: 'VISIT CANCELLED DATA',
     }
     const req = { session: sessionData } as unknown as Request
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -97,7 +97,18 @@ export const isAdult = (dateOfBirth: string | undefined | null, referenceDate: D
 }
 
 export const clearSession = (req: Request): void => {
-  ;(['addPrisonerJourney', 'bookVisitJourney', 'bookVisitConfirmed'] as const).forEach(sessionItem => {
+  ;(
+    [
+      'addPrisonerJourney',
+      'addPrisonerJourneyResult',
+      'addVisitorJourney',
+      'addVisitorJourneyResult',
+      'bookVisitJourney',
+      'bookVisitConfirmed',
+      'bookedVisits',
+      'visitCancelled',
+    ] as const
+  ).forEach(sessionItem => {
     delete req.session[sessionItem]
   })
 }

--- a/server/views/pages/addVisitor/visitorApproved.njk
+++ b/server/views/pages/addVisitor/visitorApproved.njk
@@ -14,7 +14,7 @@
 
       <p data-test="visitor-approved">
         {{- t("addVisitor:visitorApproved.approvedMessage", {
-          visitorName: visitorName,
+          visitorName: firstName + " " + lastName,
           prisonerName: prisoner | prisonerNameFirstLast
         }) -}}
       </p>

--- a/server/views/pages/addVisitor/visitorRequestFailAlreadyLinked.njk
+++ b/server/views/pages/addVisitor/visitorRequestFailAlreadyLinked.njk
@@ -12,7 +12,7 @@
       <p data-test="visitor-already-linked">
         {{- t("addVisitor:visitorRequestFailAlreadyLinked.visitorAlreadyLinked", {
           visitorName: visitorDetails.firstName + " " + visitorDetails.lastName
-        }) | safe -}}
+        }) -}}
       </p>
 
       <p>{{ t("addVisitor:visitorRequestFailAlreadyLinked.noNeedToSubmit") }}</p>

--- a/server/views/pages/addVisitor/visitorRequestFailAlreadyLinked.njk
+++ b/server/views/pages/addVisitor/visitorRequestFailAlreadyLinked.njk
@@ -11,7 +11,7 @@
 
       <p data-test="visitor-already-linked">
         {{- t("addVisitor:visitorRequestFailAlreadyLinked.visitorAlreadyLinked", {
-          visitorName: visitorDetails.firstName + " " + visitorDetails.lastName
+          visitorName: firstName + " " + lastName
         }) -}}
       </p>
 

--- a/server/views/pages/addVisitor/visitorRequestFailAlreadyRequested.njk
+++ b/server/views/pages/addVisitor/visitorRequestFailAlreadyRequested.njk
@@ -12,7 +12,7 @@
       <p data-test="visitor-already-requested">
         {{- t("addVisitor:visitorRequestFailAlreadyRequested.visitorAlreadyRequested", {
           visitorName: visitorDetails.firstName + " " + visitorDetails.lastName
-        }) | safe -}}
+        }) -}}
       </p>
 
       <p>{{ t("addVisitor:visitorRequestFailAlreadyRequested.waitingToBeReviewed") }}</p>

--- a/server/views/pages/addVisitor/visitorRequestFailAlreadyRequested.njk
+++ b/server/views/pages/addVisitor/visitorRequestFailAlreadyRequested.njk
@@ -11,7 +11,7 @@
 
       <p data-test="visitor-already-requested">
         {{- t("addVisitor:visitorRequestFailAlreadyRequested.visitorAlreadyRequested", {
-          visitorName: visitorDetails.firstName + " " + visitorDetails.lastName
+          visitorName: firstName + " " + lastName
         }) -}}
       </p>
 

--- a/server/views/pages/visitors/visitors.njk
+++ b/server/views/pages/visitors/visitors.njk
@@ -15,7 +15,7 @@
       <h2 class="govuk-heading-m" data-test="prisoner-visitors">
         {{- t("visitors:visitors.visitorsOf", {
           name: prisoner | prisonerNameFirstLast
-        }) | safe -}}
+        }) -}}
       </h2>
 
       {% if visitorsTableRows | length %}
@@ -77,7 +77,7 @@
         href: paths.ADD_VISITOR.START,
         attributes: { "data-test": "link-a-visitor" },
         preventDoubleClick: true
-      }) }} 
+      }) }}
 
 
     </div>


### PR DESCRIPTION
The English / Welsh language toggle works by reloading the current page URL with the requested language query parameter.

Previously the confirmation pages (success/failure) for adding a prisoner or visitor could be rendered once-only because the session data for these journeys was destroyed in order to prevent a user going back and re-submitting. This meant that language toggling was broken on these pages.

This change defines two new session data items to store the results of the add prisoner/visitor journeys so that the main journey data can be deleted at the end but data for the confirmation page can persist.